### PR TITLE
Enforce strict Pydantic models

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -8,46 +8,68 @@ throughout the system.
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
-class Contribution(BaseModel):
+class StrictModel(BaseModel):
+    """Base model with strict settings to prevent shape drift."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+
+class Contribution(StrictModel):
     """Item contributing to a feature's assessment.
 
     A ``Contribution`` explains how a particular reference item supports or
     detracts from a candidate feature when calculating plateau performance.
     """
 
-    item: str = Field(..., description="Name of the mapped element.")
+    item: Annotated[str, Field(min_length=1, description="Name of the mapped element.")]
     contribution: str = Field(
         ..., description="Explanation of how the item supports the feature."
     )
 
 
-class ServiceFeature(BaseModel):
+class ServiceFeature(StrictModel):
     """Feature already delivered by the service.
 
     Seed features provide additional context about existing capabilities prior to
     plateau analysis.
     """
 
-    feature_id: str = Field(..., description="Unique feature identifier.")
-    name: str = Field(..., description="Human readable feature name.")
+    feature_id: Annotated[
+        str, Field(min_length=1, description="Unique feature identifier.")
+    ]
+    name: Annotated[
+        str, Field(min_length=1, description="Human readable feature name.")
+    ]
     description: str = Field(..., description="Explanation of the feature.")
 
 
-class ServiceInput(BaseModel):
+class ServiceInput(StrictModel):
     """Basic description of a service under consideration.
 
     This model is supplied to the generator to describe the baseline service
     before any plateau analysis occurs.
     """
 
-    service_id: str = Field(..., description="Unique identifier for the service.")
-    name: str = Field(..., description="Human readable service name.")
-    customer_type: str | None = Field(
-        None, description="Primary customer segment for the service."
-    )
+    service_id: Annotated[
+        str, Field(min_length=1, description="Unique identifier for the service.")
+    ]
+    name: Annotated[
+        str, Field(min_length=1, description="Human readable service name.")
+    ]
+    customer_type: (
+        Annotated[
+            str,
+            Field(
+                min_length=1, description="Primary customer segment for the service."
+            ),
+        ]
+        | None
+    ) = None
     description: str = Field(..., description="Short explanation of the service.")
     jobs_to_be_done: list[str] = Field(
         ..., description="Customer jobs the service seeks to address."
@@ -58,66 +80,71 @@ class ServiceInput(BaseModel):
     )
 
 
-class ServiceFeaturePlateau(BaseModel):
+class ServiceFeaturePlateau(StrictModel):
     """Definition of a service feature plateau.
 
     Plateaus describe maturity stages that a service feature can achieve. They
     provide reference points when comparing services against the model.
     """
 
-    id: str = Field(..., description="Unique plateau identifier.")
-    name: str = Field(..., description="Human readable plateau name.")
+    id: Annotated[str, Field(min_length=1, description="Unique plateau identifier.")]
+    name: Annotated[
+        str, Field(min_length=1, description="Human readable plateau name.")
+    ]
     description: str = Field(..., description="Explanation of plateau characteristics.")
 
 
-class MappingItem(BaseModel):
+class MappingItem(StrictModel):
     """Reference item used for feature mapping.
 
     Items originate from datasets defined in :class:`MappingTypeConfig` and are
     used to justify a feature's presence during mapping.
     """
 
-    id: str = Field(..., description="Unique identifier for the reference item.")
-    name: str = Field(..., description="Human readable item name.")
+    id: Annotated[
+        str,
+        Field(min_length=1, description="Unique identifier for the reference item."),
+    ]
+    name: Annotated[str, Field(min_length=1, description="Human readable item name.")]
     description: str = Field(..., description="Explanation of the item.")
 
 
-class MappingTypeConfig(BaseModel):
+class MappingTypeConfig(StrictModel):
     """Configuration for a feature mapping type.
 
     The ``dataset`` field indicates a JSONL file located in ``data/`` that
     provides the catalogue of :class:`MappingItem` records for the given type.
     """
 
-    dataset: str = Field(
-        ..., description="Mapping dataset name without file extension."
-    )
-    label: str = Field(..., description="Human readable label for the mapping type.")
+    dataset: Annotated[
+        str,
+        Field(min_length=1, description="Mapping dataset name without file extension."),
+    ]
+    label: Annotated[
+        str,
+        Field(min_length=1, description="Human readable label for the mapping type."),
+    ]
 
 
-class AppConfig(BaseModel):
+class AppConfig(StrictModel):
     """Top-level application configuration controlling generation behaviour."""
 
-    model: str = Field(
-        "openai:gpt-4o-mini",
-        description="Chat model in '<provider>:<model>' format.",
-    )
-    log_level: str = Field(
-        "INFO",
-        description="Logging verbosity level.",
-    )
-    prompt_dir: str = Field(
-        "prompts",
-        description="Directory containing prompt components.",
-    )
-    context_id: str = Field(
-        "university",
-        description="Situational context identifier.",
-    )
-    inspiration: str = Field(
-        "general",
-        description="Inspirations identifier.",
-    )
+    model: Annotated[
+        str,
+        Field(min_length=1, description="Chat model in '<provider>:<model>' format."),
+    ] = "openai:gpt-4o-mini"
+    log_level: Annotated[
+        str, Field(min_length=1, description="Logging verbosity level.")
+    ] = "INFO"
+    prompt_dir: Annotated[
+        str, Field(min_length=1, description="Directory containing prompt components.")
+    ] = "prompts"
+    context_id: Annotated[
+        str, Field(min_length=1, description="Situational context identifier.")
+    ] = "university"
+    inspiration: Annotated[
+        str, Field(min_length=1, description="Inspirations identifier.")
+    ] = "general"
     concurrency: int = Field(
         5,
         ge=1,
@@ -133,29 +160,31 @@ class AppConfig(BaseModel):
     )
 
 
-class PlateauFeature(BaseModel):
+class PlateauFeature(StrictModel):
     """Feature assessed during a service plateau.
 
     Each feature includes a normalised ``score`` and optional mapping
     contributions that reference external catalogues.
     """
 
-    feature_id: str = Field(..., description="Unique identifier for the feature.")
-    name: str = Field(..., description="Feature name.")
+    feature_id: Annotated[
+        str, Field(min_length=1, description="Unique identifier for the feature.")
+    ]
+    name: Annotated[str, Field(min_length=1, description="Feature name.")]
     description: str = Field(..., description="Explanation of the feature.")
     score: float = Field(
         ..., ge=0.0, le=1.0, description="Normalised performance score between 0 and 1."
     )
-    customer_type: str = Field(
-        ..., description="Audience that benefits from the feature."
-    )
+    customer_type: Annotated[
+        str, Field(min_length=1, description="Audience that benefits from the feature.")
+    ]
     mappings: dict[str, list[Contribution]] = Field(
         default_factory=dict,
         description="Mapping contributions keyed by mapping type.",
     )
 
 
-class PlateauResult(BaseModel):
+class PlateauResult(StrictModel):
     """Collection of features describing a service at a plateau level.
 
     Instances are appended to :class:`ServiceEvolution` as the generator evaluates
