### PR TITLE
fix: update logfire auto tracing call

### DIFF
--- a/src/monitoring.py
+++ b/src/monitoring.py
@@ -36,7 +36,7 @@ def init_logfire(service: str | None = None, token: str | None = None) -> None:
         return
 
     logfire.configure(token=key, service_name=service)
-    logfire.install_auto_tracing()
+    logfire.install_auto_tracing([], min_duration=0, check_imported_modules="ignore")
     logfire.instrument_system_metrics(base="full")
 
     for name in (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -193,14 +193,19 @@ def test_cli_enables_logfire(tmp_path, monkeypatch):
         ServiceAmbitionGenerator, "process_service", fake_process_service
     )
 
-    captured: dict[str, str | None] = {}
+    captured: dict[str, object] = {}
     called: dict[str, bool] = {"installed": False}
 
     def fake_configure(**kwargs):  # type: ignore[no-untyped-def]
         captured.update(kwargs)
 
-    def fake_install() -> None:  # type: ignore[no-untyped-def]
+    def fake_install(
+        modules, *, min_duration, check_imported_modules="error"
+    ):  # type: ignore[no-untyped-def]
         called["installed"] = True
+        captured["modules"] = modules
+        captured["min_duration"] = min_duration
+        captured["check"] = check_imported_modules
 
     dummy_module = SimpleNamespace(
         configure=fake_configure,
@@ -226,6 +231,8 @@ def test_cli_enables_logfire(tmp_path, monkeypatch):
 
     assert captured["token"] == "lf-key"
     assert captured["service_name"] == "demo"
+    assert captured["modules"] == []
+    assert captured["min_duration"] == 0
     assert called["installed"]
 
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -19,10 +19,16 @@ def test_init_logfire_replaces_root_handlers(monkeypatch):
             pass
 
     installed = False
+    install_args: dict[str, object] = {}
 
-    def install() -> None:
+    def install(
+        modules, *, min_duration, check_imported_modules="error"
+    ):  # type: ignore[no-untyped-def]
         nonlocal installed
         installed = True
+        install_args["modules"] = modules
+        install_args["min_duration"] = min_duration
+        install_args["check"] = check_imported_modules
 
     dummy_module = SimpleNamespace(
         configure=lambda **kwargs: None,
@@ -42,5 +48,7 @@ def test_init_logfire_replaces_root_handlers(monkeypatch):
     assert len(handlers) == 1
     assert isinstance(handlers[0], LFHandler)
     assert installed
+    assert install_args["modules"] == []
+    assert install_args["min_duration"] == 0
 
     root_logger.handlers.clear()


### PR DESCRIPTION
## Summary
- pass required parameters to logfire.install_auto_tracing and ignore already-imported modules
- update tests for new logfire auto tracing signature

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLError certificate verify failed)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68942ea9210c832ba5b01cef90c99372