### PR TITLE
refactor: restructure plateau results

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,17 +95,22 @@ Each JSON line in the output file follows the `ServiceEvolution` schema:
     "description": "string",
     "customer_type": "string"
   },
-  "results": [
+  "plateaus": [
     {
-      "feature": {
-        "feature_id": "string",
-        "name": "string",
-        "description": "string"
-      },
-      "score": 0.0,
-      "conceptual_data_types": [{"item": "string", "contribution": "string"}],
-      "logical_application_types": [{"item": "string", "contribution": "string"}],
-      "logical_technology_types": [{"item": "string", "contribution": "string"}]
+      "plateau": 1,
+      "service_description": "string",
+      "features": [
+        {
+          "feature_id": "string",
+          "name": "string",
+          "description": "string",
+          "score": 0.0,
+          "customer_type": "string",
+          "data": [{"item": "string", "contribution": "string"}],
+          "applications": [{"item": "string", "contribution": "string"}],
+          "technology": [{"item": "string", "contribution": "string"}]
+        }
+      ]
     }
   ]
 }
@@ -115,12 +120,15 @@ Fields in the schema:
 
 - `service`: `ServiceInput` with `name`, optional `customer_type`, and
   `description`.
-- `results`: list of `PlateauResult` entries, each containing:
-  - `feature`: `PlateauFeature` with `feature_id`, `name`, and `description`.
-  - `score`: float between `0.0` and `1.0`.
-  - `conceptual_data_types`, `logical_application_types`,
-    `logical_technology_types`: lists of `Contribution` objects describing why a
-    mapped item supports the feature.
+- `plateaus`: list of `PlateauResult` entries, each containing:
+  - `plateau`: integer plateau level.
+  - `service_description`: narrative for the service at that plateau.
+  - `features`: list of `PlateauFeature` entries with:
+    - `feature_id`, `name`, and `description`.
+    - `score`: float between `0.0` and `1.0`.
+    - `customer_type`: audience benefiting from the feature.
+    - `data`, `applications`, `technology`: lists of `Contribution` objects
+      describing why a mapped item supports the feature.
 
 ## Reference Data
 

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -23,17 +23,22 @@ Each line in the output file is a JSON object with:
     "description": "string",
     "customer_type": "string"
   },
-  "results": [
+  "plateaus": [
     {
-      "feature": {
-        "feature_id": "string",
-        "name": "string",
-        "description": "string"
-      },
-      "score": 0.0,
-      "conceptual_data_types": [{"item": "string", "contribution": "string"}],
-      "logical_application_types": [{"item": "string", "contribution": "string"}],
-      "logical_technology_types": [{"item": "string", "contribution": "string"}]
+      "plateau": 1,
+      "service_description": "string",
+      "features": [
+        {
+          "feature_id": "string",
+          "name": "string",
+          "description": "string",
+          "score": 0.0,
+          "customer_type": "string",
+          "data": [{"item": "string", "contribution": "string"}],
+          "applications": [{"item": "string", "contribution": "string"}],
+          "technology": [{"item": "string", "contribution": "string"}]
+        }
+      ]
     }
   ]
 }

--- a/prompts/mapping_prompt.md
+++ b/prompts/mapping_prompt.md
@@ -8,7 +8,7 @@ Associate the feature with relevant {category_label} from the list below.
 ## Instructions
 - Return a JSON object with a "{category_key}" array.
 - Each item in the array must include:
-  - "type": identifier from the list.
+  - "item": identifier from the list.
   - "contribution": brief explanation of how it supports the feature.
 - Use only items provided above.
 - Do not include any text outside the JSON object.
