### PR TITLE
Add run script and early .env loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Sample environment configuration
+# Rename this file to .env and fill in your keys
+
+OPENAI_API_KEY=your_openai_api_key
+# Optional settings
+# LANGSMITH_API_KEY=your_langsmith_key
+# MODEL=o4-mini
+# RESPONSE_FORMAT=
+# LOG_LEVEL=INFO

--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@ The CLI requires an OpenAI API key available in the `OPENAI_API_KEY` environment
 variable. The key is loaded after `.env` files are processed and the application
 will exit if the variable is missing.
 
-Create a `.env` file in the project root with:
+An example configuration is provided in `.env.example`. Copy it to `.env` and
+fill in your credentials:
 
-```
-OPENAI_API_KEY=your_api_key_here
+```bash
+cp .env.example .env
 ```
 
-For production deployments, inject the variable using your platform's secret
-manager instead of committing keys to source control.
+Update the `OPENAI_API_KEY` value and any optional settings. For production
+deployments, inject the variable using your platform's secret manager instead of
+committing keys to source control.
 
 The chat model can be set with the `--model` flag or the `MODEL` environment
 variable. Additional parameters such as the desired `response_format` may be
@@ -27,16 +29,12 @@ project name via `--langsmith-project`.
 ## Installation
 
 Dependencies are managed with [Poetry](https://python-poetry.org/). Install the
-tool and then install the project's dependencies with:
+tool and then either run the project directly through Poetry or use the provided
+`run.sh` helper script, which installs dependencies, loads environment variables
+from `.env` and launches the CLI:
 
 ```bash
-poetry install
-```
-
-Run the CLI through Poetry to ensure it uses the managed environment:
-
-```bash
-poetry run python -m service_ambitions.cli --input-file sample-services.jsonl --output-file ambitions.jsonl
+./run.sh --input-file sample-services.jsonl --output-file ambitions.jsonl
 ```
 
 ## Usage

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v poetry >/dev/null 2>&1; then
+  echo "Poetry is required but not installed. Visit https://python-poetry.org/docs/" >&2
+  exit 1
+fi
+
+poetry install
+
+if [ -f .env ]; then
+  set -a
+  . ./.env
+  set +a
+fi
+
+poetry run python main.py "$@"

--- a/src/service_ambitions/cli.py
+++ b/src/service_ambitions/cli.py
@@ -18,6 +18,8 @@ logger = logging.getLogger(__name__)
 def main() -> None:
     """Parse arguments and generate ambitions for each service."""
 
+    load_dotenv()
+
     parser = argparse.ArgumentParser(description="Generate service ambitions")
     parser.add_argument(
         "--prompt-file", default="prompt.md", help="Path to the system prompt file"
@@ -65,8 +67,6 @@ def main() -> None:
     args = parser.parse_args()
 
     logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
-
-    load_dotenv()
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError(


### PR DESCRIPTION
## Summary
- load environment variables from `.env` before CLI argument parsing
- document and provide `.env.example`
- add `run.sh` helper script to install deps and launch CLI

## Testing
- `poetry install` *(failed: pyproject.toml changed since poetry.lock was last generated)*
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(failed: HTTPSConnectionPool host='pypi.org' ... SSLCertVerificationError)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893dc447314832ba6fdad27f80120ea