### PR TITLE
fix loader context manager typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,6 @@ select = ["E", "F", "I"]
 
 [tool.isort]
 profile = "black"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]

--- a/src/loader.py
+++ b/src/loader.py
@@ -6,7 +6,7 @@ import logging
 import os
 from contextlib import closing, contextmanager
 from functools import lru_cache
-from typing import Dict, Iterator, List, Sequence, TypeVar
+from typing import Dict, Generator, Iterator, List, Sequence, TypeVar
 
 import logfire
 from pydantic import TypeAdapter
@@ -235,7 +235,7 @@ def load_prompt(
 
 
 @contextmanager
-def load_services(path: str) -> Iterator[ServiceInput]:
+def load_services(path: str) -> Iterator[Iterator[ServiceInput]]:
     """Yield services from ``path`` in JSON Lines format.
 
     Each line is parsed as JSON and returned as a dictionary. The function
@@ -254,7 +254,7 @@ def load_services(path: str) -> Iterator[ServiceInput]:
             fields.
     """
 
-    def load_services_int(path: str) -> Iterator[ServiceInput]:
+    def load_services_int(path: str) -> Generator[ServiceInput, None, None]:
         with logfire.span("Calling loader.load_services"):
             adapter = TypeAdapter(ServiceInput)
             try:


### PR DESCRIPTION
## Summary
- configure pytest to include src modules on the path
- correct `load_services` context manager typing so the generator closes cleanly

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 .` *(fails: Command not found: flake8)*
- `poetry run mypy src/loader.py` *(fails: Cannot find implementation or library stub for module named "pydantic", "logfire")*
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'logfire')*


------
https://chatgpt.com/codex/tasks/task_e_6895e3b73a64832ba6fe9fe0cdc32b97