### PR TITLE
Add plateau feature generator

### DIFF
--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -1,0 +1,117 @@
+"""Plateau feature generation and service evolution utilities."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Iterable
+
+from conversation import ConversationSession
+from mapping import MappedPlateauFeature, map_feature
+from models import PlateauFeature, PlateauResult, ServiceEvolution, ServiceInput
+
+logger = logging.getLogger(__name__)
+
+
+class PlateauGenerator:
+    """Generate plateau features and service evolution summaries."""
+
+    def __init__(self, session: ConversationSession, required_count: int = 5) -> None:
+        """Initialize the generator.
+
+        Args:
+            session: Active conversation session for agent queries.
+            required_count: Minimum number of features per plateau.
+        """
+        if required_count < 1:
+            raise ValueError("required_count must be positive")
+        self.session = session
+        self.required_count = required_count
+
+    async def generate_plateau(
+        self, service: ServiceInput, plateau: str, customer_type: str
+    ) -> list[PlateauResult]:
+        """Return plateau results for ``service`` and ``customer_type``.
+
+        Requests at least ``required_count`` features for the specified plateau
+        and customer type, mapping each feature using :func:`map_feature`.
+        """
+
+        prompt = (
+            "Provide JSON with a 'features' key containing at least "
+            f"{self.required_count} items. Each item must include 'feature_id', "
+            "'name', 'description', and 'score' between 0 and 1.\n"
+            f"Service name: {service.name}\n"
+            f"Service description: {service.description}\n"
+            f"Plateau: {plateau}\nCustomer type: {customer_type}"
+        )
+        logger.info(
+            "Requesting features for service=%s plateau=%s customer=%s",
+            service.name,
+            plateau,
+            customer_type,
+        )
+        response = await self.session.ask(prompt)
+        logger.debug("Raw feature response: %s", response)
+
+        try:
+            payload = json.loads(response)
+        except json.JSONDecodeError as exc:  # pragma: no cover - logging
+            logger.error("Invalid JSON from feature response: %s", exc)
+            raise ValueError("Agent returned invalid JSON") from exc
+
+        raw_features = payload.get("features")
+        if not isinstance(raw_features, list):
+            raise ValueError("'features' key missing or not a list")
+        if len(raw_features) < self.required_count:
+            logger.error(
+                "Expected at least %s features, received %s",
+                self.required_count,
+                len(raw_features),
+            )
+            raise ValueError("Insufficient number of features returned")
+
+        results: list[PlateauResult] = []
+        for item in raw_features:
+            feature = PlateauFeature(
+                feature_id=item["feature_id"],
+                name=item["name"],
+                description=item["description"],
+            )
+            mapped: MappedPlateauFeature = await map_feature(self.session, feature)
+            results.append(PlateauResult(feature=mapped, score=float(item["score"])))
+        return results
+
+    async def generate_service_evolution(
+        self,
+        service: ServiceInput,
+        plateaus: Iterable[str],
+        customer_types: Iterable[str],
+    ) -> ServiceEvolution:
+        """Return aggregated service evolution across ``plateaus``.
+
+        Each plateau is processed for every customer type using
+        :meth:`generate_plateau`.
+        """
+
+        all_results: list[PlateauResult] = []
+        for plateau in plateaus:
+            for customer in customer_types:
+                logger.debug("Processing plateau=%s for customer=%s", plateau, customer)
+                try:
+                    plateau_results = await self.generate_plateau(
+                        service, plateau, customer
+                    )
+                except ValueError as exc:
+                    logger.error(
+                        "Failed to generate plateau %s for customer %s: %s",
+                        plateau,
+                        customer,
+                        exc,
+                    )
+                    raise
+                all_results.extend(plateau_results)
+        return ServiceEvolution(service=service, results=all_results)
+
+
+__all__ = ["PlateauGenerator"]

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -1,0 +1,61 @@
+"""Tests for plateau feature generation."""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from conversation import ConversationSession
+from models import ServiceInput
+from plateau_generator import PlateauGenerator
+
+
+class DummySession:
+    """Conversation session returning queued responses."""
+
+    def __init__(self, responses: list[str]) -> None:
+        self._responses = responses
+
+    async def ask(self, prompt: str) -> str:  # pragma: no cover - simple proxy
+        return self._responses.pop(0)
+
+
+def _feature_payload(count: int) -> str:
+    items = [
+        {
+            "feature_id": f"f{i}",
+            "name": f"Feature {i}",
+            "description": f"Desc {i}",
+            "score": 0.5,
+        }
+        for i in range(count)
+    ]
+    return json.dumps({"features": items})
+
+
+def test_generate_plateau_returns_results() -> None:
+    responses = [_feature_payload(5)] + ['{"mappings": []}'] * 5
+    session = DummySession(responses)
+    generator = PlateauGenerator(cast(ConversationSession, session))
+    service = ServiceInput(name="svc", description="desc")
+
+    results = asyncio.run(
+        generator.generate_plateau(service, "alpha", "retail")
+    )  # type: ignore[arg-type]
+
+    assert len(results) == 5
+
+
+def test_generate_plateau_raises_on_insufficient_features() -> None:
+    session = DummySession([_feature_payload(3)])
+    generator = PlateauGenerator(cast(ConversationSession, session))
+    service = ServiceInput(name="svc", description="desc")
+
+    with pytest.raises(ValueError):
+        asyncio.run(
+            generator.generate_plateau(service, "alpha", "retail")
+        )  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- add PlateauGenerator to request plateau features, map them, and combine into service evolution summaries
- test plateau generation and error handling

## Testing
- `python -m black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: certificate verify failed)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68947dccb8f4832b9e79af14595ead96