### PR TITLE
feat: make conversation async

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -153,7 +153,7 @@ class ServiceAmbitionGenerator:
                 writer.cancel()
 
     @logfire.instrument()
-    def generate(
+    async def generate(
         self,
         services: Iterable[ServiceInput],
         prompt: str,
@@ -177,7 +177,7 @@ class ServiceAmbitionGenerator:
         try:
             # Run the async processing loop and stream results directly to disk
             # to avoid storing large intermediate data sets.
-            asyncio.run(self._process_all(services, output_path))
+            await self._process_all(services, output_path)
         except Exception as exc:  # pylint: disable=broad-except
             logger.error("Failed to write results to %s: %s", output_path, exc)
             raise

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -60,7 +60,7 @@ def _render_features(features: Sequence[PlateauFeature]) -> str:
     )
 
 
-def map_feature(
+async def map_feature(
     session: ConversationSession,
     feature: PlateauFeature,
     mapping_types: Mapping[str, MappingTypeConfig] | None = None,
@@ -80,7 +80,7 @@ def map_feature(
         A :class:`PlateauFeature` with mapping information applied.
     """
 
-    return map_features(session, [feature], mapping_types)[0]
+    return (await map_features(session, [feature], mapping_types))[0]
 
 
 def _build_mapping_prompt(
@@ -148,7 +148,7 @@ def _merge_mapping_results(
     return results
 
 
-def map_features(
+async def map_features(
     session: ConversationSession,
     features: Sequence[PlateauFeature],
     mapping_types: Mapping[str, MappingTypeConfig] | None = None,
@@ -162,7 +162,7 @@ def map_features(
     mapping_types = mapping_types or load_mapping_type_config()
     prompt = _build_mapping_prompt(features, mapping_types)
     logger.debug("Requesting mappings for %s features", len(features))
-    response = session.ask(prompt)
+    response = await session.ask(prompt)
     logger.debug("Raw multi-feature mapping response: %s", response)
     payload = _parse_mapping_response(response)
     return _merge_mapping_results(features, payload, mapping_types)

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 
+import pytest
 from pydantic_ai import (  # noqa: E402  pylint: disable=wrong-import-position
     Agent,
     messages,
@@ -80,19 +81,21 @@ def test_add_parent_materials_includes_features() -> None:
     assert "Existing features: F1: Feat" in material
 
 
-def test_ask_adds_responses_to_history() -> None:
+@pytest.mark.asyncio
+async def test_ask_adds_responses_to_history() -> None:
     """``ask`` should forward prompts and store new messages."""
 
     session = ConversationSession(cast(Agent[None, str], DummyAgent()))
-    reply = session.ask("ping")
+    reply = await session.ask("ping")
 
     assert reply == "pong"
     assert session._history[-1] == "msg"  # noqa: SLF001 - accessing test-only attribute
 
 
-def test_ask_forwards_prompt_to_agent() -> None:
+@pytest.mark.asyncio
+async def test_ask_forwards_prompt_to_agent() -> None:
     """``ask`` should delegate to the underlying agent."""
     agent = DummyAgent()
     session = ConversationSession(cast(Agent[None, str], agent))
-    session.ask("hello")
+    await session.ask("hello")
     assert agent.called_with == ["hello"]

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from typing import cast
 
+import pytest
+
 from conversation import (  # noqa: E402  pylint: disable=wrong-import-position
     ConversationSession,
 )
@@ -28,7 +30,7 @@ class DummySession:
         self._responses = responses
         self.prompts: list[str] = []
 
-    def ask(self, prompt: str) -> str:  # pragma: no cover - trivial
+    async def ask(self, prompt: str) -> str:  # pragma: no cover - trivial
         self.prompts.append(prompt)
         return self._responses.pop(0)
 
@@ -52,7 +54,8 @@ def _feature_payload(count: int) -> str:
     return json.dumps(payload)
 
 
-def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
     """``generate_service_evolution`` should aggregate all plateaus."""
 
     responses: list[str] = []
@@ -92,7 +95,7 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
         description="desc",
         jobs_to_be_done=["job"],
     )
-    evolution = generator.generate_service_evolution(
+    evolution = await generator.generate_service_evolution(
         service,
         ["Foundational", "Enhanced", "Experimental", "Disruptive"],
         ["learners", "staff", "community"],

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -19,12 +19,13 @@ class DummySession:
         self._responses = iter(responses)
         self.prompts: list[str] = []
 
-    def ask(self, prompt: str) -> str:  # pragma: no cover - trivial
+    async def ask(self, prompt: str) -> str:  # pragma: no cover - trivial
         self.prompts.append(prompt)
         return next(self._responses)
 
 
-def test_map_feature_returns_mappings(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_map_feature_returns_mappings(monkeypatch) -> None:
     template = "{mapping_labels} {mapping_sections} {mapping_fields} {features}"
 
     def fake_loader(name, *_, **__):
@@ -67,7 +68,7 @@ def test_map_feature_returns_mappings(monkeypatch) -> None:
         customer_type="learners",
     )
 
-    result = map_feature(session, feature)  # type: ignore[arg-type]
+    result = await map_feature(session, feature)  # type: ignore[arg-type]
 
     assert isinstance(result, PlateauFeature)
     assert result.mappings["data"][0].item == "INF-1"
@@ -75,7 +76,8 @@ def test_map_feature_returns_mappings(monkeypatch) -> None:
     assert result.mappings["technology"][0].item == "TEC-1"
 
 
-def test_map_feature_injects_reference_data(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_map_feature_injects_reference_data(monkeypatch) -> None:
     template = "{mapping_labels} {mapping_sections} {mapping_fields} {features}"
 
     def fake_loader(name, *_, **__):
@@ -117,7 +119,7 @@ def test_map_feature_injects_reference_data(monkeypatch) -> None:
         score=0.5,
         customer_type="learners",
     )
-    map_feature(session, feature)  # type: ignore[arg-type]
+    await map_feature(session, feature)  # type: ignore[arg-type]
 
     assert len(session.prompts) == 1
     assert "User Data" in session.prompts[0]
@@ -125,7 +127,8 @@ def test_map_feature_injects_reference_data(monkeypatch) -> None:
     assert "AI Engine" in session.prompts[0]
 
 
-def test_map_feature_rejects_invalid_json(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_map_feature_rejects_invalid_json(monkeypatch) -> None:
     template = "{mapping_labels} {mapping_sections} {mapping_fields} {features}"
 
     def fake_loader(name, *_, **__):
@@ -149,10 +152,11 @@ def test_map_feature_rejects_invalid_json(monkeypatch) -> None:
         customer_type="learners",
     )
     with pytest.raises(ValueError):
-        map_feature(session, feature)  # type: ignore[arg-type]
+        await map_feature(session, feature)  # type: ignore[arg-type]
 
 
-def test_map_features_returns_mappings(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_map_features_returns_mappings(monkeypatch) -> None:
     template = "{mapping_labels} {mapping_sections} {mapping_fields} {features}"
 
     def fake_loader(name, *_, **__):
@@ -192,13 +196,14 @@ def test_map_features_returns_mappings(monkeypatch) -> None:
         customer_type="learners",
     )
 
-    result = map_features(session, [feature])  # type: ignore[arg-type]
+    result = await map_features(session, [feature])  # type: ignore[arg-type]
 
     assert result[0].mappings["data"][0].item == "INF-1"
     assert "User Data" in session.prompts[0]
 
 
-def test_map_features_validates_lists(monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_map_features_validates_lists(monkeypatch) -> None:
     template = "{mapping_labels} {mapping_sections} {mapping_fields} {features}"
 
     def fake_loader(name, *_, **__):
@@ -239,4 +244,4 @@ def test_map_features_validates_lists(monkeypatch) -> None:
     )
 
     with pytest.raises(ValueError):
-        map_features(session, [feature])  # type: ignore[arg-type]
+        await map_features(session, [feature])  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- make ConversationSession.ask async to avoid per-call event loops
- refactor mapping, plateau generation, and CLI to work with async session
- expose async ambition generation and top-level asyncio entrypoint

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 .`
- `poetry run mypy .` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLError: HTTPSConnectionPool(host='pypi.org', ... certificate verify failed))*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_6896cda2bbd8832bb02fed5fe00128c6