### PR TITLE
Leverage Pydantic for service and mapping data handling

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -16,7 +16,6 @@ from loader import (
     load_prompt,
     load_services,
 )
-from models import ServiceInput
 from monitoring import init_logfire
 from plateau_generator import PlateauGenerator
 from settings import load_settings
@@ -71,8 +70,7 @@ def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
     agent = Agent(model)
 
     with open(args.output_file, "w", encoding="utf-8") as output:
-        for raw in load_services(args.input_file):
-            service = ServiceInput(**raw)
+        for service in load_services(args.input_file):
             session = ConversationSession(agent)
             generator = PlateauGenerator(session)
             evolution = generator.generate_service_evolution(

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -7,7 +7,7 @@ import logging
 from typing import TYPE_CHECKING, Sequence
 
 from loader import load_mapping_items, load_prompt_text
-from models import MappingResponse, PlateauFeature
+from models import MappingItem, MappingResponse, PlateauFeature
 
 if TYPE_CHECKING:  # pragma: no cover - import for type checking only
     from conversation import ConversationSession
@@ -15,13 +15,13 @@ if TYPE_CHECKING:  # pragma: no cover - import for type checking only
 logger = logging.getLogger(__name__)
 
 
-def _render_items(items: list[dict[str, str]]) -> str:
+def _render_items(items: list[MappingItem]) -> str:
     """Return a bullet list representation of mapping reference items."""
 
     # Present each mapping reference item on a separate line so it can be
     # directly inserted into the agent prompt as a bullet list.
     return "\n".join(
-        f"- {entry['id']}: {entry['name']} - {entry['description']}" for entry in items
+        f"- {entry.id}: {entry.name} - {entry.description}" for entry in items
     )
 
 
@@ -82,7 +82,7 @@ def map_features(
 
     template = load_prompt_text("mapping_prompt")
     schema = json.dumps(MappingResponse.model_json_schema(), indent=2)
-    mapping_items = load_mapping_items()
+    mapping_items: dict[str, list[MappingItem]] = load_mapping_items()
     prompt = template.format(
         data_items=_render_items(mapping_items["information"]),
         application_items=_render_items(mapping_items["applications"]),

--- a/src/models.py
+++ b/src/models.py
@@ -36,6 +36,14 @@ class ServiceFeaturePlateau(BaseModel):
     description: str = Field(..., description="Explanation of plateau characteristics.")
 
 
+class MappingItem(BaseModel):
+    """Reference item used for feature mapping."""
+
+    id: str = Field(..., description="Unique identifier for the reference item.")
+    name: str = Field(..., description="Human readable item name.")
+    description: str = Field(..., description="Explanation of the item.")
+
+
 class PlateauFeature(BaseModel):
     """Feature assessed during a service plateau."""
 
@@ -142,5 +150,6 @@ __all__ = [
     "FeatureItem",
     "PlateauFeaturesResponse",
     "MappingFeature",
+    "MappingItem",
     "MappingResponse",
 ]

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -69,17 +69,14 @@ def test_load_plateau_definitions(tmp_path):
 def test_load_services_reads_jsonl(tmp_path):
     data = tmp_path / "services.jsonl"
     data.write_text(
-        '{"service_id": "a1", "name": "alpha", "jobs_to_be_done": []}'
-        "\n\n"
-        '{"service_id": "b2", "name": "beta", "jobs_to_be_done": []}'
-        "\n",
+        '{"service_id": "a1", "name": "alpha", "description": "d", "jobs_to_be_done":'
+        ' []}\n\n{"service_id": "b2", "name": "beta", "description": "d",'
+        ' "jobs_to_be_done": []}\n',
         encoding="utf-8",
     )
     services = list(load_services(str(data)))
-    assert services == [
-        {"service_id": "a1", "name": "alpha", "jobs_to_be_done": []},
-        {"service_id": "b2", "name": "beta", "jobs_to_be_done": []},
-    ]
+    assert services[0].service_id == "a1"
+    assert services[1].name == "beta"
 
 
 def test_load_services_missing(tmp_path):
@@ -101,9 +98,9 @@ def test_load_services_invalid_json(tmp_path):
 def test_valid_fixture_parses():
     path = Path(__file__).parent / "fixtures" / "services-valid.jsonl"
     services = list(load_services(str(path)))
-    assert services[0]["service_id"] == "svc1"
-    assert services[0]["jobs_to_be_done"] == ["job1"]
-    assert services[1]["description"] == "Test"
+    assert services[0].service_id == "svc1"
+    assert services[0].jobs_to_be_done == ["job1"]
+    assert services[1].description == "Test"
 
 
 def test_invalid_fixture_raises():

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from mapping import map_feature, map_features
-from models import PlateauFeature
+from models import MappingItem, PlateauFeature
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
@@ -34,11 +34,13 @@ def test_map_feature_returns_mappings(monkeypatch) -> None:
     monkeypatch.setattr(
         "mapping.load_mapping_items",
         lambda *a, **k: {
-            "information": [{"id": "INF-1", "name": "User Data", "description": "d"}],
+            "information": [MappingItem(id="INF-1", name="User Data", description="d")],
             "applications": [
-                {"id": "APP-1", "name": "Learning Platform", "description": "d"}
+                MappingItem(id="APP-1", name="Learning Platform", description="d")
             ],
-            "technologies": [{"id": "TEC-1", "name": "AI Engine", "description": "d"}],
+            "technologies": [
+                MappingItem(id="TEC-1", name="AI Engine", description="d")
+            ],
         },
     )
     session = DummySession(
@@ -83,11 +85,13 @@ def test_map_feature_injects_reference_data(monkeypatch) -> None:
     monkeypatch.setattr(
         "mapping.load_mapping_items",
         lambda *a, **k: {
-            "information": [{"id": "INF-1", "name": "User Data", "description": "d"}],
+            "information": [MappingItem(id="INF-1", name="User Data", description="d")],
             "applications": [
-                {"id": "APP-1", "name": "Learning Platform", "description": "d"}
+                MappingItem(id="APP-1", name="Learning Platform", description="d")
             ],
-            "technologies": [{"id": "TEC-1", "name": "AI Engine", "description": "d"}],
+            "technologies": [
+                MappingItem(id="TEC-1", name="AI Engine", description="d")
+            ],
         },
     )
     session = DummySession(
@@ -158,9 +162,9 @@ def test_map_features_returns_mappings(monkeypatch) -> None:
     monkeypatch.setattr(
         "mapping.load_mapping_items",
         lambda *a, **k: {
-            "information": [{"id": "INF-1", "name": "User Data", "description": "d"}],
-            "applications": [{"id": "APP-1", "name": "App", "description": "d"}],
-            "technologies": [{"id": "TEC-1", "name": "Tech", "description": "d"}],
+            "information": [MappingItem(id="INF-1", name="User Data", description="d")],
+            "applications": [MappingItem(id="APP-1", name="App", description="d")],
+            "technologies": [MappingItem(id="TEC-1", name="Tech", description="d")],
         },
     )
 
@@ -204,9 +208,9 @@ def test_map_features_validates_lists(monkeypatch) -> None:
     monkeypatch.setattr(
         "mapping.load_mapping_items",
         lambda *a, **k: {
-            "information": [{"id": "INF-1", "name": "User Data", "description": "d"}],
-            "applications": [{"id": "APP-1", "name": "App", "description": "d"}],
-            "technologies": [{"id": "TEC-1", "name": "Tech", "description": "d"}],
+            "information": [MappingItem(id="INF-1", name="User Data", description="d")],
+            "applications": [MappingItem(id="APP-1", name="App", description="d")],
+            "technologies": [MappingItem(id="TEC-1", name="Tech", description="d")],
         },
     )
 


### PR DESCRIPTION
## Summary
- Introduce `MappingItem` model and use Pydantic validation when loading mapping data and services
- Refactor generator and CLI to operate on `ServiceInput` instances
- Update tests for new Pydantic-backed structures

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 .`
- `poetry run mypy --ignore-missing-imports .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443)... certificate verify failed)*
- `PYTHONPATH=src poetry run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_689599e004dc832b81b815dcefa4ffb3