### PR TITLE
feat: add configurable logging verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,4 @@ Alternatively, use the provided shell script which forwards all arguments to the
 [JSON Lines](https://jsonlines.org/) format, with one JSON object per line. The
 output file will also be in JSON Lines format. Use the `--concurrency` option to
 control how many services are processed in parallel.
+Pass `-v` for informative logs or `-vv` for detailed debugging output.


### PR DESCRIPTION
## Summary
- add `-v/--verbose` flag to control logging detail
- log service loading and output path for easier tracing
- document verbose usage and test logging option

## Testing
- `poetry run black .`
- `poetry run ruff check .`
- `poetry run mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSL certificate verify failed)*
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68941c44050c832b83ff6f49c625bca7