### PR TITLE
Align prompts with core context

### DIFF
--- a/prompts/description_prompt.md
+++ b/prompts/description_prompt.md
@@ -1,9 +1,12 @@
 # Service description generation
 
+Refer to the situational context, definitions and inspirations provided earlier to maintain consistent terminology across stages.
+
 Provide a description of the service at plateau {plateau}.
 
 ## Instructions
 
+- Base wording on the situational context, definitions and inspirations.
 - Return a JSON object containing only a `description` field.
 - `description` must be a non-empty string explaining the service at plateau {plateau}.
 - Do not include any text outside the JSON object.

--- a/prompts/mapping_prompt.md
+++ b/prompts/mapping_prompt.md
@@ -14,6 +14,7 @@ Map each feature to relevant {mapping_labels} from the lists below.
 - Each element must include "feature_id" and the following arrays: {mapping_fields}.
 - Items in these arrays must provide "item" and "contribution" fields.
 - Use only identifiers from the provided lists.
+- Maintain terminology consistent with the situational context, definitions and inspirations.
 - Do not include any text outside the JSON object.
 - The response must adhere to the JSON schema provided below.
 

--- a/prompts/plateau_prompt.md
+++ b/prompts/plateau_prompt.md
@@ -5,6 +5,7 @@ Generate service features for the {service_name} service at plateau {plateau}.
 ## Instructions
 
 - Use the service description: {service_description}.
+- Reference the situational context, definitions and inspirations to maintain consistent terminology.
 - Return a single JSON object with three keys: "learners", "staff" and "community".
 - Each key must map to an array containing at least {required_count} feature objects.
 - Every feature must provide:


### PR DESCRIPTION
## Summary
- Reference shared situational context, definitions, and inspirations in service description, plateau, and feature mapping prompts to keep terminology aligned across stages

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 .`
- `poetry run mypy .` *(fails: Cannot find implementation or library stubs)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL certificate verify failed)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'settings')*

------
https://chatgpt.com/codex/tasks/task_e_6895d160c224832bb41cacfe7044c290