### PR TITLE
feat: add service evolution subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,19 @@ tool and then install the project's dependencies with:
 poetry install
 ```
 
-Run the CLI through Poetry to ensure it uses the managed environment:
+Run the CLI through Poetry to ensure it uses the managed environment. Use
+subcommands to select the desired operation:
 
 ```bash
-poetry run python src/cli.py --input-file sample-services.jsonl --output-file ambitions.jsonl
+poetry run python src/cli.py generate-ambitions --input-file sample-services.jsonl --output-file ambitions.jsonl
+poetry run python src/cli.py generate-evolution --input-file sample-services.jsonl --output-file evolution.jsonl
 ```
 
 Alternatively, use the provided shell script which forwards all arguments to the CLI:
 
 ```bash
-./run.sh --input-file sample-services.jsonl --output-file ambitions.jsonl
+./run.sh generate-ambitions --input-file sample-services.jsonl --output-file ambitions.jsonl
+./run.sh generate-evolution --input-file sample-services.jsonl --output-file evolution.jsonl
 ```
 
 ## Usage
@@ -58,5 +61,8 @@ Alternatively, use the provided shell script which forwards all arguments to the
 `sample-services.jsonl` contains example services in
 [JSON Lines](https://jsonlines.org/) format, with one JSON object per line. The
 output file will also be in JSON Lines format. Use the `--concurrency` option to
-control how many services are processed in parallel.
-Pass `-v` for informative logs or `-vv` for detailed debugging output.
+control how many services are processed in parallel when running
+`generate-ambitions`.
+
+The `generate-evolution` subcommand produces plateau feature evolutions for each
+service. Pass `-v` for informative logs or `-vv` for detailed debugging output.

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,92 +1,43 @@
-"""Command-line interface for service ambitions generation."""
+"""Command-line interface for service ambitions and evolutions."""
 
 from __future__ import annotations
 
 import argparse
+import asyncio
 import logging
+from typing import Iterable
 
 import logfire
+from pydantic_ai import Agent
 
+from conversation import ConversationSession
 from generator import ServiceAmbitionGenerator, build_model
 from loader import load_prompt, load_services
+from models import ServiceInput
 from monitoring import init_logfire
+from plateau_generator import PlateauGenerator
 from settings import load_settings
 
 logger = logging.getLogger(__name__)
 
 
-def main() -> None:
-    """Parse arguments and generate ambitions for each service."""
+def _configure_logging(args: argparse.Namespace, settings) -> None:
+    """Configure the logging subsystem."""
 
-    parser = argparse.ArgumentParser(
-        description="Generate service ambitions",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
-    parser.add_argument(
-        "--prompt-dir",
-        default="prompts",
-        help="Directory containing prompt components",
-    )
-    parser.add_argument(
-        "--context-id",
-        default="university",
-        help="Situational context identifier",
-    )
-    parser.add_argument(
-        "--inspirations-id",
-        default="general",
-        help="Inspirations identifier",
-    )
-    parser.add_argument(
-        "--input-file",
-        default="sample-services.jsonl",
-        help="Path to the services JSONL file",
-    )
-    parser.add_argument(
-        "--output-file", default="ambitions.jsonl", help="File to write the results"
-    )
-    parser.add_argument(
-        "--model",
-        help="Chat model name. Can also be set via the MODEL env variable.",
-    )
-    parser.add_argument(
-        "--log-level",
-        help="Logging level. Can also be set via the LOG_LEVEL env variable.",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="count",
-        default=0,
-        help="Increase logging verbosity (-v for info, -vv for debug)",
-    )
-    parser.add_argument(
-        "--concurrency",
-        type=int,
-        default=5,
-        help="Number of services to process concurrently (must be > 0)",
-    )
-    parser.add_argument(
-        "--logfire-service",
-        help="Enable Logfire telemetry for the given service name",
-    )
-    args = parser.parse_args()
-
-    settings = load_settings()
-
-    log_level_name = args.log_level or settings.log_level
+    level_name = args.log_level or settings.log_level
     if args.verbose == 1:
-        log_level_name = "INFO"
+        level_name = "INFO"
     elif args.verbose >= 2:
-        log_level_name = "DEBUG"
+        level_name = "DEBUG"
     logging.basicConfig(
-        level=getattr(logging, log_level_name.upper(), logging.INFO), force=True
+        level=getattr(logging, level_name.upper(), logging.INFO), force=True
     )
-
     if settings.logfire_token or args.logfire_service:
         init_logfire(args.logfire_service, settings.logfire_token)
 
-    api_key = settings.openai_api_key
+
+def _cmd_generate_ambitions(args: argparse.Namespace, settings) -> None:
+    """Generate service ambitions and write them to disk."""
 
     system_prompt = load_prompt(args.prompt_dir, args.context_id, args.inspirations_id)
     services = list(load_services(args.input_file))
@@ -95,16 +46,148 @@ def main() -> None:
     model_name = args.model or settings.model
     logger.info("Generating ambitions using model %s", model_name)
 
-    try:
-        model = build_model(model_name, api_key)
-    except Exception as exc:  # pylint: disable=broad-except
-        logger.error("Failed to initialize model %s: %s", model_name, exc)
-        raise
-
+    model = build_model(model_name, settings.openai_api_key)
     generator = ServiceAmbitionGenerator(model, concurrency=args.concurrency)
     generator.generate(services, system_prompt, args.output_file)
     logger.info("Results written to %s", args.output_file)
     logfire.force_flush()
+
+
+async def _evolution_for_service(
+    generator: PlateauGenerator,
+    service: ServiceInput,
+    plateaus: Iterable[str],
+    customers: Iterable[str],
+) -> str:
+    """Return JSON representation of a service's evolution."""
+
+    evolution = await generator.generate_service_evolution(service, plateaus, customers)
+    return evolution.model_dump_json()
+
+
+def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
+    """Generate service evolution summaries."""
+
+    services = [ServiceInput(**svc) for svc in load_services(args.input_file)]
+    model_name = args.model or settings.model
+    model = build_model(model_name, settings.openai_api_key)
+    session = ConversationSession(Agent(model))
+    generator = PlateauGenerator(session)
+
+    with open(args.output_file, "w", encoding="utf-8") as output:
+        for service in services:
+            payload = asyncio.run(
+                _evolution_for_service(
+                    generator, service, args.plateaus, args.customers
+                )
+            )
+            output.write(f"{payload}\n")
+            logger.info("Generated evolution for %s", service.name)
+    logfire.force_flush()
+
+
+def main() -> None:
+    """Parse arguments and dispatch to the requested subcommand."""
+
+    parser = argparse.ArgumentParser(
+        description="Service ambitions utilities",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "--model",
+        help="Chat model name. Can also be set via the MODEL env variable.",
+    )
+    common.add_argument(
+        "--log-level",
+        help="Logging level. Can also be set via the LOG_LEVEL env variable.",
+    )
+    common.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase logging verbosity (-v for info, -vv for debug)",
+    )
+    common.add_argument(
+        "--logfire-service",
+        help="Enable Logfire telemetry for the given service name",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    amb = subparsers.add_parser(
+        "generate-ambitions",
+        parents=[common],
+        help="Generate service ambitions",
+        description="Generate service ambitions",
+    )
+    amb.add_argument(
+        "--prompt-dir", default="prompts", help="Directory containing prompt components"
+    )
+    amb.add_argument(
+        "--context-id", default="university", help="Situational context identifier"
+    )
+    amb.add_argument(
+        "--inspirations-id", default="general", help="Inspirations identifier"
+    )
+    amb.add_argument(
+        "--input-file",
+        default="sample-services.jsonl",
+        help="Path to the services JSONL file",
+    )
+    amb.add_argument(
+        "--output-file",
+        default="ambitions.jsonl",
+        help="File to write the results",
+    )
+    amb.add_argument(
+        "--concurrency",
+        type=int,
+        default=5,
+        help="Number of services to process concurrently (must be > 0)",
+    )
+    amb.set_defaults(func=_cmd_generate_ambitions)
+
+    evo = subparsers.add_parser(
+        "generate-evolution",
+        parents=[common],
+        help="Generate service evolution",
+    )
+    evo.add_argument(
+        "--input-file",
+        default="sample-services.jsonl",
+        help="Path to the services JSONL file",
+    )
+    evo.add_argument(
+        "--output-file",
+        default="evolution.jsonl",
+        help="File to write the results",
+    )
+    evo.add_argument(
+        "--plateaus",
+        nargs="+",
+        default=[
+            "Foundational",
+            "Enhanced",
+            "Experimental",
+            "Disruptive",
+            "Transformative",
+        ],
+        help="Plateau names to evaluate",
+    )
+    evo.add_argument(
+        "--customers",
+        nargs="+",
+        default=["retail"],
+        help="Customer types to evaluate",
+    )
+    evo.set_defaults(func=_cmd_generate_evolution)
+
+    args = parser.parse_args()
+    settings = load_settings()
+    _configure_logging(args, settings)
+    args.func(args, settings)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,7 @@ def test_cli_generates_output(tmp_path, monkeypatch):
 
     argv = [
         "main",
+        "generate-ambitions",
         "--prompt-dir",
         str(base),
         "--context-id",
@@ -68,7 +69,7 @@ def test_cli_generates_output(tmp_path, monkeypatch):
 
 def test_cli_requires_api_key(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.setattr(sys, "argv", ["main"])
+    monkeypatch.setattr(sys, "argv", ["main", "generate-ambitions"])
     with pytest.raises(RuntimeError) as excinfo:
         cli.main()
     assert "openai_api_key" in str(excinfo.value)
@@ -101,6 +102,7 @@ def test_cli_switches_context(tmp_path, monkeypatch):
 
     argv = [
         "main",
+        "generate-ambitions",
         "--context-id",
         "beta",
         "--input-file",
@@ -155,6 +157,7 @@ def test_cli_model_instantiation_arguments(tmp_path, monkeypatch):
 
     argv = [
         "main",
+        "generate-ambitions",
         "--input-file",
         str(input_file),
         "--output-file",
@@ -216,6 +219,7 @@ def test_cli_enables_logfire(tmp_path, monkeypatch):
 
     argv = [
         "main",
+        "generate-ambitions",
         "--input-file",
         str(input_file),
         "--output-file",
@@ -242,7 +246,7 @@ def test_cli_rejects_invalid_concurrency(monkeypatch):
     monkeypatch.setattr(cli, "load_services", lambda *a, **k: [])
     monkeypatch.setattr(cli, "build_model", lambda *a, **k: object())
 
-    argv = ["main", "--concurrency", "0", "--model", "test"]
+    argv = ["main", "generate-ambitions", "--concurrency", "0", "--model", "test"]
     monkeypatch.setattr(sys, "argv", argv)
 
     with pytest.raises(ValueError, match="concurrency must be a positive integer"):
@@ -250,7 +254,7 @@ def test_cli_rejects_invalid_concurrency(monkeypatch):
 
 
 def test_cli_help_shows_parameters(monkeypatch, capsys):
-    monkeypatch.setattr(sys, "argv", ["main", "--help"])
+    monkeypatch.setattr(sys, "argv", ["main", "generate-ambitions", "--help"])
     with pytest.raises(SystemExit):
         cli.main()
     out = capsys.readouterr().out
@@ -284,6 +288,7 @@ def test_cli_verbose_logging(tmp_path, monkeypatch, capsys):
 
     argv = [
         "main",
+        "generate-ambitions",
         "--prompt-dir",
         str(base),
         "--context-id",

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -1,0 +1,60 @@
+"""Tests for the generate-evolution CLI subcommand."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from cli import _cmd_generate_evolution
+from models import ServiceEvolution, ServiceInput
+
+
+def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
+    input_path = tmp_path / "services.jsonl"
+    output_path = tmp_path / "out.jsonl"
+    input_path.write_text(json.dumps({"name": "svc", "description": "desc"}) + "\n")
+
+    def fake_build_model(
+        model_name: str, api_key: str
+    ) -> object:  # pragma: no cover - simple stub
+        return object()
+
+    class DummyAgent:  # pragma: no cover - simple stub
+        def __init__(self, model: object) -> None:  # noqa: D401 - no behaviour
+            self.model = model
+
+    async def fake_generate(
+        self, service: ServiceInput, plateaus, customers
+    ) -> ServiceEvolution:
+        return ServiceEvolution(service=service, results=[])
+
+    monkeypatch.setattr("cli.build_model", fake_build_model)
+    monkeypatch.setattr("cli.Agent", DummyAgent)
+    monkeypatch.setattr(
+        "cli.PlateauGenerator.generate_service_evolution", fake_generate
+    )
+    monkeypatch.setattr("cli.logfire.force_flush", lambda: None)
+
+    settings = SimpleNamespace(
+        model="test-model",
+        log_level="INFO",
+        openai_api_key="key",
+        logfire_token=None,
+    )
+    args = argparse.Namespace(
+        input_file=str(input_path),
+        output_file=str(output_path),
+        plateaus=["alpha"],
+        customers=["retail"],
+        model=None,
+        logfire_service=None,
+        log_level=None,
+        verbose=0,
+    )
+
+    _cmd_generate_evolution(args, settings)
+
+    payload = json.loads(output_path.read_text().strip())
+    assert payload["service"]["name"] == "svc"


### PR DESCRIPTION
## Summary
- add `generate-evolution` subcommand to CLI
- document CLI subcommands
- cover new subcommand in tests

## Testing
- `black src/cli.py tests/test_cli.py tests/test_cli_generate_evolution.py`
- `ruff check src/cli.py tests/test_cli.py tests/test_cli_generate_evolution.py`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLError)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68947ff76690832b95b6db61ef8f4c70