@@ -21,7 +21,7 @@ Feature description: {feature_description}
 {
   "{category_key}": [
     {
-      "type": "INF-1",
+      "item": "INF-1",
       "contribution": "Explanation"
     }
   ]

--- a/src/models.py
+++ b/src/models.py
@@ -30,35 +30,44 @@ class PlateauFeature(BaseModel):
     feature_id: str = Field(..., description="Unique identifier for the feature.")
     name: str = Field(..., description="Feature name.")
     description: str = Field(..., description="Explanation of the feature.")
-
-
-class PlateauResult(BaseModel):
-    """Result of evaluating a particular plateau feature."""
-
-    feature: PlateauFeature = Field(..., description="The assessed feature.")
     score: float = Field(
         ..., ge=0.0, le=1.0, description="Normalised performance score between 0 and 1."
     )
-    conceptual_data_types: list[Contribution] = Field(
+    customer_type: str = Field(
+        ..., description="Audience that benefits from the feature."
+    )
+    data: list[Contribution] = Field(
         default_factory=list,
         description="Conceptual data types related to the feature.",
     )
-    logical_application_types: list[Contribution] = Field(
-        default_factory=list,
-        description="Logical application types relevant to the feature.",
+    applications: list[Contribution] = Field(
+        default_factory=list, description="Applications relevant to the feature."
     )
-    logical_technology_types: list[Contribution] = Field(
+    technology: list[Contribution] = Field(
         default_factory=list,
-        description="Logical technology types supporting the feature.",
+        description="Supporting technologies for the feature.",
+    )
+
+
+class PlateauResult(BaseModel):
+    """Collection of features describing a service at a plateau level."""
+
+    plateau: int = Field(..., ge=1, description="Plateau level evaluated.")
+    service_description: str = Field(
+        ..., description="Description of the service at this plateau."
+    )
+    features: list[PlateauFeature] = Field(
+        default_factory=list,
+        description="Features identified for this plateau level.",
     )
 
 
 class ServiceEvolution(BaseModel):
-    """Summary of a service's progress across plateau features."""
+    """Summary of a service's progress across plateaus."""
 
     service: ServiceInput = Field(..., description="Service being evaluated.")
-    results: list[PlateauResult] = Field(
-        default_factory=list, description="Outcomes for evaluated plateau features."
+    plateaus: list[PlateauResult] = Field(
+        default_factory=list, description="Evaluated plateaus for the service."
     )
 
 

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -29,7 +29,7 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
             self.model = model
 
     def fake_generate(self, service: ServiceInput) -> ServiceEvolution:
-        return ServiceEvolution(service=service, results=[])
+        return ServiceEvolution(service=service, plateaus=[])
 
     monkeypatch.setattr("cli.build_model", fake_build_model)
     monkeypatch.setattr("cli.Agent", DummyAgent)
@@ -81,7 +81,7 @@ def test_generate_evolution_uses_agent_model(tmp_path, monkeypatch) -> None:
             captured["agent_model"] = model
 
     def fake_generate(self, service: ServiceInput) -> ServiceEvolution:
-        return ServiceEvolution(service=service, results=[])
+        return ServiceEvolution(service=service, plateaus=[])
 
     monkeypatch.setattr("cli.build_model", fake_build_model)
     monkeypatch.setattr("cli.Agent", DummyAgent)

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -9,13 +9,15 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from conversation import (
     ConversationSession,
 )  # noqa: E402  pylint: disable=wrong-import-position
-from models import (
+from models import (  # noqa: E402  pylint: disable=wrong-import-position
+    Contribution,
+    PlateauFeature,
     ServiceEvolution,
     ServiceInput,
-)  # noqa: E402  pylint: disable=wrong-import-position
-from plateau_generator import (
+)
+from plateau_generator import (  # noqa: E402  pylint: disable=wrong-import-position
     PlateauGenerator,
-)  # noqa: E402  pylint: disable=wrong-import-position
+)
 
 
 class DummySession:
@@ -34,14 +36,13 @@ class DummySession:
 
 
 def _fake_map_feature(session, feature, prompt_dir):  # pragma: no cover - stub
-    from mapping import MappedPlateauFeature, TypeContribution
-
-    return MappedPlateauFeature(
-        **feature.model_dump(),
-        data=[TypeContribution(type="d", contribution="c")],
-        applications=[TypeContribution(type="a", contribution="c")],
-        technology=[TypeContribution(type="t", contribution="c")],
+    payload = feature.model_dump()
+    payload.update(
+        data=[Contribution(item="d", contribution="c")],
+        applications=[Contribution(item="a", contribution="c")],
+        technology=[Contribution(item="t", contribution="c")],
     )
+    return PlateauFeature(**payload)
 
 
 def _feature_payload(count: int) -> str:
@@ -79,5 +80,6 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
     service = ServiceInput(name="svc", customer_type="retail", description="desc")
     evolution = generator.generate_service_evolution(service)
     assert isinstance(evolution, ServiceEvolution)
-    assert len(evolution.results) == 60
-    assert len(evolution.results) // 4 >= 15
+    assert len(evolution.plateaus) == 4
+    assert sum(len(p.features) for p in evolution.plateaus) == 60
+    assert all(len(p.features) >= 15 for p in evolution.plateaus)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,26 +16,35 @@ from models import (  # noqa: E402  pylint: disable=wrong-import-position
 )
 
 
-def test_service_evolution_contains_results() -> None:
+def test_service_evolution_contains_plateaus() -> None:
     """Constructing a ServiceEvolution should retain nested models."""
 
     service = ServiceInput(name="svc", customer_type="retail", description="desc")
-    feature = PlateauFeature(feature_id="f1", name="Feat", description="D")
-    contrib = Contribution(item="data", contribution="used")
-    result = PlateauResult(feature=feature, score=0.75, conceptual_data_types=[contrib])
+    feature = PlateauFeature(
+        feature_id="f1",
+        name="Feat",
+        description="D",
+        score=0.75,
+        customer_type="learners",
+    )
+    plateau = PlateauResult(plateau=1, service_description="desc", features=[feature])
 
-    evolution = ServiceEvolution(service=service, results=[result])
+    evolution = ServiceEvolution(service=service, plateaus=[plateau])
 
-    assert evolution.results[0].feature.name == "Feat"
+    assert evolution.plateaus[0].features[0].name == "Feat"
 
 
-def test_plateau_result_validates_score() -> None:
+def test_plateau_feature_validates_score() -> None:
     """Scores must lie within the inclusive range [0, 1]."""
 
-    feature = PlateauFeature(feature_id="f1", name="Feat", description="D")
-
     with pytest.raises(ValidationError):
-        PlateauResult(feature=feature, score=2.0)
+        PlateauFeature(
+            feature_id="f1",
+            name="Feat",
+            description="D",
+            score=2.0,
+            customer_type="learners",
+        )
 
 
 def test_contribution_requires_fields() -> None:

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -11,7 +11,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from conversation import (
     ConversationSession,
 )  # noqa: E402  pylint: disable=wrong-import-position
-from models import ServiceInput  # noqa: E402  pylint: disable=wrong-import-position
+from models import (
+    PlateauResult,
+    ServiceInput,
+)  # noqa: E402  pylint: disable=wrong-import-position
 from plateau_generator import (
     PlateauGenerator,
 )  # noqa: E402  pylint: disable=wrong-import-position
@@ -58,9 +61,9 @@ def test_generate_plateau_returns_results(monkeypatch) -> None:
         responses.append(_feature_payload(1))
         responses.extend(
             [
-                json.dumps({"data": [{"type": "d", "contribution": "c"}]}),
-                json.dumps({"applications": [{"type": "a", "contribution": "c"}]}),
-                json.dumps({"technology": [{"type": "t", "contribution": "c"}]}),
+                json.dumps({"data": [{"item": "d", "contribution": "c"}]}),
+                json.dumps({"applications": [{"item": "a", "contribution": "c"}]}),
+                json.dumps({"technology": [{"item": "t", "contribution": "c"}]}),
             ]
         )
     session = DummySession(responses)
@@ -68,9 +71,10 @@ def test_generate_plateau_returns_results(monkeypatch) -> None:
     service = ServiceInput(name="svc", customer_type="retail", description="desc")
     generator._service = service  # type: ignore[attr-defined]
 
-    results = generator.generate_plateau(cast(ConversationSession, session), 1)
+    plateau = generator.generate_plateau(cast(ConversationSession, session), 1)
 
-    assert len(results) == 3
+    assert isinstance(plateau, PlateauResult)
+    assert len(plateau.features) == 3
 
 
 def test_generate_plateau_raises_on_insufficient_features(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- restructure plateau data model and include mappings
- expose evaluated plateaus in service evolution
- document new plateau and feature schema

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68952220f664832b88b5c6d2625905f6