### PR TITLE
Add service input details and model call checks in tests

### DIFF
--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -137,7 +137,13 @@ def test_request_description_invalid_json(monkeypatch) -> None:
 
 
 def test_generate_service_evolution_filters(monkeypatch) -> None:
-    service = ServiceInput(name="svc", customer_type="retail", description="d")
+    service = ServiceInput(
+        service_id="svc-1",
+        name="svc",
+        customer_type="retail",
+        description="d",
+        jobs_to_be_done=["job"],
+    )
     session = DummySession([])
     generator = PlateauGenerator(cast(ConversationSession, session))
 


### PR DESCRIPTION
## Summary
- include `service_id` and `jobs_to_be_done` when constructing `ServiceInput` in integration and plateau generator tests
- track feature-mapping invocations and assert 12 total model calls across four plateaus
- import `json` explicitly in integration test

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 .` *(fails: Command not found: flake8)*
- `poetry run mypy .` *(fails: Cannot find implementation or library stub for module named "pydantic"; Cannot find implementation or library stub for module named "pydantic_settings"; Cannot find implementation or library stub for module named "logfire"; Cannot find implementation or library stub for module named "pydantic_ai"; Missing module imports)*
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `poetry run pytest tests/test_integration_service_evolution.py::test_service_evolution_across_four_plateaus tests/test_plateau_generator.py::test_generate_service_evolution_filters -q` *(fails: ModuleNotFoundError: No module named 'conversation')*


------
https://chatgpt.com/codex/tasks/task_e_68955808f9e8832bb512c8ac845d3d8e