### PR TITLE
Reset conversation session per service

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -56,12 +56,13 @@ def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
 
     model_name = args.model or settings.model
     model = build_model(model_name, settings.openai_api_key)
-    session = ConversationSession(Agent(model))
-    generator = PlateauGenerator(session)
+    agent = Agent(model)
 
     with open(args.output_file, "w", encoding="utf-8") as output:
         for raw in load_services(args.input_file):
             service = ServiceInput(**raw)
+            session = ConversationSession(agent)
+            generator = PlateauGenerator(session)
             evolution = generator.generate_service_evolution(service)
             output.write(f"{evolution.model_dump_json()}\n")
             logger.info("Generated evolution for %s", service.name)

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -35,7 +35,9 @@ class DummySession:
         pass
 
 
-def _fake_map_features(session, features, prompt_dir="prompts"):  # pragma: no cover - stub
+def _fake_map_features(
+    session, features, prompt_dir="prompts"
+):  # pragma: no cover - stub
     results = []
     for feature in features:
         payload = feature.model_dump()


### PR DESCRIPTION
## Summary
- Instantiate a fresh conversation session for each service to ensure history is scoped per service while generating plateau evolutions.
- Reformat integration test helper for lint compliance.

## Testing
- `black src/cli.py tests/test_integration_service_evolution.py`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stubs for several modules)*
- `bandit -r src -ll`
- `pip-audit` *(fails: certificate verify failed: Missing Authority Key Identifier)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'logfire')*

------
https://chatgpt.com/codex/tasks/task_e_68952edd9c00832ba7e00e2caa128cb5