### PR TITLE
feat: generate plateau and service evolution

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import argparse
-import asyncio
 import logging
-from typing import Iterable
 
 import logfire
 from pydantic_ai import Agent
@@ -53,18 +51,6 @@ def _cmd_generate_ambitions(args: argparse.Namespace, settings) -> None:
     logfire.force_flush()
 
 
-async def _evolution_for_service(
-    generator: PlateauGenerator,
-    service: ServiceInput,
-    plateaus: Iterable[str],
-    customers: Iterable[str],
-) -> str:
-    """Return JSON representation of a service's evolution."""
-
-    evolution = await generator.generate_service_evolution(service, plateaus, customers)
-    return evolution.model_dump_json()
-
-
 def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
     """Generate service evolution summaries."""
 
@@ -76,12 +62,8 @@ def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
 
     with open(args.output_file, "w", encoding="utf-8") as output:
         for service in services:
-            payload = asyncio.run(
-                _evolution_for_service(
-                    generator, service, args.plateaus, args.customers
-                )
-            )
-            output.write(f"{payload}\n")
+            evolution = generator.generate_service_evolution(service)
+            output.write(f"{evolution.model_dump_json()}\n")
             logger.info("Generated evolution for %s", service.name)
     logfire.force_flush()
 

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -28,9 +28,7 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
         def __init__(self, model: object) -> None:  # noqa: D401 - no behaviour
             self.model = model
 
-    async def fake_generate(
-        self, service: ServiceInput, plateaus, customers
-    ) -> ServiceEvolution:
+    def fake_generate(self, service: ServiceInput) -> ServiceEvolution:
         return ServiceEvolution(service=service, results=[])
 
     monkeypatch.setattr("cli.build_model", fake_build_model)


### PR DESCRIPTION
## Summary
- expand PlateauGenerator to request plateau descriptions, generate mapped features for learners, staff, and community, and aggregate levels 1–4 into a service evolution
- simplify CLI evolution command to use new PlateauGenerator API
- adjust tests for new plateau generation workflow

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLError: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/ag-ui-protocol/0.1.8/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)')))*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894a77ab630832b8d8dab88ba396678