### PR TITLE
feat: add plateau and customer filtering

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -63,7 +63,9 @@ def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
             service = ServiceInput(**raw)
             session = ConversationSession(agent)
             generator = PlateauGenerator(session)
-            evolution = generator.generate_service_evolution(service)
+            evolution = generator.generate_service_evolution(
+                service, args.plateaus, args.customers
+            )
             output.write(f"{evolution.model_dump_json()}\n")
             logger.info("Generated evolution for %s", service.name)
     logfire.force_flush()

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -115,15 +115,37 @@ class PlateauGenerator:
         )
 
     def generate_service_evolution(
-        self, service_input: ServiceInput
+        self,
+        service_input: ServiceInput,
+        plateau_names: list[str],
+        customer_types: list[str],
     ) -> ServiceEvolution:
-        """Return aggregated service evolution across plateaus 1-4."""
+        """Return service evolution for selected plateaus and customers.
+
+        Args:
+            service_input: Service under evaluation.
+            plateau_names: Ordered plateau identifiers to process.
+            customer_types: Customer segments to include in results.
+
+        Returns:
+            Combined evolution limited to the requested plateaus and customers.
+        """
         self._service = service_input
         self.session.add_parent_materials(service_input)
 
         plateaus: list[PlateauResult] = []
-        for level in range(1, 5):
-            plateaus.append(self.generate_plateau(self.session, level))
+        for level, _name in enumerate(plateau_names, start=1):
+            result = self.generate_plateau(self.session, level)
+            filtered = [
+                feat for feat in result.features if feat.customer_type in customer_types
+            ]
+            plateaus.append(
+                PlateauResult(
+                    plateau=result.plateau,
+                    service_description=result.service_description,
+                    features=filtered,
+                )
+            )
         return ServiceEvolution(service=service_input, plateaus=plateaus)
 
 

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -28,7 +28,16 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
         def __init__(self, model: object) -> None:  # noqa: D401 - no behaviour
             self.model = model
 
-    def fake_generate(self, service: ServiceInput) -> ServiceEvolution:
+    captured: dict[str, list[str]] = {}
+
+    def fake_generate(
+        self,
+        service: ServiceInput,
+        plateaus: list[str],
+        customers: list[str],
+    ) -> ServiceEvolution:
+        captured["plateaus"] = plateaus
+        captured["customers"] = customers
         return ServiceEvolution(service=service, plateaus=[])
 
     monkeypatch.setattr("cli.build_model", fake_build_model)
@@ -59,6 +68,8 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
 
     payload = json.loads(output_path.read_text().strip())
     assert payload["service"]["name"] == "svc"
+    assert captured["plateaus"] == ["alpha"]
+    assert captured["customers"] == ["retail"]
 
 
 def test_generate_evolution_uses_agent_model(tmp_path, monkeypatch) -> None:
@@ -80,7 +91,12 @@ def test_generate_evolution_uses_agent_model(tmp_path, monkeypatch) -> None:
         def __init__(self, model: object) -> None:  # pragma: no cover - simple init
             captured["agent_model"] = model
 
-    def fake_generate(self, service: ServiceInput) -> ServiceEvolution:
+    def fake_generate(
+        self,
+        service: ServiceInput,
+        plateaus: list[str],
+        customers: list[str],
+    ) -> ServiceEvolution:
         return ServiceEvolution(service=service, plateaus=[])
 
     monkeypatch.setattr("cli.build_model", fake_build_model)

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -83,7 +83,11 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
     )
 
     service = ServiceInput(name="svc", customer_type="retail", description="desc")
-    evolution = generator.generate_service_evolution(service)
+    evolution = generator.generate_service_evolution(
+        service,
+        ["Foundational", "Enhanced", "Experimental", "Disruptive"],
+        ["learners", "staff", "community"],
+    )
     assert isinstance(evolution, ServiceEvolution)
     assert len(evolution.plateaus) == 4
     assert sum(len(p.features) for p in evolution.plateaus) == 60

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -13,6 +13,7 @@ from conversation import (
 )  # noqa: E402  pylint: disable=wrong-import-position
 from models import (
     Contribution,
+    PlateauFeature,
     PlateauResult,
     ServiceInput,
 )  # noqa: E402  pylint: disable=wrong-import-position
@@ -31,6 +32,11 @@ class DummySession:
     def ask(self, prompt: str) -> str:  # pragma: no cover - simple proxy
         self.prompts.append(prompt)
         return self._responses.pop(0)
+
+    def add_parent_materials(
+        self, service_input: ServiceInput
+    ) -> None:  # pragma: no cover - simple stub
+        pass
 
 
 def _feature_payload(count: int) -> str:
@@ -104,3 +110,53 @@ def test_request_description_invalid_json(monkeypatch) -> None:
     generator = PlateauGenerator(cast(ConversationSession, session), required_count=1)
     with pytest.raises(ValueError):
         generator._request_description(cast(ConversationSession, session), 1)
+
+
+def test_generate_service_evolution_filters(monkeypatch) -> None:
+    service = ServiceInput(name="svc", customer_type="retail", description="d")
+    session = DummySession([])
+    generator = PlateauGenerator(cast(ConversationSession, session))
+
+    called: list[int] = []
+
+    def fake_generate_plateau(self, sess, level):
+        called.append(level)
+        feats = [
+            PlateauFeature(
+                feature_id=f"l{level}",
+                name="L",
+                description="d",
+                score=0.5,
+                customer_type="learners",
+            ),
+            PlateauFeature(
+                feature_id=f"s{level}",
+                name="S",
+                description="d",
+                score=0.5,
+                customer_type="staff",
+            ),
+            PlateauFeature(
+                feature_id=f"c{level}",
+                name="C",
+                description="d",
+                score=0.5,
+                customer_type="community",
+            ),
+        ]
+        return PlateauResult(plateau=level, service_description="d", features=feats)
+
+    monkeypatch.setattr(
+        PlateauGenerator, "generate_plateau", fake_generate_plateau, raising=False
+    )
+
+    evo = generator.generate_service_evolution(
+        service,
+        ["Foundational", "Enhanced"],
+        ["learners", "staff"],
+    )
+
+    assert called == [1, 2]
+    assert len(evo.plateaus) == 2
+    for plat in evo.plateaus:
+        assert {f.customer_type for f in plat.features} <= {"learners", "staff"}


### PR DESCRIPTION
## Summary
- allow CLI to forward plateau and customer filters
- support selective plateau and customer generation
- test CLI and generator filtering behavior

## Testing
- `python -m black tests/test_plateau_generator.py tests/test_cli_generate_evolution.py src/cli.py src/plateau_generator.py tests/test_integration_service_evolution.py`
- `ruff check .`
- `mypy tests/test_plateau_generator.py tests/test_cli_generate_evolution.py tests/test_integration_service_evolution.py src/cli.py src/plateau_generator.py`
- `bandit -r src -ll`
- `pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/ag-ui-protocol/0.1.8/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)'))))*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895425dc688832b94dc14af47453ac5