### PR TITLE
feat: support multi-feature mapping prompts

### DIFF
--- a/prompts/mapping_prompt.md
+++ b/prompts/mapping_prompt.md
@@ -1,28 +1,41 @@
 # Feature mapping
 
-Associate the feature with relevant {category_label} from the list below.
+Map each feature to relevant Data, Applications and Technologies from the lists below.
 
-## Available {category_label}
-{category_items}
+## Available Data
+{data_items}
+
+## Available Applications
+{application_items}
+
+## Available Technologies
+{technology_items}
+
+## Features
+{features}
 
 ## Instructions
-- Return a JSON object with a "{category_key}" array.
-- Each item in the array must include:
-  - "item": identifier from the list.
-  - "contribution": brief explanation of how it supports the feature.
-- Use only items provided above.
+- Return a JSON object with a top-level "features" array.
+- Each element must include "feature_id", "data", "applications" and "technology" arrays.
+- Items in these arrays must provide "item" and "contribution" fields.
+- Use only identifiers from the provided lists.
 - Do not include any text outside the JSON object.
-
-Feature name: {feature_name}
-Feature description: {feature_description}
 
 ## Expected Output
 ```
 {
-  "{category_key}": [
+  "features": [
     {
-      "item": "INF-1",
-      "contribution": "Explanation"
+      "feature_id": "feat-001",
+      "data": [
+        {"item": "INF-1", "contribution": "Explanation"}
+      ],
+      "applications": [
+        {"item": "APP-1", "contribution": "Explanation"}
+      ],
+      "technology": [
+        {"item": "TEC-1", "contribution": "Explanation"}
+      ]
     }
   ]
 }

--- a/prompts/plateau_prompt.md
+++ b/prompts/plateau_prompt.md
@@ -1,12 +1,12 @@
 # Plateau feature generation
 
-Generate service features for the {service_name} service at plateau {plateau} for {customer_type} customers.
+Generate service features for the {service_name} service at plateau {plateau}.
 
 ## Instructions
 - Use the service description: {service_description}.
-- Return a valid JSON object.
-- Include a top-level "features" array with at least {required_count} objects.
-- Each feature must provide:
+- Return a single JSON object with three keys: "learners", "staff" and "community".
+- Each key must map to an array containing at least {required_count} feature objects.
+- Every feature must provide:
   - "feature_id": unique string identifier.
   - "name": short feature title.
   - "description": explanation of the feature.
@@ -16,11 +16,27 @@ Generate service features for the {service_name} service at plateau {plateau} fo
 ## Expected Output
 ```
 {
-  "features": [
+  "learners": [
     {
-      "feature_id": "feat-001",
+      "feature_id": "learn-001",
       "name": "Accessible content",
       "description": "Learners can access materials from any device.",
+      "score": 0.5
+    }
+  ],
+  "staff": [
+    {
+      "feature_id": "staff-001",
+      "name": "Training dashboard",
+      "description": "Staff can track learner progress.",
+      "score": 0.5
+    }
+  ],
+  "community": [
+    {
+      "feature_id": "community-001",
+      "name": "Public resources",
+      "description": "Open materials for the wider community.",
       "score": 0.5
     }
   ]

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -35,14 +35,17 @@ class DummySession:
         pass
 
 
-def _fake_map_feature(session, feature, prompt_dir):  # pragma: no cover - stub
-    payload = feature.model_dump()
-    payload.update(
-        data=[Contribution(item="d", contribution="c")],
-        applications=[Contribution(item="a", contribution="c")],
-        technology=[Contribution(item="t", contribution="c")],
-    )
-    return PlateauFeature(**payload)
+def _fake_map_features(session, features, prompt_dir="prompts"):  # pragma: no cover - stub
+    results = []
+    for feature in features:
+        payload = feature.model_dump()
+        payload.update(
+            data=[Contribution(item="d", contribution="c")],
+            applications=[Contribution(item="a", contribution="c")],
+            technology=[Contribution(item="t", contribution="c")],
+        )
+        results.append(PlateauFeature(**payload))
+    return results
 
 
 def _feature_payload(count: int) -> str:
@@ -69,7 +72,7 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
     session = DummySession(responses)
     generator = PlateauGenerator(cast(ConversationSession, session), required_count=5)
 
-    monkeypatch.setattr("plateau_generator.map_feature", _fake_map_feature)
+    monkeypatch.setattr("plateau_generator.map_features", _fake_map_features)
     template = "{required_count} {service_name} {service_description} {plateau}"
     monkeypatch.setattr(
         "plateau_generator.load_plateau_prompt", lambda *a, **k: template


### PR DESCRIPTION
## Summary
- expand plateau prompt to request separate feature sets for learners, staff and community
- replace mapping prompt with multi-feature template and update mapping logic
- adjust tests for new mapping workflow

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLError: CERTIFICATE_VERIFY_FAILED)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68952c660294832b88a43baef22cfc10