### PR TITLE
Stream services lazily during ambition generation

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -59,9 +59,6 @@ async def _cmd_generate_ambitions(args: argparse.Namespace, settings) -> None:
     # Load prompt components from the configured directory
     configure_prompt_dir(settings.prompt_dir)
     system_prompt = load_prompt(settings.context_id, settings.inspiration)
-    with load_services(args.input_file) as service_iter:
-        services = list(service_iter)
-    logger.debug("Loaded %d services from %s", len(services), args.input_file)
 
     # Prefer model specified on the CLI, falling back to settings
     model_name = args.model or settings.model
@@ -69,7 +66,10 @@ async def _cmd_generate_ambitions(args: argparse.Namespace, settings) -> None:
 
     model = build_model(model_name, settings.openai_api_key)
     generator = ServiceAmbitionGenerator(model, concurrency=settings.concurrency)
-    await generator.generate(services, system_prompt, args.output_file)
+
+    with load_services(args.input_file) as services:
+        await generator.generate_async(services, system_prompt, args.output_file)
+
     logger.info("Results written to %s", args.output_file)
 
 


### PR DESCRIPTION
## Summary
- Avoid loading all services into memory by iterating the input generator lazily
- Add `generate_async` and incremental task scheduling to `ServiceAmbitionGenerator`
- Update CLI to stream services directly into the generator

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL: CERTIFICATE_VERIFY_FAILED)*
- `poetry run pytest` *(fails: No module named 'logfire')*

------
https://chatgpt.com/codex/tasks/task_e_6896d08039d4832bafb2207b83b9e39d