### PR TITLE
feat: add run script for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Run the CLI through Poetry to ensure it uses the managed environment:
 poetry run python -m service_ambitions.cli --input-file sample-services.jsonl --output-file ambitions.jsonl
 ```
 
+Alternatively, use the provided shell script which forwards all arguments to the CLI:
+
+```bash
+./run.sh --input-file sample-services.jsonl --output-file ambitions.jsonl
+```
+
 ## Usage
 
 `sample-services.jsonl` contains example services in

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Launch the Service Ambitions CLI.
+# Requires OPENAI_API_KEY to be set in the environment.
+
+set -euo pipefail
+
+if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+  echo "OPENAI_API_KEY is not set" >&2
+  exit 1
+fi
+
+poetry run python -m service_ambitions.cli "$@"


### PR DESCRIPTION
## Summary
- add run.sh to launch CLI and verify OPENAI_API_KEY
- document run.sh usage in README

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` (fails: `[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier`)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893f055f630832bb0451d591d5203cd