### PR TITLE
Add domain models for service evaluation

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,46 @@
+"""Domain models for service feature evaluation."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class ServiceInput(BaseModel):
+    """Basic description of a service under consideration."""
+
+    name: str = Field(..., description="Human readable service name.")
+    description: str = Field(..., description="Short explanation of the service.")
+
+
+class PlateauFeature(BaseModel):
+    """Feature assessed during a service plateau."""
+
+    feature_id: str = Field(..., description="Unique identifier for the feature.")
+    name: str = Field(..., description="Feature name.")
+    description: str = Field(..., description="Explanation of the feature.")
+
+
+class PlateauResult(BaseModel):
+    """Result of evaluating a particular plateau feature."""
+
+    feature: PlateauFeature = Field(..., description="The assessed feature.")
+    score: float = Field(
+        ..., ge=0.0, le=1.0, description="Normalised performance score between 0 and 1."
+    )
+
+
+class ServiceEvolution(BaseModel):
+    """Summary of a service's progress across plateau features."""
+
+    service: ServiceInput = Field(..., description="Service being evaluated.")
+    results: list[PlateauResult] = Field(
+        default_factory=list, description="Outcomes for evaluated plateau features."
+    )
+
+
+__all__ = [
+    "ServiceInput",
+    "PlateauFeature",
+    "PlateauResult",
+    "ServiceEvolution",
+]

--- a/src/monitoring.py
+++ b/src/monitoring.py
@@ -38,6 +38,10 @@ def init_logfire(service: str | None = None, token: str | None = None) -> None:
     logfire.configure(token=key, service_name=service)
     logfire.instrument_system_metrics(base="full")
 
+    install = getattr(logfire, "install_auto_tracing", None)
+    if install:
+        install(modules=[], min_duration=0)
+
     for name in (
         "instrument_pydantic_ai",
         "instrument_pydantic",

--- a/src/settings.py
+++ b/src/settings.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logfire
 from pydantic import Field, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
 


### PR DESCRIPTION
## Summary
- add pydantic models for service inputs, plateau features, results and evolution
- call `install_auto_tracing` when enabling Logfire telemetry
- drop unused `logfire` import from settings

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pytest`
- `pip-audit` *(fails: [SSL: CERTIFICATE_VERIFY_FAILED])*

------
https://chatgpt.com/codex/tasks/task_e_68946e067080832bb2aa20325dca27b4