### PR TITLE
Add service evolution models with mapping support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,11 @@ Each JSON line is a service evolution record:
 
 ```json
 {
-  "service": {"name": "string", "description": "string"},
+  "service": {
+    "name": "string",
+    "description": "string",
+    "customer_type": "string"
+  },
   "results": [
     {
       "feature": {
@@ -86,7 +90,10 @@ Each JSON line is a service evolution record:
         "name": "string",
         "description": "string"
       },
-      "score": 0.0
+      "score": 0.0,
+      "conceptual_data_types": [{"item": "string", "contribution": "string"}],
+      "logical_application_types": [{"item": "string", "contribution": "string"}],
+      "logical_technology_types": [{"item": "string", "contribution": "string"}]
     }
   ]
 }

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -18,7 +18,11 @@ Each line in the output file is a JSON object with:
 
 ```json
 {
-  "service": {"name": "string", "description": "string"},
+  "service": {
+    "name": "string",
+    "description": "string",
+    "customer_type": "string"
+  },
   "results": [
     {
       "feature": {
@@ -26,7 +30,10 @@ Each line in the output file is a JSON object with:
         "name": "string",
         "description": "string"
       },
-      "score": 0.0
+      "score": 0.0,
+      "conceptual_data_types": [{"item": "string", "contribution": "string"}],
+      "logical_application_types": [{"item": "string", "contribution": "string"}],
+      "logical_technology_types": [{"item": "string", "contribution": "string"}]
     }
   ]
 }

--- a/src/models.py
+++ b/src/models.py
@@ -5,10 +5,22 @@ from __future__ import annotations
 from pydantic import BaseModel, Field
 
 
+class Contribution(BaseModel):
+    """Item contributing to a feature's assessment."""
+
+    item: str = Field(..., description="Name of the mapped element.")
+    contribution: str = Field(
+        ..., description="Explanation of how the item supports the feature."
+    )
+
+
 class ServiceInput(BaseModel):
     """Basic description of a service under consideration."""
 
     name: str = Field(..., description="Human readable service name.")
+    customer_type: str | None = Field(
+        None, description="Primary customer segment for the service."
+    )
     description: str = Field(..., description="Short explanation of the service.")
 
 
@@ -27,6 +39,18 @@ class PlateauResult(BaseModel):
     score: float = Field(
         ..., ge=0.0, le=1.0, description="Normalised performance score between 0 and 1."
     )
+    conceptual_data_types: list[Contribution] = Field(
+        default_factory=list,
+        description="Conceptual data types related to the feature.",
+    )
+    logical_application_types: list[Contribution] = Field(
+        default_factory=list,
+        description="Logical application types relevant to the feature.",
+    )
+    logical_technology_types: list[Contribution] = Field(
+        default_factory=list,
+        description="Logical technology types supporting the feature.",
+    )
 
 
 class ServiceEvolution(BaseModel):
@@ -41,6 +65,7 @@ class ServiceEvolution(BaseModel):
 __all__ = [
     "ServiceInput",
     "PlateauFeature",
+    "Contribution",
     "PlateauResult",
     "ServiceEvolution",
 ]

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -14,7 +14,10 @@ from models import ServiceEvolution, ServiceInput
 def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
     input_path = tmp_path / "services.jsonl"
     output_path = tmp_path / "out.jsonl"
-    input_path.write_text(json.dumps({"name": "svc", "description": "desc"}) + "\n")
+    input_path.write_text(
+        json.dumps({"name": "svc", "description": "desc", "customer_type": "retail"})
+        + "\n"
+    )
 
     def fake_build_model(
         model_name: str, api_key: str

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -6,7 +6,9 @@ from pathlib import Path
 from types import SimpleNamespace
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
-from pydantic_ai import messages  # noqa: E402  pylint: disable=wrong-import-position
+from typing import cast
+
+from pydantic_ai import Agent, messages  # noqa: E402  pylint: disable=wrong-import-position
 
 from conversation import (
     ConversationSession,
@@ -29,7 +31,7 @@ class DummyAgent:
 def test_add_parent_materials_records_history() -> None:
     """``add_parent_materials`` should append system prompts to history."""
 
-    session = ConversationSession(DummyAgent())
+    session = ConversationSession(cast(Agent[None, str], DummyAgent()))
     session.add_parent_materials(["alpha", "beta"])
 
     assert len(session._history) == 2  # noqa: SLF001 - accessing test-only attribute
@@ -39,7 +41,7 @@ def test_add_parent_materials_records_history() -> None:
 def test_ask_adds_responses_to_history() -> None:
     """``ask`` should forward prompts and store new messages."""
 
-    session = ConversationSession(DummyAgent())
+    session = ConversationSession(cast(Agent[None, str], DummyAgent()))
     reply = asyncio.run(session.ask("ping"))
 
     assert reply == "pong"

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -59,7 +59,7 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
 
     monkeypatch.setattr("plateau_generator.map_feature", _fake_map_feature)
 
-    service = ServiceInput(name="svc", description="desc")
+    service = ServiceInput(name="svc", customer_type="retail", description="desc")
     evolution = asyncio.run(
         generator.generate_service_evolution(service, ["a", "b", "c", "d"], ["retail"])
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from models import (  # noqa: E402  pylint: disable=wrong-import-position
+    Contribution,
     PlateauFeature,
     PlateauResult,
     ServiceEvolution,
@@ -18,9 +19,10 @@ from models import (  # noqa: E402  pylint: disable=wrong-import-position
 def test_service_evolution_contains_results() -> None:
     """Constructing a ServiceEvolution should retain nested models."""
 
-    service = ServiceInput(name="svc", description="desc")
+    service = ServiceInput(name="svc", customer_type="retail", description="desc")
     feature = PlateauFeature(feature_id="f1", name="Feat", description="D")
-    result = PlateauResult(feature=feature, score=0.75)
+    contrib = Contribution(item="data", contribution="used")
+    result = PlateauResult(feature=feature, score=0.75, conceptual_data_types=[contrib])
 
     evolution = ServiceEvolution(service=service, results=[result])
 

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -41,7 +41,7 @@ def test_generate_plateau_returns_results() -> None:
     responses = [_feature_payload(5)] + ['{"mappings": []}'] * 15
     session = DummySession(responses)
     generator = PlateauGenerator(cast(ConversationSession, session))
-    service = ServiceInput(name="svc", description="desc")
+    service = ServiceInput(name="svc", customer_type="retail", description="desc")
 
     results = asyncio.run(
         generator.generate_plateau(service, "alpha", "retail")
@@ -53,7 +53,7 @@ def test_generate_plateau_returns_results() -> None:
 def test_generate_plateau_raises_on_insufficient_features() -> None:
     session = DummySession([_feature_payload(3)])
     generator = PlateauGenerator(cast(ConversationSession, session))
-    service = ServiceInput(name="svc", description="desc")
+    service = ServiceInput(name="svc", customer_type="retail", description="desc")
 
     with pytest.raises(ValueError):
         asyncio.run(


### PR DESCRIPTION
## Summary
- expand service models to include customer type and mapping contributions
- document updated JSON schema for service evolution output

## Testing
- `python -m black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68948f2e5734832bad2d1f32f1742760