### PR TITLE
feat: centralize prompt loading

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -10,7 +10,12 @@ from pydantic_ai import Agent
 
 from conversation import ConversationSession
 from generator import ServiceAmbitionGenerator, build_model
-from loader import load_plateau_definitions, load_prompt, load_services
+from loader import (
+    configure_prompt_dir,
+    load_plateau_definitions,
+    load_prompt,
+    load_services,
+)
 from models import ServiceInput
 from monitoring import init_logfire
 from plateau_generator import PlateauGenerator
@@ -43,7 +48,8 @@ def _configure_logging(args: argparse.Namespace, settings) -> None:
 def _cmd_generate_ambitions(args: argparse.Namespace, settings) -> None:
     """Generate service ambitions and write them to disk."""
 
-    system_prompt = load_prompt(args.prompt_dir, args.context_id, args.inspirations_id)
+    configure_prompt_dir(args.prompt_dir)
+    system_prompt = load_prompt(args.context_id, args.inspirations_id)
     services = list(load_services(args.input_file))
     logger.debug("Loaded %d services from %s", len(services), args.input_file)
 

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -6,7 +6,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any, Sequence
 
-from loader import load_mapping_items, load_mapping_prompt
+from loader import load_mapping_items, load_prompt_text
 from models import Contribution, MappingResponse, PlateauFeature
 
 if TYPE_CHECKING:  # pragma: no cover - import for type checking only
@@ -34,7 +34,6 @@ def _render_features(features: Sequence[PlateauFeature]) -> str:
 def map_feature(
     session: ConversationSession,
     feature: PlateauFeature,
-    prompt_dir: str = "prompts",
 ) -> PlateauFeature:
     """Return ``feature`` augmented with mapping information.
 
@@ -44,19 +43,17 @@ def map_feature(
     Args:
         session: Active conversation session used to query the agent.
         feature: Plateau feature to map.
-        prompt_dir: Directory containing prompt templates.
 
     Returns:
         A :class:`PlateauFeature` with mapping information applied.
     """
 
-    return map_features(session, [feature], prompt_dir)[0]
+    return map_features(session, [feature])[0]
 
 
 def map_features(
     session: ConversationSession,
     features: Sequence[PlateauFeature],
-    prompt_dir: str = "prompts",
 ) -> list[PlateauFeature]:
     """Return ``features`` augmented with data, application and technology mappings.
 
@@ -79,7 +76,7 @@ def map_features(
         missing.
     """
 
