### PR TITLE
feat: support resumable atomic writes

### DIFF
--- a/src/persistence.py
+++ b/src/persistence.py
@@ -1,0 +1,49 @@
+"""Utilities for safe, resumable file writes.
+
+This module centralises helper functions used to atomically update output files
+and track processed service identifiers across CLI commands.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable, List
+
+
+def read_lines(path: Path) -> List[str]:
+    """Return lines from ``path`` if it exists.
+
+    Args:
+        path: File to read.
+
+    Returns:
+        A list of lines without trailing newlines. Missing files yield an empty
+        list.
+    """
+
+    try:
+        return path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:  # pragma: no cover - best effort
+        return []
+
+
+def atomic_write(path: Path, lines: Iterable[str]) -> None:
+    """Write ``lines`` to ``path`` atomically.
+
+    Args:
+        path: Destination file to replace.
+        lines: Iterable of lines to write without trailing newlines.
+
+    The function writes to ``path`` with a ``.tmp`` suffix then performs
+    :func:`os.replace` to ensure the final file is updated atomically.
+    """
+
+    tmp_path = Path(f"{path}.tmp")
+    with open(tmp_path, "w", encoding="utf-8") as handle:
+        for line in lines:
+            handle.write(f"{line}\n")
+    os.replace(tmp_path, path)
+
+
+__all__ = ["atomic_write", "read_lines"]


### PR DESCRIPTION
## Summary
- support atomic writes with resumable processing
- skip previously handled services via processed_ids.txt
- allow resuming with new `--continue` CLI flag

## Testing
- `poetry run isort --float-to-top --combine-star --order-by-type .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check src/cli.py src/generator.py src/persistence.py tests/test_cli.py tests/test_cli_generate_evolution.py`
- `poetry run flake8 src/cli.py src/generator.py src/persistence.py tests/test_cli.py tests/test_cli_generate_evolution.py`
- `poetry run mypy src/cli.py src/generator.py src/persistence.py tests/test_cli.py tests/test_cli_generate_evolution.py`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*
- `poetry run pytest tests/test_cli.py::test_cli_resume_skips_processed tests/test_cli_generate_evolution.py::test_generate_evolution_resume`


------
https://chatgpt.com/codex/tasks/task_e_6896d680abf8832ba705fc1852f2cc5a