### PR TITLE
Add conversation session wrapper

### DIFF
--- a/src/conversation.py
+++ b/src/conversation.py
@@ -1,58 +1,78 @@
-"""Conversation session management for Pydantic AI clients."""
+"""Conversational session wrapper for LLM interactions.
+
+This module exposes :class:`ConversationSession` which provides a thin
+abstraction over a Pydantic-AI ``Agent``.  The session maintains the message
+history so that each prompt sent to the model retains prior context.  The
+session can be seeded with details from a :class:`models.ServiceInput` via
+``add_parent_materials``.
+"""
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Iterable
 
 from pydantic_ai import Agent, messages
+
+from models import ServiceInput
 
 logger = logging.getLogger(__name__)
 
 
 class ConversationSession:
-    """Manage a conversational interaction with a Pydantic-AI Agent.
+    """Manage a conversational interaction with a Pydantic-AI agent.
 
-    The session maintains message history so that subsequent requests include
-    prior context. Additional materials can be injected as system prompts via
-    :meth:`add_parent_materials`.
+    The session stores message history so that subsequent prompts include
+    previous context. Additional materials about the service under discussion
+    may be seeded using :meth:`add_parent_materials`.
     """
 
     def __init__(self, client: Agent) -> None:
-        """Initialize the session.
+        """Initialise the session with a configured LLM client.
 
         Args:
-            client: Configured Pydantic-AI agent used for exchanges.
+            client: Pydantic-AI ``Agent`` used for exchanges with the model.
         """
 
         self.client = client
         self._history: list[messages.ModelMessage] = []
 
-    def add_parent_materials(self, materials: Iterable[str]) -> None:
-        """Append ``materials`` to the conversation as system prompts.
+    def add_parent_materials(self, service_input: ServiceInput) -> None:
+        """Seed the conversation with details about the target service.
 
         Args:
-            materials: Iterable of additional context strings.
+            service_input: Metadata describing the service being evaluated.
         """
 
-        for material in materials:
-            logger.debug("Adding parent material: %s", material)
-            self._history.append(
-                messages.ModelRequest(parts=[messages.SystemPromptPart(material)])
-            )
+        material = (
+            f"Service name: {service_input.name}\n"
+            f"Customer type: {service_input.customer_type or 'N/A'}\n"
+            f"Description: {service_input.description}"
+        )
+        logger.debug("Adding service material to history: %s", material)
+        self._history.append(
+            messages.ModelRequest(parts=[messages.SystemPromptPart(material)])
+        )
 
-    async def ask(self, prompt: str) -> str:
-        """Send ``prompt`` to the agent and return the text response.
+    def ask(self, prompt: str) -> str:
+        """Send ``prompt`` to the agent and return the textual response.
+
+        The prompt along with accumulated message history is forwarded to the
+        underlying ``Agent``.  The response and any new messages are recorded in
+        the session history.
 
         Args:
-            prompt: The user message to send.
+            prompt: The user message to send to the model.
 
         Returns:
-            The agent's response as text.
+            The agent's response text.
         """
 
         logger.info("Sending prompt: %s", prompt)
-        result = await self.client.run(prompt, message_history=self._history)
+        result = asyncio.run(self.client.run(prompt, message_history=self._history))
         self._history.extend(result.new_messages())
         logger.info("Received response: %s", result.output)
         return result.output
+
+
+__all__ = ["ConversationSession"]

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import TYPE_CHECKING, Any
@@ -86,7 +87,7 @@ async def map_feature(
         )
 
         logger.debug("Requesting %s mappings for feature %s", key, feature.feature_id)
-        response = await session.ask(prompt)
+        response = await asyncio.to_thread(session.ask, prompt)
         logger.debug("Raw %s mapping response: %s", key, response)
 
         try:

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Iterable
@@ -59,7 +60,7 @@ class PlateauGenerator:
             plateau,
             customer_type,
         )
-        response = await self.session.ask(prompt)
+        response = await asyncio.to_thread(self.session.ask, prompt)
         logger.debug("Raw feature response: %s", response)
 
         try:

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,6 +1,5 @@
 """Unit tests for the :mod:`conversation` module."""
 
-import asyncio
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -8,11 +7,15 @@ from types import SimpleNamespace
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from typing import cast
 
-from pydantic_ai import Agent, messages  # noqa: E402  pylint: disable=wrong-import-position
+from pydantic_ai import (
+    Agent,
+    messages,
+)  # noqa: E402  pylint: disable=wrong-import-position
 
 from conversation import (
     ConversationSession,
 )  # noqa: E402  pylint: disable=wrong-import-position
+from models import ServiceInput  # noqa: E402  pylint: disable=wrong-import-position
 
 
 class DummyAgent:
@@ -29,12 +32,13 @@ class DummyAgent:
 
 
 def test_add_parent_materials_records_history() -> None:
-    """``add_parent_materials`` should append system prompts to history."""
+    """``add_parent_materials`` should append service info to history."""
 
     session = ConversationSession(cast(Agent[None, str], DummyAgent()))
-    session.add_parent_materials(["alpha", "beta"])
+    service = ServiceInput(name="svc", customer_type=None, description="desc")
+    session.add_parent_materials(service)
 
-    assert len(session._history) == 2  # noqa: SLF001 - accessing test-only attribute
+    assert len(session._history) == 1  # noqa: SLF001 - accessing test-only attribute
     assert isinstance(session._history[0], messages.ModelRequest)
 
 
@@ -42,7 +46,7 @@ def test_ask_adds_responses_to_history() -> None:
     """``ask`` should forward prompts and store new messages."""
 
     session = ConversationSession(cast(Agent[None, str], DummyAgent()))
-    reply = asyncio.run(session.ask("ping"))
+    reply = session.ask("ping")
 
     assert reply == "pong"
     assert session._history[-1] == "msg"  # noqa: SLF001 - accessing test-only attribute

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -25,7 +25,7 @@ class DummySession:
     def __init__(self, responses: list[str]) -> None:
         self._responses = responses
 
-    async def ask(self, prompt: str) -> str:  # pragma: no cover - trivial
+    def ask(self, prompt: str) -> str:  # pragma: no cover - trivial
         return self._responses.pop(0)
 
 

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -16,7 +16,7 @@ class DummySession:
         self._responses = iter(responses)
         self.prompts: list[str] = []
 
-    async def ask(self, prompt: str) -> str:  # pragma: no cover - trivial
+    def ask(self, prompt: str) -> str:  # pragma: no cover - trivial
         self.prompts.append(prompt)
         return next(self._responses)
 

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -20,7 +20,7 @@ class DummySession:
     def __init__(self, responses: list[str]) -> None:
         self._responses = responses
 
-    async def ask(self, prompt: str) -> str:  # pragma: no cover - simple proxy
+    def ask(self, prompt: str) -> str:  # pragma: no cover - simple proxy
         return self._responses.pop(0)
 
 


### PR DESCRIPTION
## Summary
- wrap LLM client in new `ConversationSession` with seed and ask helpers
- adapt mapping and plateau generation to use synchronous session calls
- update tests for new conversation session API

## Testing
- `pytest`
- `black src tests/test_conversation.py tests/test_mapping.py tests/test_plateau_generator.py tests/test_integration_service_evolution.py`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded...)*


------
https://chatgpt.com/codex/tasks/task_e_689491dc2b54832b915d66d12a0e2868