### PR TITLE
chore: streamline linting and test runtime

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-select = B950
-extend-ignore = E203,E501,E701

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'poetry'
+          cache-dependency-path: 'poetry.lock'
       - name: Install dependencies
         run: |
           pip install poetry
-          poetry install
+          poetry install --no-root --with dev
       - name: Check formatting
         run: poetry run black --check .
       - name: Lint
@@ -28,4 +30,4 @@ jobs:
       - name: Dependency audit
         run: poetry run pip-audit
       - name: Run tests
-        run: poetry run pytest
+        run: poetry run pytest -q -n auto

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,11 @@ This repository uses automated code quality tooling for all Python sources.
 
 ## Formatting
 
-- Run `poetry run isort --float-to-top --combine-star --order-by-type .` to sort import statements in the code base.
 - Run `poetry run black --preview --enable-unstable-feature string_processing .` to auto-format the code base.
 
 ## Linting
 
-- Execute `poetry run ruff check .` to check style and catch common bugs.
-- Execute `poetry run flake8 .` to check style and catch common bugs.
+- Execute `poetry run ruff check --fix .` to lint and sort imports in one pass.
 
 ## Static Analysis
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,7 @@ mypy = "*"
 bandit = "*"
 "pip-audit" = "*"
 pytest = "*"
-isort = "*"
-flake8 = "*"
-flake8-bugbear = "*"
+"pytest-xdist" = "*"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
@@ -49,9 +47,6 @@ target-version = "py313"
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]
-
-[tool.isort]
-profile = "black"
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+class DummyAgent:
+    """Simple stand-in for :class:`pydantic_ai.Agent`."""
+
+    def __init__(
+        self,
+        model=None,
+        instructions: str | None = None,
+    ) -> None:  # pragma: no cover
+        self.model = model
+        self.instructions = instructions
+
+    async def run(self, prompt: str, output_type=None):  # pragma: no cover - stub
+        output = output_type.model_construct() if output_type else None
+        return SimpleNamespace(output=output, new_messages=lambda: [])
+
+
+class DummyModel:
+    """Placeholder model used to avoid network calls."""
+
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - trivial
+        return
+
+
+@pytest.fixture(autouse=True)
+def _mock_openai_pydantic_ai(monkeypatch):
+    """Prevent external API calls during tests."""
+
+    # Replace OpenAI client with no-op implementation.
+    def _openai_client(*_, **__):  # pragma: no cover - simple stub
+        return SimpleNamespace()
+
+    monkeypatch.setattr("openai.OpenAI", _openai_client, raising=False)
+
+    # Stub out Pydantic-AI components that could reach the network.
+    monkeypatch.setattr("pydantic_ai.Agent", DummyAgent)
+    monkeypatch.setattr("pydantic_ai.models.openai.OpenAIResponsesModel", DummyModel)
+
+    # Ensure modules importing Agent directly use the stub.
+    import generator
+
+    monkeypatch.setattr(generator, "Agent", DummyAgent)


### PR DESCRIPTION
## Summary
- replace flake8/isort with a single Ruff pass
- run tests in parallel via pytest-xdist and mock external AI clients
- cache Poetry installs in CI and use `poetry install --no-root --with dev`

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: certificate verify failed)*
- `poetry run pytest -q -n auto` *(fails: RuntimeError: Invalid service definition)*


------
https://chatgpt.com/codex/tasks/task_e_6896d347b210832b97f2d405a1933483