### PR TITLE
Update evolution CLI defaults for plateaus and customers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ sequential calls:
 The 4 × 3 workflow totals 12 calls and produces a complete `ServiceEvolution`
 record for every service.
 
+Plateau names and descriptions are sourced from
+`data/service_feature_plateaus.json`, allowing the progression to be
+reconfigured without code changes. By default the CLI uses the first four
+entries from this file.
+
 ### Generating service evolutions
 
 Use the `generate-evolution` subcommand to score each service against plateau

--- a/data/service_feature_plateaus.json
+++ b/data/service_feature_plateaus.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "PLAT001",
+    "name": "Foundational",
+    "description": "Represents widely adopted practices and technologies as of 2025, emphasising reliability, efficiency and adherence to established standards while balancing stability with current innovations."
+  },
+  {
+    "id": "PLAT002",
+    "name": "Enhanced",
+    "description": "Focuses on advanced optimisation of existing technologies, adopting leading-edge tools and continuous improvements while managing early adoption risks."
+  },
+  {
+    "id": "PLAT003",
+    "name": "Experimental",
+    "description": "Explores and pilots cutting-edge technologies and methodologies not yet mainstream, prioritising agility, learning and potential competitive advantage."
+  },
+  {
+    "id": "PLAT004",
+    "name": "Disruptive",
+    "description": "Develops innovative solutions capable of redefining markets, involving high-risk and high-reward scenarios to challenge conventional models."
+  },
+  {
+    "id": "PLAT005",
+    "name": "Transformative",
+    "description": "Redefines the ecosystem by integrating disruptive innovations with broader societal trends to drive large-scale industry or societal change."
+  }
+]

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -2,7 +2,9 @@
 
 The evolution workflow spans four plateaus—**Foundational**, **Enhanced**,
 **Experimental** and **Disruptive**—with three calls per plateau (description,
-features, mapping).
+features, mapping). Plateau definitions are stored in
+`data/service_feature_plateaus.json`; the CLI uses the first four entries by
+default.
 
 ## Running
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -10,13 +10,19 @@ from pydantic_ai import Agent
 
 from conversation import ConversationSession
 from generator import ServiceAmbitionGenerator, build_model
-from loader import load_prompt, load_services
+from loader import load_plateau_definitions, load_prompt, load_services
 from models import ServiceInput
 from monitoring import init_logfire
 from plateau_generator import PlateauGenerator
 from settings import load_settings
 
 logger = logging.getLogger(__name__)
+
+
+def _default_plateaus() -> list[str]:
+    """Return plateau names from configuration."""
+
+    return [p.name for p in load_plateau_definitions()[:4]]
 
 
 def _configure_logging(args: argparse.Namespace, settings) -> None:
@@ -152,19 +158,13 @@ def main() -> None:
     evo.add_argument(
         "--plateaus",
         nargs="+",
-        default=[
-            "Foundational",
-            "Enhanced",
-            "Experimental",
-            "Disruptive",
-            "Transformative",
-        ],
+        default=_default_plateaus(),
         help="Plateau names to evaluate",
     )
     evo.add_argument(
         "--customers",
         nargs="+",
-        default=["retail"],
+        default=["learners", "staff", "community"],
         help="Customer types to evaluate",
     )
     evo.set_defaults(func=_cmd_generate_evolution)

--- a/src/models.py
+++ b/src/models.py
@@ -28,6 +28,14 @@ class ServiceInput(BaseModel):
     )
 
 
+class ServiceFeaturePlateau(BaseModel):
+    """Definition of a service feature plateau."""
+
+    id: str = Field(..., description="Unique plateau identifier.")
+    name: str = Field(..., description="Human readable plateau name.")
+    description: str = Field(..., description="Explanation of plateau characteristics.")
+
+
 class PlateauFeature(BaseModel):
     """Feature assessed during a service plateau."""
 
@@ -125,6 +133,7 @@ class MappingResponse(BaseModel):
 
 __all__ = [
     "ServiceInput",
+    "ServiceFeaturePlateau",
     "PlateauFeature",
     "Contribution",
     "PlateauResult",

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from cli import _cmd_generate_evolution
+from loader import load_plateau_definitions
 from models import ServiceEvolution, ServiceInput
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
@@ -62,11 +63,12 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
         openai_api_key="key",
         logfire_token=None,
     )
+    plateaus = [p.name for p in load_plateau_definitions()[:4]]
     args = argparse.Namespace(
         input_file=str(input_path),
         output_file=str(output_path),
-        plateaus=["alpha"],
-        customers=["retail"],
+        plateaus=plateaus,
+        customers=["learners", "staff", "community"],
         model=None,
         logfire_service=None,
         log_level=None,
@@ -78,8 +80,8 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
     payload = json.loads(output_path.read_text().strip())
     assert payload["service"]["name"] == "svc"
     assert payload["service"]["service_id"] == "svc-1"
-    assert captured["plateaus"] == ["alpha"]
-    assert captured["customers"] == ["retail"]
+    assert captured["plateaus"] == plateaus
+    assert captured["customers"] == ["learners", "staff", "community"]
 
 
 def test_generate_evolution_uses_agent_model(tmp_path, monkeypatch) -> None:
@@ -130,11 +132,12 @@ def test_generate_evolution_uses_agent_model(tmp_path, monkeypatch) -> None:
         openai_api_key="key",
         logfire_token=None,
     )
+    plateaus = [p.name for p in load_plateau_definitions()[:4]]
     args = argparse.Namespace(
         input_file=str(input_path),
         output_file=str(output_path),
-        plateaus=["alpha"],
-        customers=["retail"],
+        plateaus=plateaus,
+        customers=["learners", "staff", "community"],
         model="special",  # override default
         logfire_service=None,
         log_level=None,

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -6,6 +6,7 @@ import pytest
 from loader import (
     load_description_prompt,
     load_mapping_prompt,
+    load_plateau_definitions,
     load_plateau_prompt,
     load_prompt,
     load_services,
@@ -54,6 +55,17 @@ def test_load_description_prompt(tmp_path):
     base.mkdir()
     (base / "description_prompt.md").write_text("desc", encoding="utf-8")
     assert load_description_prompt(str(base)) == "desc"
+
+
+def test_load_plateau_definitions(tmp_path):
+    base = tmp_path / "data"
+    base.mkdir()
+    (base / "service_feature_plateaus.json").write_text(
+        '[{"id": "P1", "name": "Alpha", "description": "d"}]',
+        encoding="utf-8",
+    )
+    plateaus = load_plateau_definitions(str(base))
+    assert plateaus[0].name == "Alpha"
 
 
 def test_load_services_reads_jsonl(tmp_path):


### PR DESCRIPTION
## Summary
- set generate-evolution `--plateaus` default to Foundational/Enhanced/Experimental/Disruptive
- default `--customers` to learners, staff, and community
- update CLI tests for new defaults
- load plateau definitions from `data/service_feature_plateaus.json` and model
- document configurable plateau data source

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 .` *(fails: Command not found: flake8)*
- `poetry run mypy .` *(fails: Cannot find implementation or library stub for modules including "pydantic")*
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'settings')*


------
https://chatgpt.com/codex/tasks/task_e_689557fedc44832bbd648a8bce7ab92d