### PR TITLE
Add feature mapping with data, application and technology lists

### DIFF
--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -9,7 +9,7 @@ from typing import Iterable
 
 from conversation import ConversationSession
 from loader import load_plateau_prompt
-from mapping import MappedPlateauFeature, map_feature
+from mapping import map_feature
 from models import PlateauFeature, PlateauResult, ServiceEvolution, ServiceInput
 
 logger = logging.getLogger(__name__)
@@ -87,9 +87,7 @@ class PlateauGenerator:
                 name=item["name"],
                 description=item["description"],
             )
-            mapped: MappedPlateauFeature = await map_feature(
-                self.session, feature, self.prompt_dir
-            )
+            mapped = map_feature(self.session, feature, self.prompt_dir)
             results.append(PlateauResult(feature=mapped, score=float(item["score"])))
         return results
 

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -29,10 +29,15 @@ class DummySession:
         return self._responses.pop(0)
 
 
-async def _fake_map_feature(session, feature, prompt_dir):  # pragma: no cover - stub
-    from mapping import MappedPlateauFeature
+def _fake_map_feature(session, feature, prompt_dir):  # pragma: no cover - stub
+    from mapping import MappedPlateauFeature, TypeContribution
 
-    return MappedPlateauFeature(**feature.model_dump(), mappings=[])
+    return MappedPlateauFeature(
+        **feature.model_dump(),
+        data=[TypeContribution(type="d", contribution="c")],
+        applications=[TypeContribution(type="a", contribution="c")],
+        technology=[TypeContribution(type="t", contribution="c")],
+    )
 
 
 def _feature_payload() -> str:

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -38,7 +38,16 @@ def _feature_payload(count: int) -> str:
 
 
 def test_generate_plateau_returns_results() -> None:
-    responses = [_feature_payload(5)] + ['{"mappings": []}'] * 15
+    mapping_responses = []
+    for _ in range(5):
+        mapping_responses.extend(
+            [
+                json.dumps({"data": [{"type": "d", "contribution": "c"}]}),
+                json.dumps({"applications": [{"type": "a", "contribution": "c"}]}),
+                json.dumps({"technology": [{"type": "t", "contribution": "c"}]}),
+            ]
+        )
+    responses = [_feature_payload(5)] + mapping_responses
     session = DummySession(responses)
     generator = PlateauGenerator(cast(ConversationSession, session))
     service = ServiceInput(name="svc", customer_type="retail", description="desc")


### PR DESCRIPTION
## Summary
- enrich plateau features via map_feature with data, application and technology contribution lists
- call the new synchronous mapping routine from PlateauGenerator
- adjust tests for updated mapping behaviour

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689494697d2c832ba09fb9ad584caec5