### PR TITLE
Add plateau name mapping and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Each JSON line in the output file follows the `ServiceEvolution` schema:
   "plateaus": [
     {
       "plateau": 1,
+      "plateau_name": "string",
       "service_description": "string",
       "features": [
         {
@@ -159,6 +160,7 @@ Fields in the schema:
   `customer_type`, and `jobs_to_be_done`.
 - `plateaus`: list of `PlateauResult` entries, each containing:
     - `plateau`: integer plateau level.
+    - `plateau_name`: descriptive plateau label.
     - `service_description`: narrative for the service at that plateau.
     - `features`: list of `PlateauFeature` entries with:
         - `feature_id`, `name`, and `description`.
@@ -177,7 +179,8 @@ options. Mapping prompts run separately for information, applications and
 technologies to keep each decision focused. All application configuration is
 stored in `config/app.json`; mapping types and their associated datasets live
 under the `mapping_types` section, allowing new categories to be added without
-code changes.
+code changes. Plateau name to level associations are defined in the
+`plateau_map` section of the same file.
 
 ## Prompt examples
 

--- a/config/app.json
+++ b/config/app.json
@@ -5,5 +5,11 @@
     "data": {"dataset": "information", "label": "Data"},
     "applications": {"dataset": "applications", "label": "Applications"},
     "technology": {"dataset": "technologies", "label": "Technologies"}
+  },
+  "plateau_map": {
+    "Foundational": 1,
+    "Enhanced": 2,
+    "Experimental": 3,
+    "Disruptive": 4
   }
 }

--- a/data/service_feature_plateaus.json
+++ b/data/service_feature_plateaus.json
@@ -1,27 +1,27 @@
 [
   {
     "id": "PLAT001",
-    "name": "Foundational (Operational Excellence)",
+    "name": "Foundational",
     "description": "This plateau represents the standard practices and technologies widely adopted by organisations as of 2025. Emphasising reliability and efficiency, organisations at this level maintain stable operations using proven methods and technologies. They adhere to established best practices and industry standards, delivering consistent and dependable service. By balancing operational stability with adopting current innovations, they form a solid base for incremental improvements without venturing into untested territories."
   },
   {
     "id": "PLAT002",
-    "name": "Enhanced (Advanced Optimisation)",
+    "name": "Enhanced",
     "description": "Positioned between foundational practices and experimental approaches, the enhanced level focuses on pushing the boundaries of existing technologies and methodologies. Organisations at this stage adopt advanced tools and practices that are leading-edge but have demonstrated effectiveness. They proactively implement improvements and optimisations, positioning themselves as industry leaders in efficiency and effectiveness while carefully managing risks associated with early adoption. This level reflects a commitment to continuous improvement and staying ahead of industry standards without engaging in high-risk experimentation."
   },
   {
     "id": "PLAT003",
-    "name": "Experimental (Emerging Technologies)",
+    "name": "Experimental",
     "description": "At the experimental stage, organisations explore and pilot cutting-edge technologies and methodologies that are not yet mainstream. Emphasising agility and adaptability, they experiment with new solutions, accepting higher risks for potentially high rewards. The focus is on learning, iteration, staying ahead of industry trends, and seeking significant competitive advantages through innovation. Organisations here are willing to challenge the status quo to discover breakthrough opportunities."
   },
   {
     "id": "PLAT004",
-    "name": "Disruptive (Market Redefinition)",
+    "name": "Disruptive",
     "description": "Organisations operating at the disruptive level develop and implement innovative solutions with the potential to upend existing markets or create entirely new ones. They introduce breakthrough ideas that challenge conventional models and practices involving high-risk and high-reward scenarios. The aim is to position the organisation as a leader in innovation and market transformation, driving significant changes in how services are delivered and consumed. This level is characterised by bold moves that can redefine industry landscapes."
   },
   {
     "id": "PLAT005",
-    "name": "Transformative (Ecosystem Evolution)",
+    "name": "Transformative",
     "description": "The transformative plateau leads systemic change by redefining the entire ecosystem in which the organisation operates. Organisations create new paradigms and business models by integrating disruptive innovations with broader societal trends. The focus is on large-scale transformation impacting industries or society as a whole, driving evolution in service delivery and consumption patterns, and establishing new standards and frameworks for the industry. Organisations at this level don’t just adapt to change—they drive it on a fundamental level."
   }
 ]

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -4,7 +4,7 @@ The evolution workflow spans four plateaus—**Foundational**, **Enhanced**,
 **Experimental** and **Disruptive**—with three calls per plateau (description,
 features, mapping). Plateau definitions are stored in
 `data/service_feature_plateaus.json`; the CLI uses the first four entries by
-default.
+default. Plateau name to level mappings come from `config/app.json`.
 
 ## Running
 
@@ -34,6 +34,7 @@ Each line in the output file is a JSON object with:
   "plateaus": [
     {
       "plateau": 1,
+      "plateau_name": "string",
       "service_description": "string",
       "features": [
         {

--- a/prompts/service_feature_plateaus.md
+++ b/prompts/service_feature_plateaus.md
@@ -1,28 +1,28 @@
 ## Service feature plateaus
 
-1. **Foundational (Operational Excellence)**: This plateau represents the standard practices and technologies widely
+1. **Foundational**: This plateau represents the standard practices and technologies widely
    adopted by organisations as of 2025. Emphasising reliability and efficiency, organisations at this level maintain
    stable operations using proven methods and technologies. They adhere to established best practices and industry
    standards, delivering consistent and dependable service. By balancing operational stability with adopting current
    innovations, they form a solid base for incremental improvements without venturing into untested territories.
-2. **Enhanced (Advanced Optimisation)**: Positioned between foundational practices and experimental approaches, the
+2. **Enhanced**: Positioned between foundational practices and experimental approaches, the
    enhanced level focuses on pushing the boundaries of existing technologies and methodologies. Organisations at this
    stage adopt advanced tools and practices that are leading-edge but have demonstrated effectiveness. They proactively
    implement improvements and optimisations, positioning themselves as industry leaders in efficiency and effectiveness
    while carefully managing risks associated with early adoption. This level reflects a commitment to continuous
    improvement and staying ahead of industry standards without engaging in high-risk experimentation.
-3. **Experimental (Emerging Technologies)**: At the experimental stage, organisations explore and pilot cutting-edge
+3. **Experimental**: At the experimental stage, organisations explore and pilot cutting-edge
    technologies and methodologies that are not yet mainstream. Emphasising agility and adaptability, they experiment
    with new solutions, accepting higher risks for potentially high rewards. The focus is on learning, iteration, staying
    ahead of industry trends, and seeking significant competitive advantages through innovation. Organisations here are
    willing to challenge the status quo to discover breakthrough opportunities.
-4. **Disruptive (Market Redefinition)**: Organisations operating at the disruptive level develop and implement
+4. **Disruptive**: Organisations operating at the disruptive level develop and implement
    innovative solutions with the potential to upend existing markets or create entirely new ones. They introduce
    breakthrough ideas that challenge conventional models and practices involving high-risk and high-reward scenarios.
    The aim is to position the organisation as a leader in innovation and market transformation, driving significant
    changes in how services are delivered and consumed. This level is characterised by bold moves that can redefine
    industry landscapes.
-5. **Transformative (Ecosystem Evolution)**: The transformative plateau leads systemic change by redefining the entire
+5. **Transformative**: The transformative plateau leads systemic change by redefining the entire
    ecosystem in which the organisation operates. Organisations create new paradigms and business models by integrating
    disruptive innovations with broader societal trends. The focus is on large-scale transformation impacting industries
    or society as a whole, driving evolution in service delivery and consumption patterns, and establishing new standards

--- a/src/models.py
+++ b/src/models.py
@@ -68,6 +68,10 @@ class AppConfig(BaseModel):
         default_factory=dict,
         description="Mapping type definitions keyed by field name.",
     )
+    plateau_map: dict[str, int] = Field(
+        default_factory=dict,
+        description="Mapping from plateau names to numeric identifiers.",
+    )
 
 
 class PlateauFeature(BaseModel):
@@ -92,6 +96,7 @@ class PlateauResult(BaseModel):
     """Collection of features describing a service at a plateau level."""
 
     plateau: int = Field(..., ge=1, description="Plateau level evaluated.")
+    plateau_name: str = Field(..., description="Human readable name for the plateau.")
     service_description: str = Field(
         ..., description="Description of the service at this plateau."
     )

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -43,11 +43,11 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
     def fake_generate(
         self,
         service: ServiceInput,
-        plateaus: list[str],
-        customers: list[str],
+        plateaus: list[str] | None = None,
+        customers: list[str] | None = None,
     ) -> ServiceEvolution:
-        captured["plateaus"] = plateaus
-        captured["customers"] = customers
+        captured["plateaus"] = plateaus or []
+        captured["customers"] = customers or []
         return ServiceEvolution(service=service, plateaus=[])
 
     monkeypatch.setattr("cli.build_model", fake_build_model)
@@ -114,8 +114,8 @@ def test_generate_evolution_uses_agent_model(tmp_path, monkeypatch) -> None:
     def fake_generate(
         self,
         service: ServiceInput,
-        plateaus: list[str],
-        customers: list[str],
+        plateaus: list[str] | None = None,
+        customers: list[str] | None = None,
     ) -> ServiceEvolution:
         return ServiceEvolution(service=service, plateaus=[])
 

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -94,7 +94,7 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
     )
     evolution = generator.generate_service_evolution(
         service,
-        ["Foundational", "Emerging", "Strategic", "Visionary"],
+        ["Foundational", "Enhanced", "Experimental", "Disruptive"],
         ["learners", "staff", "community"],
     )
     assert isinstance(evolution, ServiceEvolution)

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -128,9 +128,11 @@ def test_load_app_config(tmp_path):
     base = tmp_path / "config"
     base.mkdir()
     (base / "app.json").write_text(
-        '{"mapping_types": {"beta": {"dataset": "ds2", "label": "Beta"}}}',
+        '{"plateau_map": {"Foundational": 1}, "mapping_types": {"beta": {"dataset":'
+        ' "ds2", "label": "Beta"}}}',
         encoding="utf-8",
     )
     load_app_config.cache_clear()
     config = load_app_config(str(base))
     assert "beta" in config.mapping_types
+    assert config.plateau_map["Foundational"] == 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -34,7 +34,12 @@ def test_service_evolution_contains_plateaus() -> None:
         score=0.75,
         customer_type="learners",
     )
-    plateau = PlateauResult(plateau=1, service_description="desc", features=[feature])
+    plateau = PlateauResult(
+        plateau=1,
+        plateau_name="Foundational",
+        service_description="desc",
+        features=[feature],
+    )
 
     evolution = ServiceEvolution(service=service, plateaus=[plateau])
 

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -88,7 +88,7 @@ def test_generate_plateau_returns_results(monkeypatch) -> None:
     )
     generator._service = service  # type: ignore[attr-defined]
 
-    plateau = generator.generate_plateau(1)
+    plateau = generator.generate_plateau(1, "Foundational")
 
     assert isinstance(plateau, PlateauResult)
     assert len(plateau.features) == 3
@@ -116,7 +116,7 @@ def test_generate_plateau_raises_on_insufficient_features(monkeypatch) -> None:
     generator._service = service  # type: ignore[attr-defined]
 
     with pytest.raises(ValueError):
-        generator.generate_plateau(1)
+        generator.generate_plateau(1, "Foundational")
 
 
 def test_request_description_invalid_json(monkeypatch) -> None:
@@ -148,7 +148,7 @@ def test_generate_service_evolution_filters(monkeypatch) -> None:
 
     called: list[int] = []
 
-    def fake_generate_plateau(self, level):
+    def fake_generate_plateau(self, level, plateau_name):
         called.append(level)
         feats = [
             PlateauFeature(
@@ -173,7 +173,12 @@ def test_generate_service_evolution_filters(monkeypatch) -> None:
                 customer_type="community",
             ),
         ]
-        return PlateauResult(plateau=level, service_description="d", features=feats)
+        return PlateauResult(
+            plateau=level,
+            plateau_name=plateau_name,
+            service_description="d",
+            features=feats,
+        )
 
     monkeypatch.setattr(
         PlateauGenerator, "generate_plateau", fake_generate_plateau, raising=False


### PR DESCRIPTION
## Summary
- track plateau names alongside numeric levels in PlateauResult
- provide default plateau and customer type sets
- centralize plateau name mapping in config/app.json and load it through PlateauGenerator
- simplify plateau map to single-word names and derive default plateau list from the mapping

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .` *(Skipped 2 files)*
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 .` *(fails: Command not found: flake8)*
- `poetry run mypy .` *(fails: Cannot find implementation or library stub for modules including "logfire" and "pydantic"; type errors in cli)*
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'settings')*

------
https://chatgpt.com/codex/tasks/task_e_6895d153a8bc832bb4787e77f535a75e