### PR TITLE
chore: streamline linting and testing

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-select = B950
-extend-ignore = E203,E501,E701

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Install Poetry
+        run: pip install poetry
+      - name: Cache Poetry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
-        run: |
-          pip install poetry
-          poetry install
+        run: poetry install --no-root --with dev
       - name: Check formatting
         run: poetry run black --check .
       - name: Lint
@@ -28,4 +33,4 @@ jobs:
       - name: Dependency audit
         run: poetry run pip-audit
       - name: Run tests
-        run: poetry run pytest
+        run: poetry run pytest -q -n auto

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,11 @@ This repository uses automated code quality tooling for all Python sources.
 
 ## Formatting
 
-- Run `poetry run isort --float-to-top --combine-star --order-by-type .` to sort import statements in the code base.
 - Run `poetry run black --preview --enable-unstable-feature string_processing .` to auto-format the code base.
 
 ## Linting
 
-- Execute `poetry run ruff check .` to check style and catch common bugs.
-- Execute `poetry run flake8 .` to check style and catch common bugs.
+- Execute `poetry run ruff check --fix .` to check style, catch common bugs, and sort imports.
 
 ## Static Analysis
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,7 @@ mypy = "*"
 bandit = "*"
 "pip-audit" = "*"
 pytest = "*"
-isort = "*"
-flake8 = "*"
-flake8-bugbear = "*"
+"pytest-xdist" = "*"
 types-tqdm = "*"
 
 [build-system]
@@ -51,9 +49,6 @@ target-version = "py313"
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]
-
-[tool.isort]
-profile = "black"
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+"""Test configuration for service-ambitions.
+
+Ensures OpenAI calls are stubbed and a deterministic API key is present.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_openai(monkeypatch):
+    """Provide dummy credentials and block outbound OpenAI requests."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    try:
+        import openai
+
+        if hasattr(openai, "AsyncClient"):
+            monkeypatch.setattr(
+                openai.AsyncClient,
+                "responses",
+                AsyncMock(
+                    side_effect=RuntimeError(
+                        "OpenAI network access is disabled during tests"
+                    )
+                ),
+                raising=False,
+            )
+    except Exception:  # pragma: no cover - safety net
+        pass


### PR DESCRIPTION
## Summary
- rely on Ruff for linting and import sorting
- cache Poetry and run pytest in parallel in CI
- stub OpenAI client during tests

## Testing
- `black --preview --enable-unstable-feature string_processing tests/conftest.py`
- `ruff check --fix .`
- `mypy .`
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLError: CERTIFICATE_VERIFY_FAILED)*
- `pytest -q -n auto` *(fails: load_services returned context manager)*

------
https://chatgpt.com/codex/tasks/task_e_6896e089a614832bada80b1370154311