### PR TITLE
feat: externalize description prompt

### DIFF
--- a/prompts/description_prompt.md
+++ b/prompts/description_prompt.md
@@ -1,0 +1,15 @@
+# Service description generation
+
+Provide a description of the service at plateau {plateau}.
+
+## Instructions
+- Return a JSON object containing only a `description` field.
+- `description` must be a non-empty string explaining the service at plateau {plateau}.
+- Do not include any text outside the JSON object.
+
+## Expected Output
+```
+{{
+  "description": "Brief description here."
+}}
+```

--- a/src/loader.py
+++ b/src/loader.py
@@ -66,6 +66,27 @@ def load_plateau_prompt(
 
 
 @logfire.instrument()
+def load_description_prompt(
+    base_dir: str = "prompts", filename: str = "description_prompt.md"
+) -> str:
+    """Return the service description prompt template.
+
+    Args:
+        base_dir: Directory containing prompt templates.
+        filename: Description prompt file name.
+
+    Returns:
+        Prompt template text.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        RuntimeError: If the file cannot be read.
+    """
+
+    return _read_file(os.path.join(base_dir, filename))
+
+
+@logfire.instrument()
 def load_mapping_prompt(
     base_dir: str = "prompts", filename: str = "mapping_prompt.md"
 ) -> str:

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -6,7 +6,7 @@ import json
 import logging
 
 from conversation import ConversationSession
-from loader import load_plateau_prompt
+from loader import load_description_prompt, load_plateau_prompt
 from mapping import map_features
 from models import PlateauFeature, PlateauResult, ServiceEvolution, ServiceInput
 
@@ -41,10 +41,8 @@ class PlateauGenerator:
 
         The agent must respond with JSON containing a ``description`` field.
         """
-        prompt = (
-            "Provide JSON with a 'description' field describing the service "
-            f"at plateau level {level}."
-        )
+        template = load_description_prompt(self.prompt_dir)
+        prompt = template.format(plateau=level)
         response = session.ask(prompt)
         try:
             payload = json.loads(response)

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -5,6 +5,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from loader import (
+    load_description_prompt,
     load_mapping_prompt,
     load_plateau_prompt,
     load_prompt,
@@ -45,6 +46,13 @@ def test_load_mapping_prompt(tmp_path):
     base.mkdir()
     (base / "mapping_prompt.md").write_text("map", encoding="utf-8")
     assert load_mapping_prompt(str(base)) == "map"
+
+
+def test_load_description_prompt(tmp_path):
+    base = tmp_path / "prompts"
+    base.mkdir()
+    (base / "description_prompt.md").write_text("desc", encoding="utf-8")
+    assert load_description_prompt(str(base)) == "desc"
 
 
 def test_load_services_reads_jsonl(tmp_path):

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -58,6 +58,9 @@ def test_generate_plateau_returns_results(monkeypatch) -> None:
     monkeypatch.setattr(
         "plateau_generator.load_plateau_prompt", lambda *a, **k: template
     )
+    monkeypatch.setattr(
+        "plateau_generator.load_description_prompt", lambda *a, **k: "desc {plateau}"
+    )
     responses = [json.dumps({"description": "desc"}), _feature_payload(1)]
     session = DummySession(responses)
 
@@ -90,6 +93,9 @@ def test_generate_plateau_raises_on_insufficient_features(monkeypatch) -> None:
     monkeypatch.setattr(
         "plateau_generator.load_plateau_prompt", lambda *a, **k: template
     )
+    monkeypatch.setattr(
+        "plateau_generator.load_description_prompt", lambda *a, **k: "desc {plateau}"
+    )
     responses = [json.dumps({"description": "desc"}), _feature_payload(1)]
     session = DummySession(responses)
     generator = PlateauGenerator(cast(ConversationSession, session), required_count=2)
@@ -105,11 +111,15 @@ def test_request_description_invalid_json(monkeypatch) -> None:
     monkeypatch.setattr(
         "plateau_generator.load_plateau_prompt", lambda *a, **k: template
     )
+    monkeypatch.setattr(
+        "plateau_generator.load_description_prompt", lambda *a, **k: "desc {plateau}"
+    )
     """Invalid description payloads should raise ``ValueError``."""
     session = DummySession(["not json"])
     generator = PlateauGenerator(cast(ConversationSession, session), required_count=1)
     with pytest.raises(ValueError):
         generator._request_description(cast(ConversationSession, session), 1)
+    assert session.prompts == ["desc 1"]
 
 
 def test_generate_service_evolution_filters(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add `description_prompt.md` describing required JSON with a `description` field
- load description prompt from new template instead of inline string
- test description prompt loading and usage

## Testing
- `black .`
- `ruff check .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` (fails: SSLCertVerificationError)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689544571f20832b8607f48437d872fd