### PR TITLE
Refactor JSON loading and streamline prompt handling

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import os
 from typing import Any, Dict, Iterable
 
 import logfire
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter
 from pydantic_ai import Agent
 from pydantic_ai.models import Model
 from pydantic_ai.models.openai import OpenAIResponsesModel, OpenAIResponsesModelSettings
@@ -42,10 +41,11 @@ class ServiceAmbitionGenerator:
             raise ValueError("concurrency must be a positive integer")
         self.model = model
         self.concurrency = concurrency
+        self._prompt: str | None = None
 
     @logfire.instrument()
     async def process_service(
-        self, service: Dict[str, Any], prompt: str
+        self, service: Dict[str, Any], prompt: str | None = None
     ) -> Dict[str, Any]:
         """Return ambitions for ``service``.
 
@@ -55,8 +55,11 @@ class ServiceAmbitionGenerator:
         into a standard dictionary for downstream processing.
         """
 
-        agent = Agent(self.model, instructions=prompt)
-        service_details = json.dumps(service)
+        instructions = prompt if prompt is not None else self._prompt
+        if instructions is None:
+            raise ValueError("prompt must be provided")
+        agent = Agent(self.model, instructions=instructions)
+        service_details = TypeAdapter(Dict[str, Any]).dump_json(service).decode()
         result = await agent.run(service_details, output_type=AmbitionModel)
         return result.output.model_dump()
 
@@ -64,7 +67,6 @@ class ServiceAmbitionGenerator:
     async def _worker(
         self,
         service: Dict[str, Any],
-        prompt: str,
         output_file,
         semaphore: asyncio.Semaphore,
     ) -> None:
@@ -74,7 +76,7 @@ class ServiceAmbitionGenerator:
             logger.info("Processing service %s", service.get("name", "unknown"))
             try:
                 # Delegate to ``process_service`` for the actual model call.
-                result = await self.process_service(service, prompt)
+                result = await self.process_service(service)
             except Exception as exc:  # pylint: disable=broad-except
                 logger.error(
                     "Failed to process service %s: %s",
@@ -84,23 +86,21 @@ class ServiceAmbitionGenerator:
                 return
             # Persist each result on a single line so the file can be consumed
             # using standard ``jsonlines`` tooling.
-            output_file.write(f"{json.dumps(result)}\n")
+            output_file.write(
+                f"{AmbitionModel.model_validate(result).model_dump_json()}\n"
+            )
 
     @logfire.instrument()
     async def _process_all(
         self,
         services: Iterable[Dict[str, Any]],
-        prompt: str,
         output_file,
     ) -> None:
         # Semaphore coordinates concurrent worker tasks so only ``concurrency``
         # requests run at any given time.
         semaphore = asyncio.Semaphore(self.concurrency)
         await asyncio.gather(
-            *(
-                self._worker(service, prompt, output_file, semaphore)
-                for service in services
-            )
+            *(self._worker(service, output_file, semaphore) for service in services)
         )
 
     @logfire.instrument()
@@ -116,14 +116,17 @@ class ServiceAmbitionGenerator:
             Creates/overwrites ``output_path`` with one JSON record per line.
         """
 
+        self._prompt = prompt
         try:
             with open(output_path, "w", encoding="utf-8") as output_file:
                 # Run the async processing loop and stream results directly to
                 # disk to avoid storing large intermediate data sets.
-                asyncio.run(self._process_all(services, prompt, output_file))
+                asyncio.run(self._process_all(services, output_file))
         except Exception as exc:  # pylint: disable=broad-except
             logger.error("Failed to write results to %s: %s", output_path, exc)
             raise
+        finally:
+            self._prompt = None
 
 
 @logfire.instrument()

--- a/tests/test_async_processing.py
+++ b/tests/test_async_processing.py
@@ -27,7 +27,7 @@ def test_process_service_async(monkeypatch):
     service = {"name": "alpha"}
     gen = generator.ServiceAmbitionGenerator(SimpleNamespace())
     result = asyncio.run(gen.process_service(service, "prompt"))
-    assert result == {"service": json.dumps(service)}
+    assert json.loads(result["service"]) == service
 
 
 def test_generator_rejects_invalid_concurrency():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,8 @@ def test_cli_generates_output(tmp_path, monkeypatch):
 
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
 
-    async def fake_process_service(self, service, prompt):
+    async def fake_process_service(self, service, prompt=None):
+        assert prompt is not None
         return {"service": service["name"], "prompt": prompt[:3]}
 
     monkeypatch.setattr(
@@ -94,7 +95,8 @@ def test_cli_switches_context(tmp_path, monkeypatch):
 
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
 
-    async def fake_process_service(self, service, prompt):
+    async def fake_process_service(self, service, prompt=None):
+        assert prompt is not None
         return {"prompt": prompt}
 
     monkeypatch.setattr(
@@ -149,7 +151,7 @@ def test_cli_model_instantiation_arguments(tmp_path, monkeypatch):
     monkeypatch.setattr(generator, "build_model", fake_build_model)
     monkeypatch.setattr(cli, "build_model", fake_build_model)
 
-    async def fake_process_service(self, service, prompt):
+    async def fake_process_service(self, service, prompt=None):
         return {"ok": True}
 
     monkeypatch.setattr(
@@ -190,7 +192,7 @@ def test_cli_enables_logfire(tmp_path, monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
     monkeypatch.setenv("LOGFIRE_TOKEN", "lf-key")
 
-    async def fake_process_service(self, service, prompt):
+    async def fake_process_service(self, service, prompt=None):
         return {"ok": True}
 
     monkeypatch.setattr(
@@ -280,7 +282,7 @@ def test_cli_verbose_logging(tmp_path, monkeypatch, capsys):
 
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
 
-    async def fake_process_service(self, service, prompt):
+    async def fake_process_service(self, service, prompt=None):
         return {"ok": True}
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- add `_read_json_file` helper and use it in mapping and plateau loaders
- store prompt on generator to remove redundant parameter threading
- update CLI tests for new `process_service` signature
- use Pydantic's `TypeAdapter` and models to parse and emit JSON across loaders and generators
- adjust async test to tolerate Pydantic JSON formatting

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing src/mapping.py src/loader.py src/generator.py src/plateau_generator.py tests/test_async_processing.py`
- `poetry run ruff check .`
- `poetry run flake8 .` *(fails: Command not found)*
- `poetry run mypy .` *(fails: Cannot find implementation or library stub for modules such as "pydantic_settings", "pydantic", "logfire", "pydantic_ai")*
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'settings')*


------
https://chatgpt.com/codex/tasks/task_e_68958c9e0c54832ba59757f2feeb1d15