### PR TITLE
feat: add retry logic for LLM calls

### DIFF
--- a/tests/test_async_processing.py
+++ b/tests/test_async_processing.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 import generator
+from models import ServiceInput
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
@@ -24,10 +25,48 @@ class DummyAgent:
 
 def test_process_service_async(monkeypatch):
     monkeypatch.setattr(generator, "Agent", DummyAgent)
-    service = {"name": "alpha"}
+    service = ServiceInput(
+        service_id="svc",
+        name="alpha",
+        description="desc",
+        jobs_to_be_done=["job"],
+    )
     gen = generator.ServiceAmbitionGenerator(SimpleNamespace())
     result = asyncio.run(gen.process_service(service, "prompt"))
-    assert json.loads(result["service"]) == service
+    assert json.loads(result["service"]) == service.model_dump()
+
+
+def test_process_service_retries(monkeypatch):
+    """Transient failures trigger retries with backoff."""
+
+    attempts = {"count": 0}
+
+    class FlakyAgent(DummyAgent):
+        async def run(self, user_prompt: str, output_type):  # pragma: no cover - stub
+            attempts["count"] += 1
+            if attempts["count"] < 3:
+                raise RuntimeError("temporary")
+            return await super().run(user_prompt, output_type)
+
+    async def fast_sleep(_: float) -> None:
+        """Skip real waiting during backoff."""
+
+        return None
+
+    monkeypatch.setattr(generator, "Agent", FlakyAgent)
+    monkeypatch.setattr(generator.asyncio, "sleep", fast_sleep)
+
+    service = ServiceInput(
+        service_id="svc2",
+        name="beta",
+        description="desc",
+        jobs_to_be_done=["job"],
+    )
+    gen = generator.ServiceAmbitionGenerator(SimpleNamespace())
+    result = asyncio.run(gen.process_service(service, "prompt"))
+
+    assert attempts["count"] == 3
+    assert json.loads(result["service"]) == service.model_dump()
 
 
 def test_generator_rejects_invalid_concurrency():


### PR DESCRIPTION
## Summary
- add `_with_retry` helper with timeout, exponential backoff, and jitter
- wrap `Agent.run` with retry logic to handle transient failures
- test `process_service` retry behavior with a flaky agent

## Testing
- `poetry run ruff check .`
- `poetry run flake8 .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL certificate verify failed)*
- `poetry run pytest tests/test_async_processing.py::test_process_service_async tests/test_async_processing.py::test_process_service_retries -q`
- `poetry run pytest` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6896cde64c24832bbcfc60c8d0da665b