### PR TITLE
Require OPENAI_API_KEY via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # service-ambitions
+
+## Configuration
+
+The CLI requires an OpenAI API key available in the `OPENAI_API_KEY` environment variable. The key is loaded after `.env` files are processed and the application will exit if the variable is missing.
+
+Create a `.env` file in the project root with:
+
+```
+OPENAI_API_KEY=your_api_key_here
+```
+
+For production deployments, inject the variable using your platform's secret manager instead of committing keys to source control.
+

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 """Command-line tool for generating service ambitions using a chat model."""
 
 import argparse
-import getpass
 import json
 import os
 from typing import Dict, Any, Iterator
@@ -115,8 +114,11 @@ def main() -> None:
     args = parser.parse_args()
 
     load_dotenv()
-    if not os.environ.get("OPENAI_API_KEY"):
-        os.environ["OPENAI_API_KEY"] = getpass.getpass("Enter API key for OpenAI: ")
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "OPENAI_API_KEY is not set. Provide it via a .env file or a secret manager."
+        )
 
     system_prompt = load_prompt(args.prompt_file)
     services = load_services(args.input_file)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,8 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import main
 
@@ -45,3 +47,10 @@ def test_cli_generates_output(tmp_path, monkeypatch):
         {"service": "alpha", "prompt": "You"},
         {"service": "beta", "prompt": "You"},
     ]
+
+
+def test_cli_requires_api_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(sys, "argv", ["main"])
+    with pytest.raises(RuntimeError):
+        main.main()


### PR DESCRIPTION
## Summary
- enforce OPENAI_API_KEY presence after loading .env
- document environment-based API key configuration
- test CLI fails without OPENAI_API_KEY

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892afc8a818832bbc32dab9b0e1e011