### PR TITLE
Add explicit mapping and plateau prompt templates

### DIFF
--- a/prompts/mapping_prompt.md
+++ b/prompts/mapping_prompt.md
@@ -1,9 +1,29 @@
-## Feature mapping
+# Feature mapping
 
-Map the feature to relevant {category_label} from the list below. Respond in JSON with a "mappings" key where each item has "item" and "contribution" fields.
+Associate the feature with relevant {category_label} from the list below.
 
-### {category_label}
+## Available {category_label}
 {category_items}
+
+## Instructions
+- Return a JSON object with a "{category_key}" array.
+- Each item in the array must include:
+  - "type": identifier from the list.
+  - "contribution": brief explanation of how it supports the feature.
+- Use only items provided above.
+- Do not include any text outside the JSON object.
 
 Feature name: {feature_name}
 Feature description: {feature_description}
+
+## Expected Output
+```
+{
+  "{category_key}": [
+    {
+      "type": "INF-1",
+      "contribution": "Explanation"
+    }
+  ]
+}
+```

--- a/prompts/plateau_prompt.md
+++ b/prompts/plateau_prompt.md
@@ -1,8 +1,28 @@
-## Plateau feature generation
+# Plateau feature generation
 
-Provide JSON with a "features" key containing at least {required_count} items. Each item must include "feature_id", "name", "description", and a "score" between 0 and 1.
+Generate service features for the {service_name} service at plateau {plateau} for {customer_type} customers.
 
-Service name: {service_name}
-Service description: {service_description}
-Plateau: {plateau}
-Customer type: {customer_type}
+## Instructions
+- Use the service description: {service_description}.
+- Return a valid JSON object.
+- Include a top-level "features" array with at least {required_count} objects.
+- Each feature must provide:
+  - "feature_id": unique string identifier.
+  - "name": short feature title.
+  - "description": explanation of the feature.
+  - "score": floating-point maturity between 0 and 1.
+- Do not include any text outside the JSON object.
+
+## Expected Output
+```
+{
+  "features": [
+    {
+      "feature_id": "feat-001",
+      "name": "Accessible content",
+      "description": "Learners can access materials from any device.",
+      "score": 0.5
+    }
+  ]
+}
+```

--- a/src/loader.py
+++ b/src/loader.py
@@ -42,8 +42,13 @@ def _read_file(path: str) -> str:
 
 
 @logfire.instrument()
-def load_plateau_prompt(base_dir: str, filename: str = "plateau_prompt.md") -> str:
+def load_plateau_prompt(
+    base_dir: str = "prompts", filename: str = "plateau_prompt.md"
+) -> str:
     """Return the plateau feature generation prompt template.
+
+    The template includes detailed instructions and an example of the expected
+    JSON response to guide the agent.
 
     Args:
         base_dir: Directory containing prompt templates.
@@ -61,8 +66,13 @@ def load_plateau_prompt(base_dir: str, filename: str = "plateau_prompt.md") -> s
 
 
 @logfire.instrument()
-def load_mapping_prompt(base_dir: str, filename: str = "mapping_prompt.md") -> str:
+def load_mapping_prompt(
+    base_dir: str = "prompts", filename: str = "mapping_prompt.md"
+) -> str:
     """Return the feature mapping prompt template.
+
+    The template instructs the agent to create category-specific mappings and
+    shows the required JSON structure.
 
     Args:
         base_dir: Directory containing prompt templates.

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -92,6 +92,7 @@ def map_feature(
             feature_description=feature.description,
             category_label=label,
             category_items=_render_items(mapping_items[item_key]),
+            category_key=key,
         )
         logger.debug("Requesting %s mappings for feature %s", key, feature.feature_id)
         response = session.ask(prompt)


### PR DESCRIPTION
## Summary
- add detailed plateau and mapping prompt templates with example JSON outputs
- expose prompt-loading helpers with defaults for these templates
- ensure mapping feature loader passes category key to the prompt

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/ag-ui-protocol/0.1.8/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)')))*

------
https://chatgpt.com/codex/tasks/task_e_6894b0f7d1b0832b93bcaaf79758e202