### PR TITLE
feat: stream JSONL input and output

### DIFF
--- a/sample-services.jsonl
+++ b/sample-services.jsonl
@@ -1,0 +1,2 @@
+{"name": "Learning Platform", "description": "A site for courses"}
+{"name": "Analytics Service", "description": "Collects analytics"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,47 @@
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import main
+
+
+def test_cli_generates_output(tmp_path, monkeypatch):
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("You are a helpful assistant.")
+
+    input_file = tmp_path / "services.jsonl"
+    input_file.write_text('{"name": "alpha"}\n{"name": "beta"}\n')
+
+    output_file = tmp_path / "output.jsonl"
+
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setattr(main, "init_chat_model", lambda **_: SimpleNamespace())
+    monkeypatch.setattr(
+        main,
+        "process_service",
+        lambda service, model, prompt: {
+            "service": service["name"],
+            "prompt": prompt[:3],
+        },
+    )
+
+    argv = [
+        "main",
+        "--prompt-file",
+        str(prompt_file),
+        "--input-file",
+        str(input_file),
+        "--output-file",
+        str(output_file),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    main.main()
+
+    lines = output_file.read_text().strip().splitlines()
+    assert [json.loads(line) for line in lines] == [
+        {"service": "alpha", "prompt": "You"},
+        {"service": "beta", "prompt": "You"},
+    ]


### PR DESCRIPTION
## Summary
- read services using a line-by-line JSONL iterator
- stream ambitions to JSONL output as they are processed
- cover CLI JSONL workflow with tests

## Testing
- `black main.py tests/test_cli.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892acf73288832b91ced99f224e65b8