### PR TITLE
Load context before service evolution generation

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -80,6 +80,11 @@ def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
     model_name = args.model or settings.model
     model = build_model(model_name, settings.openai_api_key)
 
+    # Load and assemble the system prompt so each conversation begins with
+    # the situational context, definitions and inspirations.
+    configure_prompt_dir(settings.prompt_dir)
+    system_prompt = load_prompt(settings.context_id, settings.inspiration)
+
     if settings.concurrency < 1:
         raise ValueError("concurrency must be a positive integer")
 
@@ -98,7 +103,7 @@ def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
         does not leak chat history between services.
         """
 
-        agent = Agent(model)
+        agent = Agent(model, instructions=system_prompt)
         session = ConversationSession(agent)
         generator = PlateauGenerator(session)
         evolution = generator.generate_service_evolution(service)

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -30,8 +30,9 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
         return object()
 
     class DummyAgent:  # pragma: no cover - simple stub
-        def __init__(self, model: object) -> None:
+        def __init__(self, model: object, instructions: str) -> None:
             self.model = model
+            self.instructions = instructions
 
     def fake_generate(self, service: ServiceInput) -> ServiceEvolution:
         return ServiceEvolution(service=service, plateaus=[])
@@ -41,6 +42,8 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(
         "cli.PlateauGenerator.generate_service_evolution", fake_generate
     )
+    monkeypatch.setattr("cli.configure_prompt_dir", lambda _path: None)
+    monkeypatch.setattr("cli.load_prompt", lambda _ctx, _insp: "prompt")
     monkeypatch.setattr("cli.logfire.force_flush", lambda: None)
 
     settings = SimpleNamespace(
@@ -49,6 +52,9 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
         openai_api_key="key",
         logfire_token=None,
         concurrency=2,
+        prompt_dir="prompts",
+        context_id="university",
+        inspiration="general",
     )
     args = argparse.Namespace(
         input_file=str(input_path),
@@ -90,8 +96,11 @@ def test_generate_evolution_uses_agent_model(tmp_path, monkeypatch) -> None:
         return "model"
 
     class DummyAgent:
-        def __init__(self, model: object) -> None:  # pragma: no cover - simple init
+        def __init__(
+            self, model: object, instructions: str
+        ) -> None:  # pragma: no cover - simple init
             captured["agent_model"] = model
+            captured["instructions"] = instructions
 
     def fake_generate(self, service: ServiceInput) -> ServiceEvolution:
         return ServiceEvolution(service=service, plateaus=[])
@@ -101,6 +110,8 @@ def test_generate_evolution_uses_agent_model(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(
         "cli.PlateauGenerator.generate_service_evolution", fake_generate
     )
+    monkeypatch.setattr("cli.configure_prompt_dir", lambda _path: None)
+    monkeypatch.setattr("cli.load_prompt", lambda _ctx, _insp: "prompt")
     monkeypatch.setattr("cli.logfire.force_flush", lambda: None)
 
     settings = SimpleNamespace(
@@ -109,6 +120,9 @@ def test_generate_evolution_uses_agent_model(tmp_path, monkeypatch) -> None:
         openai_api_key="key",
         logfire_token=None,
         concurrency=1,
+        prompt_dir="prompts",
+        context_id="ctx",
+        inspiration="insp",
     )
     args = argparse.Namespace(
         input_file=str(input_path),
@@ -142,8 +156,11 @@ def test_generate_evolution_respects_concurrency(tmp_path, monkeypatch) -> None:
     )
 
     class DummyAgent:
-        def __init__(self, model: object) -> None:  # pragma: no cover - simple init
+        def __init__(
+            self, model: object, instructions: str
+        ) -> None:  # pragma: no cover - simple init
             self.model = model
+            self.instructions = instructions
 
     def fake_build_model(
         model_name: str, api_key: str
@@ -177,6 +194,8 @@ def test_generate_evolution_respects_concurrency(tmp_path, monkeypatch) -> None:
         "cli.PlateauGenerator.generate_service_evolution", fake_generate
     )
     monkeypatch.setattr("cli.ThreadPoolExecutor", DummyExecutor)
+    monkeypatch.setattr("cli.configure_prompt_dir", lambda _path: None)
+    monkeypatch.setattr("cli.load_prompt", lambda _ctx, _insp: "prompt")
     monkeypatch.setattr("cli.logfire.force_flush", lambda: None)
 
     settings = SimpleNamespace(
@@ -185,6 +204,9 @@ def test_generate_evolution_respects_concurrency(tmp_path, monkeypatch) -> None:
         openai_api_key="k",
         logfire_token=None,
         concurrency=3,
+        prompt_dir="prompts",
+        context_id="ctx",
+        inspiration="insp",
     )
     args = argparse.Namespace(
         input_file=str(input_path),


### PR DESCRIPTION
## Summary
- seed generate-evolution conversations with situational context, definitions, and inspirations
- adjust CLI evolution tests for new prompt loading behavior

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 .`
- `poetry run mypy .` *(fails: Error importing plugin `pydantic.mypy`: No module named 'pydantic')*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL certificate verify failed)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'logfire')*


------
https://chatgpt.com/codex/tasks/task_e_6896bffca224832b89d7b25626bee6d5