### PR TITLE
test: expand coverage and add integration scenario

### DIFF
--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -59,3 +59,55 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
 
     payload = json.loads(output_path.read_text().strip())
     assert payload["service"]["name"] == "svc"
+
+
+def test_generate_evolution_uses_agent_model(tmp_path, monkeypatch) -> None:
+    input_path = tmp_path / "services.jsonl"
+    output_path = tmp_path / "out.jsonl"
+    input_path.write_text(
+        json.dumps({"name": "svc", "description": "d", "customer_type": "retail"})
+        + "\n"
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_build_model(model_name: str, api_key: str) -> object:
+        captured["model_name"] = model_name
+        captured["api_key"] = api_key
+        return "model"
+
+    class DummyAgent:
+        def __init__(self, model: object) -> None:  # pragma: no cover - simple init
+            captured["agent_model"] = model
+
+    def fake_generate(self, service: ServiceInput) -> ServiceEvolution:
+        return ServiceEvolution(service=service, results=[])
+
+    monkeypatch.setattr("cli.build_model", fake_build_model)
+    monkeypatch.setattr("cli.Agent", DummyAgent)
+    monkeypatch.setattr(
+        "cli.PlateauGenerator.generate_service_evolution", fake_generate
+    )
+    monkeypatch.setattr("cli.logfire.force_flush", lambda: None)
+
+    settings = SimpleNamespace(
+        model=None,
+        log_level="INFO",
+        openai_api_key="key",
+        logfire_token=None,
+    )
+    args = argparse.Namespace(
+        input_file=str(input_path),
+        output_file=str(output_path),
+        plateaus=["alpha"],
+        customers=["retail"],
+        model="special",  # override default
+        logfire_service=None,
+        log_level=None,
+        verbose=0,
+    )
+
+    _cmd_generate_evolution(args, settings)
+
+    assert captured["model_name"] == "special"
+    assert captured["agent_model"] == "model"

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -50,3 +50,11 @@ def test_ask_adds_responses_to_history() -> None:
 
     assert reply == "pong"
     assert session._history[-1] == "msg"  # noqa: SLF001 - accessing test-only attribute
+
+
+def test_ask_forwards_prompt_to_agent() -> None:
+    """``ask`` should delegate to the underlying agent."""
+    agent = DummyAgent()
+    session = ConversationSession(cast(Agent[None, str], agent))
+    session.ask("hello")
+    assert agent.called_with == ["hello"]

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -44,19 +44,17 @@ def _fake_map_feature(session, feature, prompt_dir):  # pragma: no cover - stub
     )
 
 
-def _feature_payload() -> str:
-    return json.dumps(
+def _feature_payload(count: int) -> str:
+    items = [
         {
-            "features": [
-                {
-                    "feature_id": "f1",
-                    "name": "Feat",
-                    "description": "Desc",
-                    "score": 0.5,
-                }
-            ]
+            "feature_id": f"f{i}",
+            "name": f"Feat {i}",
+            "description": f"Desc {i}",
+            "score": 0.5,
         }
-    )
+        for i in range(count)
+    ]
+    return json.dumps({"features": items})
 
 
 def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
@@ -65,14 +63,21 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
     responses: list[str] = []
     for _ in range(4):
         responses.append(json.dumps({"description": "desc"}))
-        responses.extend([_feature_payload() for _ in range(3)])
+        responses.extend([_feature_payload(5) for _ in range(3)])
     session = DummySession(responses)
-    generator = PlateauGenerator(cast(ConversationSession, session), required_count=1)
+    generator = PlateauGenerator(cast(ConversationSession, session), required_count=5)
 
     monkeypatch.setattr("plateau_generator.map_feature", _fake_map_feature)
+    template = (
+        "{required_count} {service_name} {service_description} "
+        "{plateau} {customer_type}"
+    )
+    monkeypatch.setattr(
+        "plateau_generator.load_plateau_prompt", lambda *a, **k: template
+    )
 
     service = ServiceInput(name="svc", customer_type="retail", description="desc")
     evolution = generator.generate_service_evolution(service)
-
     assert isinstance(evolution, ServiceEvolution)
-    assert len(evolution.results) == 12
+    assert len(evolution.results) == 60
+    assert len(evolution.results) // 4 >= 15

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -36,3 +36,9 @@ def test_plateau_result_validates_score() -> None:
 
     with pytest.raises(ValidationError):
         PlateauResult(feature=feature, score=2.0)
+
+
+def test_contribution_requires_fields() -> None:
+    """Missing fields should trigger a ``ValidationError``."""
+    with pytest.raises(ValidationError):
+        Contribution()  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary
- extend model, conversation, mapping, plateau generator, and CLI tests using dummy agents
- verify integration over four plateaus with at least fifteen features each

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: [SSL: CERTIFICATE_VERIFY_FAILED])* 
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689516abdde8832b8f8918cc8595fb8e