-    template = load_mapping_prompt(prompt_dir)
+    template = load_prompt_text("mapping_prompt")
     schema = json.dumps(MappingResponse.model_json_schema(), indent=2)
     mapping_items = load_mapping_items()
     prompt = template.format(

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -64,7 +64,7 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
 
     map_calls = {"n": 0}
 
-    def _fake_map_features(session, features, prompt_dir="prompts"):
+    def _fake_map_features(session, features):
         map_calls["n"] += 1
         results = []
         for feature in features:
@@ -79,9 +79,11 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
 
     monkeypatch.setattr("plateau_generator.map_features", _fake_map_features)
     template = "{required_count} {service_name} {service_description} {plateau}"
-    monkeypatch.setattr(
-        "plateau_generator.load_plateau_prompt", lambda *a, **k: template
-    )
+
+    def fake_loader(name, *_, **__):
+        return template if name == "plateau_prompt" else "desc {plateau}"
+
+    monkeypatch.setattr("plateau_generator.load_prompt_text", fake_loader)
 
     service = ServiceInput(
         service_id="svc-1",

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -4,11 +4,9 @@ from pathlib import Path
 import pytest
 
 from loader import (
-    load_description_prompt,
-    load_mapping_prompt,
     load_plateau_definitions,
-    load_plateau_prompt,
     load_prompt,
+    load_prompt_text,
     load_services,
 )
 
@@ -25,7 +23,7 @@ def test_load_prompt_assembles_components(tmp_path):
     (base / "inspirations" / "insp.md").write_text("insp", encoding="utf-8")
     (base / "task_definition.md").write_text("task", encoding="utf-8")
     (base / "response_structure.md").write_text("resp", encoding="utf-8")
-    prompt = load_prompt(str(base), "ctx", "insp")
+    prompt = load_prompt("ctx", "insp", str(base))
     assert prompt == "ctx\n\nplat\n\ndefs\n\ninsp\n\ntask\n\nresp"
 
 
@@ -33,28 +31,28 @@ def test_load_prompt_missing_component(tmp_path):
     base = tmp_path / "prompts"
     base.mkdir()
     with pytest.raises(FileNotFoundError):
-        load_prompt(str(base), "ctx", "insp")
+        load_prompt("ctx", "insp", str(base))
 
 
-def test_load_plateau_prompt(tmp_path):
+def test_load_prompt_text_plateau(tmp_path):
     base = tmp_path / "prompts"
     base.mkdir()
     (base / "plateau_prompt.md").write_text("content", encoding="utf-8")
-    assert load_plateau_prompt(str(base)) == "content"
+    assert load_prompt_text("plateau_prompt", str(base)) == "content"
 
 
-def test_load_mapping_prompt(tmp_path):
+def test_load_prompt_text_mapping(tmp_path):
     base = tmp_path / "prompts"
     base.mkdir()
     (base / "mapping_prompt.md").write_text("map", encoding="utf-8")
-    assert load_mapping_prompt(str(base)) == "map"
+    assert load_prompt_text("mapping_prompt", str(base)) == "map"
 
 
-def test_load_description_prompt(tmp_path):
+def test_load_prompt_text_description(tmp_path):
     base = tmp_path / "prompts"
     base.mkdir()
     (base / "description_prompt.md").write_text("desc", encoding="utf-8")
-    assert load_description_prompt(str(base)) == "desc"
+    assert load_prompt_text("description_prompt", str(base)) == "desc"
 
 
 def test_load_plateau_definitions(tmp_path):

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -26,7 +26,11 @@ class DummySession:
 
 def test_map_feature_returns_mappings(monkeypatch) -> None:
     template = "{data_items} {application_items} {technology_items} {features}"
-    monkeypatch.setattr("mapping.load_mapping_prompt", lambda *a, **k: template)
+
+    def fake_loader(name, *_, **__):
+        return template
+
+    monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
     monkeypatch.setattr(
         "mapping.load_mapping_items",
         lambda *a, **k: {
@@ -71,7 +75,11 @@ def test_map_feature_returns_mappings(monkeypatch) -> None:
 
 def test_map_feature_injects_reference_data(monkeypatch) -> None:
     template = "{data_items} {application_items} {technology_items} {features}"
-    monkeypatch.setattr("mapping.load_mapping_prompt", lambda *a, **k: template)
+
+    def fake_loader(name, *_, **__):
+        return template
+
+    monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
     monkeypatch.setattr(
         "mapping.load_mapping_items",
         lambda *a, **k: {
@@ -115,7 +123,11 @@ def test_map_feature_injects_reference_data(monkeypatch) -> None:
 
 def test_map_feature_rejects_invalid_json(monkeypatch) -> None:
     template = "{data_items} {application_items} {technology_items} {features}"
-    monkeypatch.setattr("mapping.load_mapping_prompt", lambda *a, **k: template)
+
+    def fake_loader(name, *_, **__):
+        return template
+
+    monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
     monkeypatch.setattr(
         "mapping.load_mapping_items",
         lambda *a, **k: {
@@ -138,7 +150,11 @@ def test_map_feature_rejects_invalid_json(monkeypatch) -> None:
 
 def test_map_features_returns_mappings(monkeypatch) -> None:
     template = "{data_items} {application_items} {technology_items} {features}"
-    monkeypatch.setattr("mapping.load_mapping_prompt", lambda *a, **k: template)
+
+    def fake_loader(name, *_, **__):
+        return template
+
+    monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
     monkeypatch.setattr(
         "mapping.load_mapping_items",
         lambda *a, **k: {
@@ -180,7 +196,11 @@ def test_map_features_returns_mappings(monkeypatch) -> None:
 
 def test_map_features_validates_lists(monkeypatch) -> None:
     template = "{data_items} {application_items} {technology_items} {features}"
-    monkeypatch.setattr("mapping.load_mapping_prompt", lambda *a, **k: template)
+
+    def fake_loader(name, *_, **__):
+        return template
+
+    monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
     monkeypatch.setattr(
         "mapping.load_mapping_items",
         lambda *a, **k: {

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -56,12 +56,11 @@ def _feature_payload(count: int) -> str:
 
 def test_generate_plateau_returns_results(monkeypatch) -> None:
     template = "{required_count} {service_name} {service_description} {plateau}"
-    monkeypatch.setattr(
-        "plateau_generator.load_plateau_prompt", lambda *a, **k: template
-    )
-    monkeypatch.setattr(
-        "plateau_generator.load_description_prompt", lambda *a, **k: "desc {plateau}"
-    )
+
+    def fake_loader(name, *_, **__):
+        return template if name == "plateau_prompt" else "desc {plateau}"
+
+    monkeypatch.setattr("plateau_generator.load_prompt_text", fake_loader)
     responses = [json.dumps({"description": "desc"}), _feature_payload(1)]
     session = DummySession(responses)
 
@@ -97,12 +96,11 @@ def test_generate_plateau_returns_results(monkeypatch) -> None:
 
 def test_generate_plateau_raises_on_insufficient_features(monkeypatch) -> None:
     template = "{required_count} {service_name} {service_description} {plateau}"
-    monkeypatch.setattr(
-        "plateau_generator.load_plateau_prompt", lambda *a, **k: template
-    )
-    monkeypatch.setattr(
-        "plateau_generator.load_description_prompt", lambda *a, **k: "desc {plateau}"
-    )
+
+    def fake_loader(name, *_, **__):
+        return template if name == "plateau_prompt" else "desc {plateau}"
+
+    monkeypatch.setattr("plateau_generator.load_prompt_text", fake_loader)
     responses = [json.dumps({"description": "desc"}), _feature_payload(1)]
     session = DummySession(responses)
     generator = PlateauGenerator(cast(ConversationSession, session), required_count=2)
@@ -121,12 +119,11 @@ def test_generate_plateau_raises_on_insufficient_features(monkeypatch) -> None:
 
 def test_request_description_invalid_json(monkeypatch) -> None:
     template = "{required_count} {service_name} {service_description} {plateau}"
-    monkeypatch.setattr(
-        "plateau_generator.load_plateau_prompt", lambda *a, **k: template
-    )
-    monkeypatch.setattr(
-        "plateau_generator.load_description_prompt", lambda *a, **k: "desc {plateau}"
-    )
+
+    def fake_loader(name, *_, **__):
+        return template if name == "plateau_prompt" else "desc {plateau}"
+
+    monkeypatch.setattr("plateau_generator.load_prompt_text", fake_loader)
     """Invalid description payloads should raise ``ValueError``."""
     session = DummySession(["not json"])
     generator = PlateauGenerator(cast(ConversationSession, session), required_count=1)


### PR DESCRIPTION
## Summary
- add configurable prompt directory and generic prompt loader
- replace specific prompt loaders in mapping and plateau generation
- wire CLI to configure prompt directory once

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 .`
- `poetry run mypy .` *(fails: Cannot find implementation or library stub for module named "pydantic")*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/bandit/1.8.6/json)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'generator')*

------
https://chatgpt.com/codex/tasks/task_e_68956f688fc0832babea9bf41ae5c3bc