### PR TITLE
Include service features in inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Each JSON line in the output file follows the `ServiceEvolution` schema:
 Fields in the schema:
 
 - `service`: `ServiceInput` with `service_id`, `name`, `description`, optional
-  `customer_type`, and `jobs_to_be_done`.
+  `customer_type`, `jobs_to_be_done`, and existing `features`.
 - `plateaus`: list of `PlateauResult` entries, each containing:
     - `plateau`: integer plateau level.
     - `plateau_name`: descriptive plateau label.

--- a/src/conversation.py
+++ b/src/conversation.py
@@ -49,6 +49,9 @@ class ConversationSession:
         """
 
         jobs = ", ".join(service_input.jobs_to_be_done)
+        features = "; ".join(
+            f"{feat.feature_id}: {feat.name}" for feat in service_input.features
+        )
         material = (
             f"Service ID: {service_input.service_id}\n"
             f"Service name: {service_input.name}\n"
@@ -56,6 +59,8 @@ class ConversationSession:
             f"Description: {service_input.description}\n"
             f"Jobs to be done: {jobs or 'N/A'}"
         )
+        if service_input.features:
+            material += f"\nExisting features: {features}"
         logger.debug("Adding service material to history: %s", material)
         self._history.append(
             messages.ModelRequest(parts=[messages.SystemPromptPart(material)])

--- a/src/models.py
+++ b/src/models.py
@@ -24,6 +24,18 @@ class Contribution(BaseModel):
     )
 
 
+class ServiceFeature(BaseModel):
+    """Feature already delivered by the service.
+
+    Seed features provide additional context about existing capabilities prior to
+    plateau analysis.
+    """
+
+    feature_id: str = Field(..., description="Unique feature identifier.")
+    name: str = Field(..., description="Human readable feature name.")
+    description: str = Field(..., description="Explanation of the feature.")
+
+
 class ServiceInput(BaseModel):
     """Basic description of a service under consideration.
 
@@ -39,6 +51,10 @@ class ServiceInput(BaseModel):
     description: str = Field(..., description="Short explanation of the service.")
     jobs_to_be_done: list[str] = Field(
         ..., description="Customer jobs the service seeks to address."
+    )
+    features: list[ServiceFeature] = Field(
+        default_factory=list,
+        description="Existing features currently offered by the service.",
     )
 
 
@@ -245,6 +261,7 @@ class MappingResponse(BaseModel):
 
 __all__ = [
     "ServiceInput",
+    "ServiceFeature",
     "ServiceFeaturePlateau",
     "PlateauFeature",
     "Contribution",

--- a/tests/fixtures/services-valid.jsonl
+++ b/tests/fixtures/services-valid.jsonl
@@ -4,6 +4,13 @@
   "description": "First",
   "jobs_to_be_done": [
     "job1"
+  ],
+  "features": [
+    {
+      "feature_id": "F1",
+      "name": "FeatureA",
+      "description": "DescA"
+    }
   ]
 }
 {
@@ -12,5 +19,12 @@
   "description": "Test",
   "jobs_to_be_done": [
     "job2"
+  ],
+  "features": [
+    {
+      "feature_id": "F2",
+      "name": "FeatureB",
+      "description": "DescB"
+    }
   ]
 }

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -13,7 +13,10 @@ from pydantic_ai import (  # noqa: E402  pylint: disable=wrong-import-position
 from conversation import (  # noqa: E402  pylint: disable=wrong-import-position
     ConversationSession,
 )
-from models import ServiceInput  # noqa: E402  pylint: disable=wrong-import-position
+from models import (  # noqa: E402  pylint: disable=wrong-import-position
+    ServiceFeature,
+    ServiceInput,
+)
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
@@ -49,6 +52,30 @@ def test_add_parent_materials_records_history() -> None:
     material = session._history[0].parts[0].content  # noqa: SLF001
     assert "Service ID: svc-1" in material
     assert "Jobs to be done: job1, job2" in material
+
+
+def test_add_parent_materials_includes_features() -> None:
+    """Seed materials should list existing service features when provided."""
+
+    session = ConversationSession(cast(Agent[None, str], DummyAgent()))
+    service = ServiceInput(
+        service_id="svc-1",
+        name="svc",
+        customer_type=None,
+        description="desc",
+        jobs_to_be_done=[],
+        features=[
+            ServiceFeature(
+                feature_id="F1",
+                name="Feat",
+                description="D",
+            )
+        ],
+    )
+    session.add_parent_materials(service)
+
+    material = session._history[0].parts[0].content  # noqa: SLF001 - test helper
+    assert "Existing features: F1: Feat" in material
 
 
 def test_ask_adds_responses_to_history() -> None:

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -72,13 +72,15 @@ def test_load_services_reads_jsonl(tmp_path):
     data = tmp_path / "services.jsonl"
     data.write_text(
         '{"service_id": "a1", "name": "alpha", "description": "d", "jobs_to_be_done":'
-        ' []}\n\n{"service_id": "b2", "name": "beta", "description": "d",'
+        ' [], "features": [{"feature_id": "F1", "name": "Feat", "description":'
+        ' "Desc"}]}\n\n{"service_id": "b2", "name": "beta", "description": "d",'
         ' "jobs_to_be_done": []}\n',
         encoding="utf-8",
     )
     services = list(load_services(str(data)))
     assert services[0].service_id == "a1"
     assert services[1].name == "beta"
+    assert services[0].features[0].name == "Feat"
 
 
 def test_load_services_missing(tmp_path):
@@ -103,6 +105,7 @@ def test_valid_fixture_parses():
     assert services[0].service_id == "svc1"
     assert services[0].jobs_to_be_done == ["job1"]
     assert services[1].description == "Test"
+    assert services[0].features[0].feature_id == "F1"
 
 
 def test_invalid_fixture_raises():


### PR DESCRIPTION
## Summary
- support existing feature metadata via new `ServiceFeature` model and `features` field on `ServiceInput`
- include seed features when seeding conversations
- test loading of features from JSONL fixtures and conversation metadata

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 .`
- `poetry run mypy .` *(fails: Cannot find implementation or library stub for module named "pydantic" and others)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL: CERTIFICATE_VERIFY_FAILED)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6895fbf9bde4832bb7f11f4eb70a2b18