### PR TITLE
Add unit and integration tests for service evolution

### DIFF
--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,0 +1,46 @@
+"""Unit tests for the :mod:`conversation` module."""
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from pydantic_ai import messages  # noqa: E402  pylint: disable=wrong-import-position
+
+from conversation import (
+    ConversationSession,
+)  # noqa: E402  pylint: disable=wrong-import-position
+
+
+class DummyAgent:
+    """Minimal stand-in for a Pydantic-AI agent."""
+
+    def __init__(self) -> None:  # pragma: no cover - trivial init
+        self.called_with: list[str] = []
+
+    async def run(
+        self, prompt: str, message_history: list
+    ):  # pragma: no cover - simple stub
+        self.called_with.append(prompt)
+        return SimpleNamespace(output="pong", new_messages=lambda: ["msg"])
+
+
+def test_add_parent_materials_records_history() -> None:
+    """``add_parent_materials`` should append system prompts to history."""
+
+    session = ConversationSession(DummyAgent())
+    session.add_parent_materials(["alpha", "beta"])
+
+    assert len(session._history) == 2  # noqa: SLF001 - accessing test-only attribute
+    assert isinstance(session._history[0], messages.ModelRequest)
+
+
+def test_ask_adds_responses_to_history() -> None:
+    """``ask`` should forward prompts and store new messages."""
+
+    session = ConversationSession(DummyAgent())
+    reply = asyncio.run(session.ask("ping"))
+
+    assert reply == "pong"
+    assert session._history[-1] == "msg"  # noqa: SLF001 - accessing test-only attribute

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -1,0 +1,68 @@
+"""Integration test for four-plateau service evolution."""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import cast
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from conversation import (  # noqa: E402  pylint: disable=wrong-import-position
+    ConversationSession,
+)
+from models import (  # noqa: E402  pylint: disable=wrong-import-position
+    ServiceEvolution,
+    ServiceInput,
+)
+from plateau_generator import (  # noqa: E402  pylint: disable=wrong-import-position
+    PlateauGenerator,
+)
+
+
+class DummySession:
+    """Session returning queued JSON payloads."""
+
+    def __init__(self, responses: list[str]) -> None:
+        self._responses = responses
+
+    async def ask(self, prompt: str) -> str:  # pragma: no cover - trivial
+        return self._responses.pop(0)
+
+
+async def _fake_map_feature(session, feature, prompt_dir):  # pragma: no cover - stub
+    from mapping import MappedPlateauFeature
+
+    return MappedPlateauFeature(**feature.model_dump(), mappings=[])
+
+
+def _feature_payload() -> str:
+    return json.dumps(
+        {
+            "features": [
+                {
+                    "feature_id": "f1",
+                    "name": "Feat",
+                    "description": "Desc",
+                    "score": 0.5,
+                }
+            ]
+        }
+    )
+
+
+def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
+    """``generate_service_evolution`` should aggregate all plateaus."""
+
+    responses = [_feature_payload() for _ in range(4)]
+    session = DummySession(responses)
+    generator = PlateauGenerator(cast(ConversationSession, session), required_count=1)
+
+    monkeypatch.setattr("plateau_generator.map_feature", _fake_map_feature)
+
+    service = ServiceInput(name="svc", description="desc")
+    evolution = asyncio.run(
+        generator.generate_service_evolution(service, ["a", "b", "c", "d"], ["retail"])
+    )
+
+    assert isinstance(evolution, ServiceEvolution)
+    assert len(evolution.results) == 4

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,36 @@
+"""Unit tests for Pydantic models."""
+
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from models import (  # noqa: E402  pylint: disable=wrong-import-position
+    PlateauFeature,
+    PlateauResult,
+    ServiceEvolution,
+    ServiceInput,
+)
+
+
+def test_service_evolution_contains_results() -> None:
+    """Constructing a ServiceEvolution should retain nested models."""
+
+    service = ServiceInput(name="svc", description="desc")
+    feature = PlateauFeature(feature_id="f1", name="Feat", description="D")
+    result = PlateauResult(feature=feature, score=0.75)
+
+    evolution = ServiceEvolution(service=service, results=[result])
+
+    assert evolution.results[0].feature.name == "Feat"
+
+
+def test_plateau_result_validates_score() -> None:
+    """Scores must lie within the inclusive range [0, 1]."""
+
+    feature = PlateauFeature(feature_id="f1", name="Feat", description="D")
+
+    with pytest.raises(ValidationError):
+        PlateauResult(feature=feature, score=2.0)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,25 @@
+"""Tests for configuration loading."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from settings import load_settings  # noqa: E402  pylint: disable=wrong-import-position
+
+
+def test_load_settings_reads_env(monkeypatch) -> None:
+    """Environment variables should populate the settings model."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "token")
+    settings = load_settings()
+    assert settings.openai_api_key == "token"
+
+
+def test_load_settings_requires_key(monkeypatch) -> None:
+    """Missing API key should raise ``RuntimeError``."""
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        load_settings()


### PR DESCRIPTION
## Summary
- add unit tests for conversation sessions, Pydantic models, and settings using dummy agents
- implement integration test covering four-plateau service evolution

## Testing
- `black .`
- `ruff check .`
- `mypy . --ignore-missing-imports`
- `bandit -r src -ll`
- `pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/anyio/4.10.0/json (Caused by SSLError))*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68948561105c832baf9dfca4337c655d