### PR TITLE
Inject reference data into mapping prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,12 @@ control how many services are processed in parallel when running
 
 The `generate-evolution` subcommand produces plateau feature evolutions for each
 service. Pass `-v` for informative logs or `-vv` for detailed debugging output.
+
+## Reference Data
+
+Feature mapping uses cached reference lists stored in the `data/` directory.
+Each of `information.json`, `applications.json`, and `technologies.json`
+contains items with identifiers, names, and descriptions. These lists are
+injected into mapping prompts so that features can be matched against consistent
+options. Mapping prompts run separately for information, applications and
+technologies to keep each decision focused.

--- a/data/applications.json
+++ b/data/applications.json
@@ -1,0 +1,4 @@
+[
+  {"id": "APP001", "name": "Learning Platform", "description": "Software used for courses."},
+  {"id": "APP002", "name": "Analytics Dashboard", "description": "Provides insights into performance."}
+]

--- a/data/information.json
+++ b/data/information.json
@@ -1,0 +1,4 @@
+[
+  {"id": "INFO001", "name": "User Data", "description": "Information about the user."},
+  {"id": "INFO002", "name": "Course Material", "description": "Content used for teaching."}
+]

--- a/data/technologies.json
+++ b/data/technologies.json
@@ -1,0 +1,4 @@
+[
+  {"id": "TECH001", "name": "AI Engine", "description": "Provides intelligent features."},
+  {"id": "TECH002", "name": "Cloud Storage", "description": "Stores data securely."}
+]

--- a/prompts/mapping_prompt.md
+++ b/prompts/mapping_prompt.md
@@ -1,6 +1,9 @@
 ## Feature mapping
 
-Provide mapping items for the following feature. Respond in JSON with a "mappings" key where each item has "item" and "contribution" fields.
+Map the feature to relevant {category_label} from the list below. Respond in JSON with a "mappings" key where each item has "item" and "contribution" fields.
+
+### {category_label}
+{category_items}
 
 Feature name: {feature_name}
 Feature description: {feature_description}

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -12,18 +12,24 @@ from models import PlateauFeature
 class DummySession:
     """Simple stand-in for a conversation session."""
 
-    def __init__(self, response: str) -> None:  # pragma: no cover - simple init
-        self._response = response
+    def __init__(self, responses: list[str]) -> None:  # pragma: no cover - simple init
+        self._responses = iter(responses)
+        self.prompts: list[str] = []
 
     async def ask(self, prompt: str) -> str:  # pragma: no cover - trivial
-        return self._response
+        self.prompts.append(prompt)
+        return next(self._responses)
 
 
 def test_map_feature_returns_mappings() -> None:
     """``map_feature`` should populate mapping items with contributions."""
 
     session = DummySession(
-        '{"mappings": [{"item": "API", "contribution": "Enables integration."}]}'
+        [
+            '{"mappings": [{"item": "API", "contribution": "Enables integration."}]}',
+            '{"mappings": []}',
+            '{"mappings": []}',
+        ]
     )
     feature = PlateauFeature(
         feature_id="f1", name="Integration", description="Allows external access"
@@ -34,3 +40,18 @@ def test_map_feature_returns_mappings() -> None:
     assert isinstance(result, MappedPlateauFeature)
     assert result.mappings[0].item == "API"
     assert result.mappings[0].contribution == "Enables integration."
+
+
+def test_map_feature_injects_reference_data() -> None:
+    """The mapping prompts should include reference data lists."""
+
+    session = DummySession(['{"mappings": []}'] * 3)
+    feature = PlateauFeature(
+        feature_id="f1", name="Integration", description="Allows external access"
+    )
+    asyncio.run(map_feature(session, feature))  # type: ignore[arg-type]
+
+    assert len(session.prompts) == 3
+    assert "User Data" in session.prompts[0]
+    assert "Learning Platform" in session.prompts[1]
+    assert "AI Engine" in session.prompts[2]

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -38,7 +38,7 @@ def _feature_payload(count: int) -> str:
 
 
 def test_generate_plateau_returns_results() -> None:
-    responses = [_feature_payload(5)] + ['{"mappings": []}'] * 5
+    responses = [_feature_payload(5)] + ['{"mappings": []}'] * 15
     session = DummySession(responses)
     generator = PlateauGenerator(cast(ConversationSession, session))
     service = ServiceInput(name="svc", description="desc")


### PR DESCRIPTION
## Summary
- load mapping reference lists from JSON files and cache them
- inject information, application and technology lists into mapping prompts
- document reference data and expand mapping tests
- call mapping prompts sequentially per reference list

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: certificate verify failed)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68948699c76c832b9b4fbbc0be0d3a48