### PR TITLE
Enable pydantic mypy plugin and resolve typing issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,5 +53,8 @@ select = ["E", "F", "I"]
 [tool.isort]
 profile = "black"
 
+[tool.mypy]
+plugins = ["pydantic.mypy"]
+
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/src/generator.py
+++ b/src/generator.py
@@ -211,7 +211,7 @@ def build_model(model_name: str, api_key: str) -> Model:
     # Allow callers to pass provider-prefixed names such as ``openai:gpt-4``.
     model_name = model_name.split(":", 1)[-1]
     settings = OpenAIResponsesModelSettings(
-        openai_builtin_tools=[{"type": "web_search"}],
+        openai_builtin_tools=[{"type": "web_search_preview"}],
         openai_reasoning_summary="concise",
         openai_reasoning_effort="medium",
     )

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -91,7 +91,7 @@ def _build_mapping_prompt(
 
     template = load_prompt_text("mapping_prompt")
     schema = json.dumps(MappingResponse.model_json_schema(), indent=2)
-    items = load_mapping_items([cfg.dataset for cfg in mapping_types.values()])
+    items = load_mapping_items(tuple(cfg.dataset for cfg in mapping_types.values()))
     sections = []
     for cfg in mapping_types.values():
         # Include a bullet list of reference items for each mapping type.

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+from typing import Sequence
 
 from conversation import ConversationSession
 from loader import load_app_config, load_prompt_text
@@ -193,11 +194,17 @@ class PlateauGenerator:
     def generate_service_evolution(
         self,
         service_input: ServiceInput,
+        plateau_names: Sequence[str] | None = None,
+        customer_types: Sequence[str] | None = None,
     ) -> ServiceEvolution:
         """Return service evolution for selected plateaus and customers.
 
         Args:
             service_input: Service under evaluation.
+            plateau_names: Optional plateau names to evaluate. Defaults to
+                :data:`DEFAULT_PLATEAU_NAMES`.
+            customer_types: Optional customer segments to include. Defaults to
+                :data:`DEFAULT_CUSTOMER_TYPES`.
 
         Returns:
             Combined evolution limited to the default plateaus and customer
@@ -212,8 +219,8 @@ class PlateauGenerator:
         # Seed the conversation so later model queries have the service context.
         self.session.add_parent_materials(service_input)
 
-        plateau_names = DEFAULT_PLATEAU_NAMES
-        customer_types = DEFAULT_CUSTOMER_TYPES
+        plateau_names = list(plateau_names or DEFAULT_PLATEAU_NAMES)
+        customer_types = list(customer_types or DEFAULT_CUSTOMER_TYPES)
 
         plateaus: list[PlateauResult] = []
         for name in plateau_names:

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -74,7 +74,9 @@ def test_add_parent_materials_includes_features() -> None:
     )
     session.add_parent_materials(service)
 
-    material = session._history[0].parts[0].content  # noqa: SLF001 - test helper
+    material = cast(
+        messages.TextPart, session._history[0].parts[0]
+    ).content  # noqa: SLF001 - test helper
     assert "Existing features: F1: Feat" in material
 
 


### PR DESCRIPTION
## Summary
- enable pydantic mypy plugin for better pydantic type checking
- make mapping calls hashable and update OpenAI tool type
- allow PlateauGenerator to accept custom plateaus and customer segments

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*
- `pytest` *(fails: multiple failures)*

------
https://chatgpt.com/codex/tasks/task_e_6895ffc23160832bbb3f5f02f59e238c