### PR TITLE
feat: parameterize feature mapping types

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,10 @@ Each of `information.json`, `applications.json`, and `technologies.json`
 contains items with identifiers, names, and descriptions. These lists are
 injected into mapping prompts so that features can be matched against consistent
 options. Mapping prompts run separately for information, applications and
-technologies to keep each decision focused.
+technologies to keep each decision focused. All application configuration is
+stored in `config/app.json`; mapping types and their associated datasets live
+under the `mapping_types` section, allowing new categories to be added without
+code changes.
 
 ## Prompt examples
 

--- a/config/app.json
+++ b/config/app.json
@@ -1,0 +1,7 @@
+{
+  "mapping_types": {
+    "data": {"dataset": "information", "label": "Data"},
+    "applications": {"dataset": "applications", "label": "Applications"},
+    "technology": {"dataset": "technologies", "label": "Technologies"}
+  }
+}

--- a/prompts/mapping_prompt.md
+++ b/prompts/mapping_prompt.md
@@ -1,18 +1,8 @@
 # Feature mapping
 
-Map each feature to relevant Data, Applications and Technologies from the lists below.
+Map each feature to relevant {mapping_labels} from the lists below.
 
-## Available Data
-
-{data_items}
-
-## Available Applications
-
-{application_items}
-
-## Available Technologies
-
-{technology_items}
+{mapping_sections}
 
 ## Features
 
@@ -21,7 +11,7 @@ Map each feature to relevant Data, Applications and Technologies from the lists 
 ## Instructions
 
 - Return a JSON object with a top-level "features" array.
-- Each element must include "feature_id", "data", "applications" and "technology" arrays.
+- Each element must include "feature_id" and the following arrays: {mapping_fields}.
 - Items in these arrays must provide "item" and "contribution" fields.
 - Use only identifiers from the provided lists.
 - Do not include any text outside the JSON object.

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -69,11 +69,11 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
         results = []
         for feature in features:
             payload = feature.model_dump()
-            payload.update(
-                data=[Contribution(item="d", contribution="c")],
-                applications=[Contribution(item="a", contribution="c")],
-                technology=[Contribution(item="t", contribution="c")],
-            )
+            payload["mappings"] = {
+                "data": [Contribution(item="d", contribution="c")],
+                "applications": [Contribution(item="a", contribution="c")],
+                "technology": [Contribution(item="t", contribution="c")],
+            }
             results.append(PlateauFeature(**payload))
         return results
 
@@ -106,6 +106,6 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
     assert len(session.prompts) + map_calls["n"] == 12
     for plateau in evolution.plateaus:
         for feature in plateau.features:
