### PR TITLE
Fix default model format

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ For production deployments, inject the variable using your platform's secret
 manager instead of committing keys to source control.
 
 The chat model can be set with the `--model` flag or the `MODEL` environment
-variable.
+variable. Model identifiers must include a provider prefix, in the form
+`<provider>:<model>`. The default is `openai:gpt-4o-mini`.
 
 System prompts are assembled from modular markdown components located in the
 `prompts/` directory. Use `--prompt-dir` to point at an alternate component

--- a/src/settings.py
+++ b/src/settings.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-from pydantic import ValidationError
+from pydantic import Field, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Environment-driven settings for the CLI."""
 
-    model: str = "o4-mini"
+    model: str = Field(
+        "openai:gpt-4o-mini",
+        description="Chat model in '<provider>:<model>' format.",
+    )
     log_level: str = "INFO"
     openai_api_key: str
     logfire_token: str | None = None


### PR DESCRIPTION
## Summary
- set default model to provider-prefixed `openai:gpt-4o-mini`
- document provider-prefixed model requirement

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "pydantic")*
- `bandit -r src -ll` *(command not found: bandit)*
- `pip-audit` *(command not found: pip-audit)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_689413bdb974832b96646733294f7de5