### PR TITLE
feat: add resumable atomic ambition generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ Alternatively, use the provided shell script which forwards all arguments to the
 [JSON Lines](https://jsonlines.org/) format, with one JSON object per line. The
 output file will also be in JSON Lines format. Use the `--concurrency` option to
 control how many services are processed in parallel when running
-`generate-ambitions`.
+`generate-ambitions`. If a run is interrupted, rerun the command with
+`--continue` to resume. Progress is tracked in a `processed_ids.txt` file and
+results are written to `<output>.jsonl.tmp` until completion.
 
 ## Plateau-first workflow
 


### PR DESCRIPTION
## Summary
- write ambition outputs to a temp file and track processed service IDs
- allow `generate-ambitions` to resume with `--continue`
- document resumable runs and cover with tests

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing src/cli.py src/generator.py tests/test_cli.py`
- `poetry run ruff check src/cli.py src/generator.py tests/test_cli.py`
- `poetry run flake8 src/cli.py src/generator.py tests/test_cli.py`
- `poetry run mypy src/cli.py src/generator.py tests/test_cli.py`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` (failed: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/ag-ui-protocol/0.1.8/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)')))
- `poetry run pytest` (failed: json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0))

------
https://chatgpt.com/codex/tasks/task_e_6896d2e1e3d4832ba525f18ca1838826