### PR TITLE
Avoid duplicate logs when enabling Logfire

### DIFF
--- a/src/monitoring.py
+++ b/src/monitoring.py
@@ -19,7 +19,8 @@ def init_logfire(service: str | None = None, token: str | None = None) -> None:
     When the token is provided and the ``logfire`` package is installed this
     function configures the Logfire SDK, instruments Pydantic, Pydantic AI,
     OpenAI and system metrics, and attaches a Logfire logging handler to the
-    root logger. If either condition is not met the setup is skipped.
+    root logger, replacing existing handlers to avoid duplicate output. If either
+    condition is not met the setup is skipped.
     """
 
     key = token or os.getenv("LOGFIRE_TOKEN")
@@ -47,6 +48,7 @@ def init_logfire(service: str | None = None, token: str | None = None) -> None:
     handler_cls = getattr(logfire, "LogfireLoggingHandler", None)
     if handler_cls:
         root_logger = logging.getLogger()
+        root_logger.handlers.clear()  # avoid duplicate output from existing handlers
         root_logger.addHandler(handler_cls())
 
     logger.info(

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,0 +1,38 @@
+import logging
+import sys
+from types import SimpleNamespace
+
+import monitoring
+
+
+def test_init_logfire_replaces_root_handlers(monkeypatch):
+    class DummyHandler(logging.Handler):
+        def emit(self, record):  # pragma: no cover - no output
+            pass
+
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.addHandler(DummyHandler())
+
+    class LFHandler(logging.Handler):
+        def emit(self, record):  # pragma: no cover - no output
+            pass
+
+    dummy_module = SimpleNamespace(
+        configure=lambda **kwargs: None,
+        instrument_pydantic_ai=lambda: None,
+        instrument_pydantic=lambda: None,
+        instrument_openai=lambda: None,
+        instrument_system_metrics=lambda: None,
+        LogfireLoggingHandler=LFHandler,
+    )
+    monkeypatch.setitem(sys.modules, "logfire", dummy_module)
+    monkeypatch.setenv("LOGFIRE_TOKEN", "token")
+
+    monitoring.init_logfire("svc")
+
+    handlers = logging.getLogger().handlers
+    assert len(handlers) == 1
+    assert isinstance(handlers[0], LFHandler)
+
+    root_logger.handlers.clear()


### PR DESCRIPTION
## Summary
- prevent duplicate console output by replacing root logging handlers when Logfire is activated
- add regression test for Logfire handler configuration

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: certificate verify failed)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894286ad9c0832b8838e1ed59aef37f