### PR TITLE
Enable Logfire auto tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ supports swapping sections to suit different industries.
 
 To collect detailed traces with [Pydantic Logfire](https://logfire.pydantic.dev/),
 set the `LOGFIRE_TOKEN` environment variable and optionally supply a service
-name via `--logfire-service`. The CLI automatically instruments Pydantic,
-Pydantic AI, OpenAI, and system metrics when Logfire is enabled.
+ name via `--logfire-service`. The CLI automatically installs Logfire auto
+ tracing and instruments Pydantic, Pydantic AI, OpenAI, and system metrics when
+ Logfire is enabled.
 
 ## Installation
 

--- a/src/monitoring.py
+++ b/src/monitoring.py
@@ -17,9 +17,10 @@ def init_logfire(service: str | None = None, token: str | None = None) -> None:
         token: Logfire API token. Falls back to ``LOGFIRE_TOKEN`` env var.
 
     When the token is provided and the ``logfire`` package is installed this
-    function configures the Logfire SDK, instruments Pydantic, Pydantic AI,
-    OpenAI and system metrics, and attaches a Logfire logging handler to the
-    root logger, replacing existing handlers to avoid duplicate output. If either
+    function configures the Logfire SDK, enables auto tracing, instruments
+    Pydantic, Pydantic AI, OpenAI and system metrics, and attaches a Logfire
+    logging handler to the root logger, replacing existing handlers to avoid
+    duplicate output. If either
     condition is not met the setup is skipped.
     """
 
@@ -35,7 +36,8 @@ def init_logfire(service: str | None = None, token: str | None = None) -> None:
         return
 
     logfire.configure(token=key, service_name=service)
-    logfire.instrument_system_metrics(base='full')
+    logfire.install_auto_tracing()
+    logfire.instrument_system_metrics(base="full")
 
     for name in (
         "instrument_pydantic_ai",

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -18,12 +18,19 @@ def test_init_logfire_replaces_root_handlers(monkeypatch):
         def emit(self, record):  # pragma: no cover - no output
             pass
 
+    installed = False
+
+    def install() -> None:
+        nonlocal installed
+        installed = True
+
     dummy_module = SimpleNamespace(
         configure=lambda **kwargs: None,
         instrument_pydantic_ai=lambda: None,
         instrument_pydantic=lambda: None,
         instrument_openai=lambda: None,
-        instrument_system_metrics=lambda: None,
+        instrument_system_metrics=lambda **kwargs: None,
+        install_auto_tracing=install,
         LogfireLoggingHandler=LFHandler,
     )
     monkeypatch.setitem(sys.modules, "logfire", dummy_module)
@@ -34,5 +41,6 @@ def test_init_logfire_replaces_root_handlers(monkeypatch):
     handlers = logging.getLogger().handlers
     assert len(handlers) == 1
     assert isinstance(handlers[0], LFHandler)
+    assert installed
 
     root_logger.handlers.clear()


### PR DESCRIPTION
## Summary
- enable Logfire auto tracing during initialization and document the feature
- exercise Logfire auto tracing in tests to ensure it runs when telemetry is enabled

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: certificate verify failed)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68942b1b0584832bb61744f27e188d2a