### PR TITLE
Use OpenAI responses model with web search

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -10,7 +10,9 @@ from typing import Any, Dict, Iterable
 
 import logfire
 from pydantic import BaseModel
-from pydantic_ai import Agent, models
+from pydantic_ai import Agent
+from pydantic_ai.models import Model
+from pydantic_ai.models.openai import OpenAIResponsesModel, OpenAIResponsesModelSettings
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +27,7 @@ class ServiceAmbitionGenerator:
     """Generate ambitions for services using a Pydantic AI model."""
 
     @logfire.instrument()
-    def __init__(self, model: models.Model, concurrency: int = 5) -> None:
+    def __init__(self, model: Model, concurrency: int = 5) -> None:
         """Initialize the generator.
 
         Args:
@@ -106,9 +108,15 @@ class ServiceAmbitionGenerator:
 
 
 @logfire.instrument()
-def build_model(model_name: str, api_key: str) -> models.Model:
+def build_model(model_name: str, api_key: str) -> Model:
     """Return a configured Pydantic AI model."""
 
     if api_key:
         os.environ.setdefault("OPENAI_API_KEY", api_key)
-    return models.infer_model(model_name)
+    model_name = model_name.split(":", 1)[-1]
+    settings = OpenAIResponsesModelSettings(
+        openai_builtin_tools=[{"type": "web_search"}],
+        openai_reasoning_summary="concise",
+        openai_reasoning_effort="medium",
+    )
+    return OpenAIResponsesModel(model_name, settings=settings)


### PR DESCRIPTION
## Summary
- switch model initialization to `OpenAIResponsesModel`
- configure `OpenAIResponsesModelSettings` with web search and reasoning settings

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 .` *(fails: Command not found: flake8)*
- `poetry run mypy .` *(fails: Cannot find implementation or library stub for modules)*
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'settings')*

------
https://chatgpt.com/codex/tasks/task_e_6895821f3ddc832bae98b73e772a667b