### PR TITLE
Add tests for loading functions and expand CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["main", "master"]
+    branches: ["**"]
   pull_request:
 
 jobs:
@@ -16,10 +16,16 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install black ruff pytest
+          pip install black ruff pytest mypy bandit pip-audit
       - name: Check formatting
         run: black --check .
       - name: Lint
         run: ruff check .
+      - name: Type check
+        run: mypy .
+      - name: Security scan
+        run: bandit -r . -ll
+      - name: Dependency audit
+        run: pip-audit
       - name: Run tests
         run: pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import sys
+import types
+
+# Stub external dependencies so tests can import `main` without installing heavy packages.
+dotenv_stub = types.ModuleType("dotenv")
+dotenv_stub.load_dotenv = lambda *args, **kwargs: None
+sys.modules.setdefault("dotenv", dotenv_stub)
+
+langchain_chat_models = types.ModuleType("langchain.chat_models")
+langchain_chat_models.init_chat_model = lambda **kwargs: None
+langchain_core_prompts = types.ModuleType("langchain_core.prompts")
+langchain_core_prompts.ChatPromptTemplate = object
+langchain_core_utils_json = types.ModuleType("langchain_core.utils.json")
+langchain_core_utils_json.parse_json_markdown = lambda x: x
+
+sys.modules.setdefault("langchain", types.ModuleType("langchain"))
+sys.modules.setdefault("langchain.chat_models", langchain_chat_models)
+sys.modules.setdefault("langchain_core", types.ModuleType("langchain_core"))
+sys.modules.setdefault("langchain_core.prompts", langchain_core_prompts)
+sys.modules.setdefault("langchain_core.utils", types.ModuleType("langchain_core.utils"))
+sys.modules.setdefault("langchain_core.utils.json", langchain_core_utils_json)

--- a/tests/fixtures/services-invalid.jsonl
+++ b/tests/fixtures/services-invalid.jsonl
@@ -1,0 +1,2 @@
+{"name": "alpha"}
+{invalid json}

--- a/tests/fixtures/services-valid.jsonl
+++ b/tests/fixtures/services-valid.jsonl
@@ -1,0 +1,2 @@
+{"name": "alpha"}
+{"name": "beta", "description": "Test"}

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+import pytest
+
+from main import load_prompt, load_services
+
+
+def test_load_prompt_reads_file(tmp_path):
+    prompt = tmp_path / "prompt.md"
+    prompt.write_text("Sample prompt", encoding="utf-8")
+    assert load_prompt(str(prompt)) == "Sample prompt"
+
+
+def test_load_prompt_missing(tmp_path):
+    missing = tmp_path / "missing.md"
+    with pytest.raises(FileNotFoundError):
+        load_prompt(str(missing))
+
+
+def test_load_services_reads_jsonl(tmp_path):
+    data = tmp_path / "services.jsonl"
+    data.write_text('{"name": "alpha"}\n\n{"name": "beta"}\n', encoding="utf-8")
+    services = list(load_services(str(data)))
+    assert services == [{"name": "alpha"}, {"name": "beta"}]
+
+
+def test_load_services_missing(tmp_path):
+    missing = tmp_path / "missing.jsonl"
+    with pytest.raises(FileNotFoundError):
+        list(load_services(str(missing)))
+
+
+def test_load_services_invalid_json(tmp_path):
+    bad = tmp_path / "bad.jsonl"
+    bad.write_text('{"name": "alpha"}\n{invalid}\n', encoding="utf-8")
+    with pytest.raises(RuntimeError):
+        list(load_services(str(bad)))
+
+
+def test_valid_fixture_parses():
+    path = Path(__file__).parent / "fixtures" / "services-valid.jsonl"
+    services = list(load_services(str(path)))
+    assert services[0]["name"] == "alpha"
+    assert services[1]["description"] == "Test"
+
+
+def test_invalid_fixture_raises():
+    path = Path(__file__).parent / "fixtures" / "services-invalid.jsonl"
+    with pytest.raises(RuntimeError):
+        list(load_services(str(path)))


### PR DESCRIPTION
## Summary
- add pytest coverage for `load_prompt`, `load_services`, and JSONL parsing using sample fixtures
- stub external deps for lightweight testing
- expand CI to run format, lint, type, security, audit, and test steps on every push

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named 'dotenv')*
- `bandit -r src -ll`
- `bandit -r . -ll`
- `pip-audit` *(fails: SSLCertVerificationError)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892bf3b8e5c832b895bc8ce2e701b72