### PR TITLE
feat: load config values from file

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -1,4 +1,6 @@
 {
+  "model": "openai:gpt-4o-mini",
+  "log_level": "INFO",
   "mapping_types": {
     "data": {"dataset": "information", "label": "Data"},
     "applications": {"dataset": "applications", "label": "Applications"},

--- a/src/models.py
+++ b/src/models.py
@@ -56,6 +56,14 @@ class MappingTypeConfig(BaseModel):
 class AppConfig(BaseModel):
     """Top-level application configuration."""
 
+    model: str = Field(
+        "openai:gpt-4o-mini",
+        description="Chat model in '<provider>:<model>' format.",
+    )
+    log_level: str = Field(
+        "INFO",
+        description="Logging verbosity level.",
+    )
     mapping_types: dict[str, MappingTypeConfig] = Field(
         default_factory=dict,
         description="Mapping type definitions keyed by field name.",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -16,6 +16,8 @@ def test_load_settings_reads_env(monkeypatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "token")
     settings = load_settings()
     assert settings.openai_api_key == "token"
+    assert settings.model == "openai:gpt-4o-mini"
+    assert settings.log_level == "INFO"
 
 
 def test_load_settings_requires_key(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- load non-secret settings from config/app.json
- extend AppConfig and Settings for file-based configuration
- test settings defaults from config

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 .`
- `poetry run mypy .` *(fails: Cannot find implementation or library stub for module named "pydantic", etc.)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: certificate verify failed)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'generator', 'cli', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6895cf0dd8d0832ba882db54263180c5