### PR TITLE
Refactor plateau generator and expand inline comments

### DIFF
--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -32,6 +32,7 @@ class DummySession:
 
     def ask(self, prompt: str) -> str:  # pragma: no cover - simple proxy
         self.prompts.append(prompt)
+        # Pop from the front so responses are returned in the order queued.
         return self._responses.pop(0)
 
     def add_parent_materials(
@@ -41,6 +42,7 @@ class DummySession:
 
 
 def _feature_payload(count: int) -> str:
+    # Build a uniform payload with ``count`` features per customer type.
     items = [
         {
             "feature_id": f"f{i}",
@@ -86,7 +88,7 @@ def test_generate_plateau_returns_results(monkeypatch) -> None:
     )
     generator._service = service  # type: ignore[attr-defined]
 
-    plateau = generator.generate_plateau(cast(ConversationSession, session), 1)
+    plateau = generator.generate_plateau(1)
 
     assert isinstance(plateau, PlateauResult)
     assert len(plateau.features) == 3
@@ -114,7 +116,7 @@ def test_generate_plateau_raises_on_insufficient_features(monkeypatch) -> None:
     generator._service = service  # type: ignore[attr-defined]
 
     with pytest.raises(ValueError):
-        generator.generate_plateau(cast(ConversationSession, session), 1)
+        generator.generate_plateau(1)
 
 
 def test_request_description_invalid_json(monkeypatch) -> None:
@@ -128,7 +130,7 @@ def test_request_description_invalid_json(monkeypatch) -> None:
     session = DummySession(["not json"])
     generator = PlateauGenerator(cast(ConversationSession, session), required_count=1)
     with pytest.raises(ValueError):
-        generator._request_description(cast(ConversationSession, session), 1)
+        generator._request_description(1)
     assert len(session.prompts) == 1
     assert session.prompts[0].startswith("desc 1")
 
@@ -146,7 +148,7 @@ def test_generate_service_evolution_filters(monkeypatch) -> None:
 
     called: list[int] = []
 
-    def fake_generate_plateau(self, sess, level):
+    def fake_generate_plateau(self, level):
         called.append(level)
         feats = [
             PlateauFeature(


### PR DESCRIPTION
## Summary
- Document per-service agent use and concurrency safeguards in `ServiceAmbitionGenerator`
- Clarify mapping prompt composition and contribution conversion
- Introduce a helper for building `PlateauFeature` objects and document service evolution side effects

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 .`
- `poetry run mypy .` *(fails: Cannot find implementation or library stub for modules like "pydantic", "logfire", "pydantic_ai")*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/bandit/1.8.6/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)')))*
- `PYTHONPATH=src poetry run pytest` *(fails: ModuleNotFoundError: No module named 'logfire')*

------
https://chatgpt.com/codex/tasks/task_e_6895861dcaa0832b8081b250d45d1cc7