### PR TITLE
Batch map plateau features

### DIFF
--- a/src/mapping.py
+++ b/src/mapping.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Sequence
 
 from loader import load_mapping_items, load_mapping_prompt
 from models import Contribution, PlateauFeature
@@ -20,6 +20,14 @@ def _render_items(items: list[dict[str, str]]) -> str:
 
     return "\n".join(
         f"- {entry['id']}: {entry['name']} - {entry['description']}" for entry in items
+    )
+
+
+def _render_features(features: Sequence[PlateauFeature]) -> str:
+    """Return a bullet list of feature details for prompt construction."""
+
+    return "\n".join(
+        f"- {feat.feature_id}: {feat.name} - {feat.description}" for feat in features
     )
 
 
@@ -86,4 +94,78 @@ def map_feature(
     return PlateauFeature(**merged)
 
 
-__all__ = ["map_feature"]
+def map_features(
+    session: ConversationSession, features: Sequence[PlateauFeature]
+) -> list[PlateauFeature]:
+    """Return ``features`` augmented with data, application and technology mappings.
+
+    The function sends a single prompt containing all features and mapping
+    reference lists. The agent must respond with JSON containing a ``features``
+    array. Each feature in the array must provide non-empty ``data``,
+    ``applications`` and ``technology`` lists. A :class:`ValueError` is raised
+    if the response cannot be parsed, a feature is missing or any list is
+    empty.
+
+    Args:
+        session: Active conversation session used to query the agent.
+        features: Plateau features to map.
+
+    Returns:
+        List of :class:`PlateauFeature` objects with mapping information applied.
+
+    Raises:
+        ValueError: If the agent response is invalid or any mapping list is
+        missing.
+    """
+
+    mapping_items = load_mapping_items()
+    prompt = (
+        "Map each feature to relevant Data, Applications and Technologies from"
+        " the lists below.\n\n"
+        "## Available Data\n"
+        f"{_render_items(mapping_items['information'])}\n\n"
+        "## Available Applications\n"
+        f"{_render_items(mapping_items['applications'])}\n\n"
+        "## Available Technologies\n"
+        f"{_render_items(mapping_items['technologies'])}\n\n"
+        "## Features\n"
+        f"{_render_features(features)}\n\n"
+        "Return JSON with a 'features' array. Each element must include\n"
+        "'feature_id', 'data', 'applications' and 'technology' arrays. Each\n"
+        "array must contain at least one object with 'item' and 'contribution'.\n"
+        "Use only items from the provided lists. Do not include any text"
+        " outside the JSON object."
+    )
+    logger.debug("Requesting mappings for %s features", len(features))
+    response = session.ask(prompt)
+    logger.debug("Raw multi-feature mapping response: %s", response)
+    try:
+        payload: dict[str, Any] = json.loads(response)
+    except json.JSONDecodeError as exc:  # pragma: no cover - logging
+        logger.error("Invalid JSON from mapping response: %s", exc)
+        raise ValueError("Agent returned invalid JSON") from exc
+
+    raw_features = payload.get("features")
+    if not isinstance(raw_features, list):
+        raise ValueError("'features' key missing or invalid")
+    mapped_lookup = {item.get("feature_id"): item for item in raw_features}
+
+    results: list[PlateauFeature] = []
+    for feature in features:
+        data = mapped_lookup.get(feature.feature_id)
+        if not isinstance(data, dict):
+            raise ValueError(f"Missing mappings for feature {feature.feature_id}")
+        mapped: dict[str, list[Contribution]] = {}
+        for key in ("data", "applications", "technology"):
+            raw_list = data.get(key)
+            if not isinstance(raw_list, list) or not raw_list:
+                raise ValueError(
+                    f"'{key}' key missing or empty for feature {feature.feature_id}"
+                )
+            mapped[key] = [Contribution(**item) for item in raw_list]
+        merged = {**feature.model_dump(), **mapped}
+        results.append(PlateauFeature(**merged))
+    return results
+
+
+__all__ = ["map_feature", "map_features"]

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -7,7 +7,7 @@ import logging
 
 from conversation import ConversationSession
 from loader import load_plateau_prompt
-from mapping import map_feature
+from mapping import map_features
 from models import PlateauFeature, PlateauResult, ServiceEvolution, ServiceInput
 
 logger = logging.getLogger(__name__)
@@ -64,8 +64,8 @@ class PlateauGenerator:
         The function requests a plateau-specific service description, then
         issues a single prompt asking for features for learners, staff and
         community. The response must provide at least ``required_count``
-        features for each customer type. Each feature is enriched using
-        :func:`map_feature` before being returned as part of a
+        features for each customer type. The list of features is enriched using
+        :func:`map_features` before being returned as part of a
         :class:`PlateauResult`.
         """
         if self._service is None:
@@ -100,17 +100,18 @@ class PlateauGenerator:
                     f"Insufficient number of features returned for {customer}"
                 )
             for item in raw_features:
-                feature = PlateauFeature(
-                    feature_id=item["feature_id"],
-                    name=item["name"],
-                    description=item["description"],
-                    score=float(item["score"]),
-                    customer_type=customer,
+                features.append(
+                    PlateauFeature(
+                        feature_id=item["feature_id"],
+                        name=item["name"],
+                        description=item["description"],
+                        score=float(item["score"]),
+                        customer_type=customer,
+                    )
                 )
-                mapped = map_feature(session, feature, self.prompt_dir)
-                features.append(mapped)
+        mapped = map_features(session, features)
         return PlateauResult(
-            plateau=level, service_description=description, features=features
+            plateau=level, service_description=description, features=mapped
         )
 
     def generate_service_evolution(

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
-from mapping import map_feature
+from mapping import map_feature, map_features
 from models import PlateauFeature
 
 
@@ -111,3 +111,81 @@ def test_map_feature_rejects_invalid_json(monkeypatch) -> None:
     )
     with pytest.raises(ValueError):
         map_feature(session, feature)  # type: ignore[arg-type]
+
+
+def test_map_features_returns_mappings(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "mapping.load_mapping_items",
+        lambda *a, **k: {
+            "information": [{"id": "INF-1", "name": "User Data", "description": "d"}],
+            "applications": [{"id": "APP-1", "name": "App", "description": "d"}],
+            "technologies": [{"id": "TEC-1", "name": "Tech", "description": "d"}],
+        },
+    )
+
+    session = DummySession(
+        [
+            json.dumps(
+                {
+                    "features": [
+                        {
+                            "feature_id": "f1",
+                            "data": [{"item": "INF-1", "contribution": "c"}],
+                            "applications": [{"item": "APP-1", "contribution": "c"}],
+                            "technology": [{"item": "TEC-1", "contribution": "c"}],
+                        }
+                    ]
+                }
+            )
+        ]
+    )
+    feature = PlateauFeature(
+        feature_id="f1",
+        name="Integration",
+        description="Allows external access",
+        score=0.5,
+        customer_type="learners",
+    )
+
+    result = map_features(session, [feature])  # type: ignore[arg-type]
+
+    assert result[0].data[0].item == "INF-1"
+    assert "User Data" in session.prompts[0]
+
+
+def test_map_features_validates_lists(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "mapping.load_mapping_items",
+        lambda *a, **k: {
+            "information": [{"id": "INF-1", "name": "User Data", "description": "d"}],
+            "applications": [{"id": "APP-1", "name": "App", "description": "d"}],
+            "technologies": [{"id": "TEC-1", "name": "Tech", "description": "d"}],
+        },
+    )
+
+    session = DummySession(
+        [
+            json.dumps(
+                {
+                    "features": [
+                        {
+                            "feature_id": "f1",
+                            "data": [],
+                            "applications": [],
+                            "technology": [],
+                        }
+                    ]
+                }
+            )
+        ]
+    )
+    feature = PlateauFeature(
+        feature_id="f1",
+        name="Integration",
+        description="Allows external access",
+        score=0.5,
+        customer_type="learners",
+    )
+
+    with pytest.raises(ValueError):
+        map_features(session, [feature])  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- add `map_features` to request all feature mappings in a single prompt and validate populated data
- call `map_features` once per plateau instead of mapping per feature
- expand tests for batch mapping and plateau generation

## Testing
- `black .`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "logfire")*
- `bandit -r src -ll`
- `pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/ag-ui-protocol/0.1.8/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)')))*
- `pytest tests/test_mapping.py tests/test_plateau_generator.py` *(fails: ModuleNotFoundError: No module named 'logfire')*

------
https://chatgpt.com/codex/tasks/task_e_689529f5483c832bb51a0be823033a8e