### PR TITLE
feat: make chat model configurable

### DIFF
--- a/main.py
+++ b/main.py
@@ -104,12 +104,26 @@ def main() -> None:
         "--prompt-file", default="prompt.md", help="Path to the system prompt file"
     )
     parser.add_argument(
+        "--prompt-id",
+        help="Prompt template identifier. Overrides --prompt-file when provided.",
+    )
+    parser.add_argument(
         "--input-file",
         default="sample-services.jsonl",
         help="Path to the services JSONL file",
     )
     parser.add_argument(
         "--output-file", default="ambitions.jsonl", help="File to write the results"
+    )
+    parser.add_argument(
+        "--model",
+        default=os.getenv("MODEL", "o4-mini"),
+        help="Chat model name. Can also be set via the MODEL env variable.",
+    )
+    parser.add_argument(
+        "--model-provider",
+        default=os.getenv("MODEL_PROVIDER", "openai"),
+        help="Chat model provider. Can also be set via the MODEL_PROVIDER env variable.",
     )
     args = parser.parse_args()
 
@@ -120,10 +134,13 @@ def main() -> None:
             "OPENAI_API_KEY is not set. Provide it via a .env file or a secret manager."
         )
 
-    system_prompt = load_prompt(args.prompt_file)
+    prompt_file = args.prompt_file
+    if args.prompt_id:
+        prompt_file = f"prompt-{args.prompt_id}.md"
+    system_prompt = load_prompt(prompt_file)
     services = load_services(args.input_file)
 
-    model = init_chat_model(model="o4-mini", model_provider="openai")
+    model = init_chat_model(model=args.model, model_provider=args.model_provider)
 
     with open(args.output_file, "w", encoding="utf-8") as output_file:
         for i, service in enumerate(services, start=1):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,3 +54,72 @@ def test_cli_requires_api_key(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["main"])
     with pytest.raises(RuntimeError):
         main.main()
+
+
+def test_cli_uses_prompt_id(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prompt-special.md").write_text("Special prompt")
+    input_file = tmp_path / "services.jsonl"
+    input_file.write_text('{"name": "alpha"}\n')
+    output_file = tmp_path / "output.jsonl"
+
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setattr(main, "init_chat_model", lambda **_: SimpleNamespace())
+    monkeypatch.setattr(
+        main,
+        "process_service",
+        lambda service, model, prompt: {"prompt": prompt},
+    )
+
+    argv = [
+        "main",
+        "--prompt-id",
+        "special",
+        "--input-file",
+        str(input_file),
+        "--output-file",
+        str(output_file),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    main.main()
+
+    line = json.loads(output_file.read_text().strip())
+    assert line["prompt"] == "Special prompt"
+
+
+def test_cli_model_parameters_from_env(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prompt.md").write_text("Prompt")
+    input_file = tmp_path / "services.jsonl"
+    input_file.write_text('{"name": "alpha"}\n')
+    output_file = tmp_path / "output.jsonl"
+
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setenv("MODEL", "test-model")
+    monkeypatch.setenv("MODEL_PROVIDER", "acme")
+
+    captured = {}
+
+    def fake_init_chat_model(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace()
+
+    monkeypatch.setattr(main, "init_chat_model", fake_init_chat_model)
+    monkeypatch.setattr(
+        main, "process_service", lambda service, model, prompt: {"ok": True}
+    )
+
+    argv = [
+        "main",
+        "--input-file",
+        str(input_file),
+        "--output-file",
+        str(output_file),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    main.main()
+
+    assert captured["model"] == "test-model"
+    assert captured["model_provider"] == "acme"


### PR DESCRIPTION
## Summary
- allow choosing chat model/provider via CLI flags or env vars
- add `--prompt-id` to switch prompt templates
- cover new options with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892b11ea598832bb5bd7e04def57b34