-            assert feature.data
-            assert feature.applications
-            assert feature.technology
+            assert feature.mappings["data"]
+            assert feature.mappings["applications"]
+            assert feature.mappings["technology"]

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import pytest
 
 from loader import (
+    load_app_config,
+    load_mapping_type_config,
     load_plateau_definitions,
     load_prompt,
     load_prompt_text,
@@ -107,3 +109,28 @@ def test_invalid_fixture_raises():
     path = Path(__file__).parent / "fixtures" / "services-invalid.jsonl"
     with pytest.raises(RuntimeError):
         list(load_services(str(path)))
+
+
+def test_load_mapping_type_config(tmp_path):
+    base = tmp_path / "config"
+    base.mkdir()
+    (base / "app.json").write_text(
+        '{"mapping_types": {"alpha": {"dataset": "ds", "label": "Alpha"}}}',
+        encoding="utf-8",
+    )
+    load_app_config.cache_clear()
+    load_mapping_type_config.cache_clear()
+    config = load_mapping_type_config(str(base))
+    assert config["alpha"].dataset == "ds"
+
+
+def test_load_app_config(tmp_path):
+    base = tmp_path / "config"
+    base.mkdir()
+    (base / "app.json").write_text(
+        '{"mapping_types": {"beta": {"dataset": "ds2", "label": "Beta"}}}',
+        encoding="utf-8",
+    )
+    load_app_config.cache_clear()
+    config = load_app_config(str(base))
+    assert "beta" in config.mapping_types

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -25,7 +25,7 @@ class DummySession:
 
 
 def test_map_feature_returns_mappings(monkeypatch) -> None:
-    template = "{data_items} {application_items} {technology_items} {features}"
+    template = "{mapping_labels} {mapping_sections} {mapping_fields} {features}"
 
     def fake_loader(name, *_, **__):
         return template
@@ -33,7 +33,7 @@ def test_map_feature_returns_mappings(monkeypatch) -> None:
     monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
     monkeypatch.setattr(
         "mapping.load_mapping_items",
-        lambda *a, **k: {
+        lambda types, *a, **k: {
             "information": [MappingItem(id="INF-1", name="User Data", description="d")],
             "applications": [
                 MappingItem(id="APP-1", name="Learning Platform", description="d")
@@ -70,13 +70,13 @@ def test_map_feature_returns_mappings(monkeypatch) -> None:
     result = map_feature(session, feature)  # type: ignore[arg-type]
 
     assert isinstance(result, PlateauFeature)
-    assert result.data[0].item == "INF-1"
-    assert result.applications[0].item == "APP-1"
-    assert result.technology[0].item == "TEC-1"
+    assert result.mappings["data"][0].item == "INF-1"
+    assert result.mappings["applications"][0].item == "APP-1"
+    assert result.mappings["technology"][0].item == "TEC-1"
 
 
 def test_map_feature_injects_reference_data(monkeypatch) -> None:
-    template = "{data_items} {application_items} {technology_items} {features}"
+    template = "{mapping_labels} {mapping_sections} {mapping_fields} {features}"
 
     def fake_loader(name, *_, **__):
         return template
@@ -84,7 +84,7 @@ def test_map_feature_injects_reference_data(monkeypatch) -> None:
     monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
     monkeypatch.setattr(
         "mapping.load_mapping_items",
-        lambda *a, **k: {
+        lambda types, *a, **k: {
             "information": [MappingItem(id="INF-1", name="User Data", description="d")],
             "applications": [
                 MappingItem(id="APP-1", name="Learning Platform", description="d")
@@ -126,7 +126,7 @@ def test_map_feature_injects_reference_data(monkeypatch) -> None:
 
 
 def test_map_feature_rejects_invalid_json(monkeypatch) -> None:
-    template = "{data_items} {application_items} {technology_items} {features}"
+    template = "{mapping_labels} {mapping_sections} {mapping_fields} {features}"
 
     def fake_loader(name, *_, **__):
         return template
@@ -134,7 +134,7 @@ def test_map_feature_rejects_invalid_json(monkeypatch) -> None:
     monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
     monkeypatch.setattr(
         "mapping.load_mapping_items",
-        lambda *a, **k: {
+        lambda types, *a, **k: {
             "information": [],
             "applications": [],
             "technologies": [],
@@ -153,7 +153,7 @@ def test_map_feature_rejects_invalid_json(monkeypatch) -> None:
 
 
 def test_map_features_returns_mappings(monkeypatch) -> None:
-    template = "{data_items} {application_items} {technology_items} {features}"
+    template = "{mapping_labels} {mapping_sections} {mapping_fields} {features}"
 
     def fake_loader(name, *_, **__):
         return template
@@ -161,7 +161,7 @@ def test_map_features_returns_mappings(monkeypatch) -> None:
     monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
     monkeypatch.setattr(
         "mapping.load_mapping_items",
-        lambda *a, **k: {
+        lambda types, *a, **k: {
             "information": [MappingItem(id="INF-1", name="User Data", description="d")],
             "applications": [MappingItem(id="APP-1", name="App", description="d")],
             "technologies": [MappingItem(id="TEC-1", name="Tech", description="d")],
@@ -194,12 +194,12 @@ def test_map_features_returns_mappings(monkeypatch) -> None:
 
     result = map_features(session, [feature])  # type: ignore[arg-type]
 
-    assert result[0].data[0].item == "INF-1"
+    assert result[0].mappings["data"][0].item == "INF-1"
     assert "User Data" in session.prompts[0]
 
 
 def test_map_features_validates_lists(monkeypatch) -> None:
-    template = "{data_items} {application_items} {technology_items} {features}"
+    template = "{mapping_labels} {mapping_sections} {mapping_fields} {features}"
 
     def fake_loader(name, *_, **__):
         return template
@@ -207,7 +207,7 @@ def test_map_features_validates_lists(monkeypatch) -> None:
     monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
     monkeypatch.setattr(
         "mapping.load_mapping_items",
-        lambda *a, **k: {
+        lambda types, *a, **k: {
             "information": [MappingItem(id="INF-1", name="User Data", description="d")],
             "applications": [MappingItem(id="APP-1", name="App", description="d")],
             "technologies": [MappingItem(id="TEC-1", name="Tech", description="d")],

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -71,9 +71,9 @@ def test_generate_plateau_returns_results(monkeypatch) -> None:
     def dummy_map_features(sess, feats):
         call["n"] += 1
         for feat in feats:
-            feat.data = [Contribution(item="d", contribution="c")]
-            feat.applications = [Contribution(item="a", contribution="c")]
-            feat.technology = [Contribution(item="t", contribution="c")]
+            feat.mappings["data"] = [Contribution(item="d", contribution="c")]
+            feat.mappings["applications"] = [Contribution(item="a", contribution="c")]
+            feat.mappings["technology"] = [Contribution(item="t", contribution="c")]
         return feats
 
     monkeypatch.setattr("plateau_generator.map_features", dummy_map_features)


### PR DESCRIPTION
## Summary
- load mapping type definitions from a JSON configuration file
- update mapping utilities to use `load_mapping_type_config` and document the new configuration
- test `load_mapping_type_config` and mention the config in README
- consolidate application settings into a single `config/app.json` file and expose a `load_app_config` helper

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 .` *(fails: Command not found)*
- `poetry run mypy .` *(fails: missing modules and type errors)*
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'settings')*

------
https://chatgpt.com/codex/tasks/task_e_6895a085433c832b9f2f58712d753265