### PR TITLE
feat: add LangSmith tracing for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ variable. Additional parameters such as the desired `response_format` may be
 provided with the `--response-format` flag or the `RESPONSE_FORMAT` environment
 variable.
 
+To collect detailed traces with [LangSmith](https://docs.smith.langchain.com/),
+set the `LANGSMITH_API_KEY` environment variable and optionally supply a
+project name via `--langsmith-project`.
+
 ## Installation
 
 Dependencies are managed with [Poetry](https://python-poetry.org/). Install the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 "langchain" ,
 "langchain-core" ,
 "langchain-openai",
+"langsmith",
 "python-dotenv",
 ]
 

--- a/src/service_ambitions/cli.py
+++ b/src/service_ambitions/cli.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 
 from .generator import ServiceAmbitionGenerator, build_model
 from .loader import load_prompt, load_services
+from .monitoring import init_langsmith
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +58,10 @@ def main() -> None:
         default=5,
         help="Number of services to process concurrently",
     )
+    parser.add_argument(
+        "--langsmith-project",
+        help="Enable LangSmith tracing for the given project",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
@@ -67,6 +72,9 @@ def main() -> None:
         raise RuntimeError(
             "OPENAI_API_KEY is not set. Provide it via a .env file or a secret manager."
         )
+
+    if os.getenv("LANGSMITH_API_KEY") or args.langsmith_project:
+        init_langsmith(args.langsmith_project)
 
     prompt_file = args.prompt_file
     if args.prompt_id:

--- a/src/service_ambitions/monitoring.py
+++ b/src/service_ambitions/monitoring.py
@@ -1,0 +1,39 @@
+"""Helpers for enabling LangSmith tracing."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from langsmith import Client
+
+logger = logging.getLogger(__name__)
+
+
+def init_langsmith(project: str | None = None) -> None:
+    """Enable LangSmith tracing if configured.
+
+    Args:
+        project: Optional name for the LangSmith project.
+
+    When the ``LANGSMITH_API_KEY`` environment variable is present this
+    function activates LangSmith's tracing support by setting the appropriate
+    environment variables. If ``project`` is given, traces are grouped under
+    that project.
+    """
+
+    api_key = os.getenv("LANGSMITH_API_KEY")
+    if not api_key:
+        logger.debug("LANGSMITH_API_KEY not set; skipping LangSmith setup")
+        return
+
+    os.environ["LANGCHAIN_TRACING_V2"] = "true"
+    os.environ["LANGCHAIN_API_KEY"] = api_key
+    if project:
+        os.environ["LANGCHAIN_PROJECT"] = project
+
+    Client()
+    logger.info(
+        "LangSmith tracing enabled%s",
+        f" for project {project}" if project else "",
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import json
+import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -173,3 +174,47 @@ def test_cli_response_format_flag(tmp_path, monkeypatch):
     cli.main()
 
     assert captured["response_format"] == "json_schema"
+
+
+def test_cli_enables_langsmith(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prompt.md").write_text("Prompt")
+    input_file = tmp_path / "services.jsonl"
+    input_file.write_text('{"name": "alpha"}\n')
+    output_file = tmp_path / "output.jsonl"
+
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.setenv("LANGSMITH_API_KEY", "ls-key")
+    monkeypatch.delenv("LANGCHAIN_TRACING_V2", raising=False)
+    monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
+    monkeypatch.delenv("LANGCHAIN_PROJECT", raising=False)
+
+    monkeypatch.setattr(generator, "ChatOpenAI", lambda **_: SimpleNamespace())
+
+    async def fake_process_service(self, service, prompt):
+        return {"ok": True}
+
+    monkeypatch.setattr(
+        ServiceAmbitionGenerator, "process_service", fake_process_service
+    )
+
+    monkeypatch.setattr(
+        "service_ambitions.monitoring.Client", lambda: SimpleNamespace()
+    )
+
+    argv = [
+        "main",
+        "--input-file",
+        str(input_file),
+        "--output-file",
+        str(output_file),
+        "--langsmith-project",
+        "demo",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    cli.main()
+
+    assert os.environ["LANGCHAIN_TRACING_V2"] == "true"
+    assert os.environ["LANGCHAIN_API_KEY"] == "ls-key"
+    assert os.environ["LANGCHAIN_PROJECT"] == "demo"


### PR DESCRIPTION
## Summary
- add optional LangSmith tracing helper and CLI flag
- document LangSmith configuration and add test

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68933c1111bc832bbf4e5d8c9e0f5a81