@@ -163,7 +192,9 @@ class PlateauResult(BaseModel):
     """
 
     plateau: int = Field(..., ge=1, description="Plateau level evaluated.")
-    plateau_name: str = Field(..., description="Human readable name for the plateau.")
+    plateau_name: Annotated[
+        str, Field(min_length=1, description="Human readable name for the plateau.")
+    ]
     service_description: str = Field(
         ..., description="Description of the service at this plateau."
     )
@@ -173,7 +204,7 @@ class PlateauResult(BaseModel):
     )
 
 
-class ServiceEvolution(BaseModel):
+class ServiceEvolution(StrictModel):
     """Summary of a service's progress across plateaus.
 
     The ``plateaus`` list is ordered from lowest to highest maturity and
@@ -186,7 +217,7 @@ class ServiceEvolution(BaseModel):
     )
 
 
-class DescriptionResponse(BaseModel):
+class DescriptionResponse(StrictModel):
     """Schema for intermediate service description responses."""
 
     description: str = Field(
@@ -194,20 +225,21 @@ class DescriptionResponse(BaseModel):
     )
 
 
-class FeatureItem(BaseModel):
+class FeatureItem(StrictModel):
     """Schema for individual plateau features returned by generation APIs."""
 
-    feature_id: str = Field(
-        ..., description="Unique string identifier for the feature."
-    )
-    name: str = Field(..., description="Short feature title.")
+    feature_id: Annotated[
+        str,
+        Field(min_length=1, description="Unique string identifier for the feature."),
+    ]
+    name: Annotated[str, Field(min_length=1, description="Short feature title.")]
     description: str = Field(..., description="Explanation of the feature.")
     score: float = Field(
         ..., ge=0.0, le=1.0, description="Maturity score between 0 and 1."
     )
 
 
-class PlateauFeaturesResponse(BaseModel):
+class PlateauFeaturesResponse(StrictModel):
     """Schema for plateau feature generation responses.
 
     Features are grouped by audience segment to simplify downstream rendering.
@@ -220,14 +252,14 @@ class PlateauFeaturesResponse(BaseModel):
     )
 
 
-class MappingFeature(BaseModel):
+class MappingFeature(StrictModel):
     """Schema for mapped features with dynamic mapping types.
 
     Any additional properties on the input are interpreted as mapping lists and
     consolidated into the ``mappings`` dictionary by ``_collect_mappings``.
     """
 
-    feature_id: str = Field(..., description="Feature identifier.")
+    feature_id: Annotated[str, Field(min_length=1, description="Feature identifier.")]
     mappings: dict[str, list[Contribution]] = Field(
         default_factory=dict, description="Mapping contributions by type."
     )
@@ -251,7 +283,7 @@ class MappingFeature(BaseModel):
         return data
 
 
-class MappingResponse(BaseModel):
+class MappingResponse(StrictModel):
     """Schema for feature mapping responses returned by the mapping worker."""
 
     features: list[MappingFeature] = Field(
@@ -275,4 +307,5 @@ __all__ = [
     "MappingItem",
     "MappingTypeConfig",
     "MappingResponse",
+    "StrictModel",
 ]


### PR DESCRIPTION
## Summary
- add `StrictModel` base with strict config to prevent extra fields
- validate ID and name strings with `Annotated` + `Field(min_length=1)`

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run flake8 .` *(fails: Command not found)*
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*
- `poetry run pytest` *(fails: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_6896d2f615dc832b8852fca4d31bc46c