### PR TITLE
docs: document generate-evolution usage and checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,31 @@ control how many services are processed in parallel when running
 
 The `generate-evolution` subcommand produces plateau feature evolutions for each
 service. Pass `-v` for informative logs or `-vv` for detailed debugging output.
+Use `--plateaus` and `--customers` to control what is evaluated:
+
+```bash
+./run.sh generate-evolution --plateaus Foundational Enhanced --customers retail enterprise
+```
+
+## Output schema
+
+Each JSON line is a service evolution record:
+
+```json
+{
+  "service": {"name": "string", "description": "string"},
+  "results": [
+    {
+      "feature": {
+        "feature_id": "string",
+        "name": "string",
+        "description": "string"
+      },
+      "score": 0.0
+    }
+  ]
+}
+```
 
 ## Reference Data
 
@@ -75,3 +100,15 @@ contains items with identifiers, names, and descriptions. These lists are
 injected into mapping prompts so that features can be matched against consistent
 options. Mapping prompts run separately for information, applications and
 technologies to keep each decision focused.
+
+## Testing
+
+Run the following checks before committing:
+
+```bash
+black .
+ruff .
+mypy .
+bandit -r src -ll
+pip-audit
+```

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -1,0 +1,45 @@
+# Generate evolution
+
+## Running
+
+Example command:
+
+```bash
+poetry run python src/cli.py generate-evolution \
+  --input-file sample-services.jsonl \
+  --output-file evolution.jsonl \
+  --plateaus Foundational Enhanced \
+  --customers retail enterprise
+```
+
+## Output schema
+
+Each line in the output file is a JSON object with:
+
+```json
+{
+  "service": {"name": "string", "description": "string"},
+  "results": [
+    {
+      "feature": {
+        "feature_id": "string",
+        "name": "string",
+        "description": "string"
+      },
+      "score": 0.0
+    }
+  ]
+}
+```
+
+## Testing
+
+Run project checks before committing:
+
+```bash
+black .
+ruff .
+mypy .
+bandit -r src -ll
+pip-audit
+```


### PR DESCRIPTION
## Summary
- document generate-evolution usage, output schema, and quality checks in README
- add a dedicated generate-evolution doc with example command and JSON schema

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Argument 1 to "ConversationSession" incompatible, etc.)*
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError when contacting pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_68948bcb9c64832badd48748ed203bec