### PR TITLE
Add configurable timeouts and pathlib-based loaders

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -19,6 +19,9 @@
   "context_id": "university",
   "inspiration": "general",
   "concurrency": 5,
+  "request_timeout": 60,
+  "retries": 5,
+  "retry_base_delay": 0.5,
   "plateau_map": {
     "Foundational": 1,
     "Enhanced": 2,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ select = ["E", "F", "I"]
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]
+warn_redundant_casts = true
+disallow_any_generics = true
+warn_unused_ignores = true
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/src/cli.py
+++ b/src/cli.py
@@ -72,7 +72,13 @@ async def _cmd_generate_ambitions(args: argparse.Namespace, settings) -> None:
 
     model = build_model(model_name, settings.openai_api_key)
     concurrency = args.concurrency or settings.concurrency
-    generator = ServiceAmbitionGenerator(model, concurrency=concurrency)
+    generator = ServiceAmbitionGenerator(
+        model,
+        concurrency=concurrency,
+        request_timeout=settings.request_timeout,
+        retries=settings.retries,
+        retry_base_delay=settings.retry_base_delay,
+    )
 
     output_path = Path(args.output_file)
     part_path = output_path.with_suffix(
@@ -85,7 +91,7 @@ async def _cmd_generate_ambitions(args: argparse.Namespace, settings) -> None:
     processed_ids: set[str] = set(read_lines(processed_path)) if args.resume else set()
     existing_lines: list[str] = read_lines(output_path) if args.resume else []
 
-    with load_services(args.input_file) as svc_iter:
+    with load_services(Path(args.input_file)) as svc_iter:
         if args.max_services is not None:
             # Limit processing to the requested number of services.
             svc_iter = islice(svc_iter, args.max_services)
@@ -183,7 +189,7 @@ async def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
     processed_ids: set[str] = set(read_lines(processed_path)) if args.resume else set()
     existing_lines: list[str] = read_lines(output_path) if args.resume else []
 
-    with load_services(args.input_file) as svc_iter:
+    with load_services(Path(args.input_file)) as svc_iter:
         if args.max_services is not None:
             svc_iter = islice(svc_iter, args.max_services)
         services = [s for s in svc_iter if s.service_id not in processed_ids]

--- a/src/conversation.py
+++ b/src/conversation.py
@@ -79,10 +79,10 @@ class ConversationSession:
             The agent's response text.
         """
 
-        logger.info("Sending prompt: %s", prompt)
+        logger.debug("Sending prompt: %s", prompt)
         result = await self.client.run(prompt, message_history=self._history)
         self._history.extend(result.new_messages())
-        logger.info("Received response: %s", result.output)
+        logger.debug("Received response: %s", result.output)
         return result.output
 
 

--- a/src/models.py
+++ b/src/models.py
@@ -8,6 +8,7 @@ throughout the system.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -137,8 +138,9 @@ class AppConfig(StrictModel):
         str, Field(min_length=1, description="Logging verbosity level.")
     ] = "INFO"
     prompt_dir: Annotated[
-        str, Field(min_length=1, description="Directory containing prompt components.")
-    ] = "prompts"
+        Path,
+        Field(min_length=1, description="Directory containing prompt components."),
+    ] = Path("prompts")
     context_id: Annotated[
         str, Field(min_length=1, description="Situational context identifier.")
     ] = "university"
@@ -150,6 +152,18 @@ class AppConfig(StrictModel):
         ge=1,
         description="Number of services to process concurrently.",
     )
+    request_timeout: Annotated[
+        int,
+        Field(gt=0, description="Per-request timeout in seconds."),
+    ] = 60
+    retries: Annotated[
+        int,
+        Field(ge=1, description="Number of retry attempts."),
+    ] = 5
+    retry_base_delay: Annotated[
+        float,
+        Field(gt=0, description="Initial backoff delay in seconds."),
+    ] = 0.5
     mapping_types: dict[str, MappingTypeConfig] = Field(
         default_factory=dict,
         description="Mapping type definitions keyed by field name.",

--- a/src/settings.py
+++ b/src/settings.py
@@ -8,6 +8,8 @@ the merged configuration is validated before use.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from pydantic import Field, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -19,11 +21,18 @@ class Settings(BaseSettings):
 
     model: str = Field(..., description="Chat model in '<provider>:<model>' format.")
     log_level: str = Field(..., description="Logging verbosity level.")
-    prompt_dir: str = Field(..., description="Directory containing prompt components.")
+    prompt_dir: Path = Field(..., description="Directory containing prompt components.")
     context_id: str = Field(..., description="Situational context identifier.")
     inspiration: str = Field(..., description="Inspirations identifier.")
     concurrency: int = Field(
         ..., ge=1, description="Number of services to process concurrently."
+    )
+    request_timeout: int = Field(
+        60, gt=0, description="Per-request timeout in seconds."
+    )
+    retries: int = Field(5, ge=1, description="Number of retry attempts.")
+    retry_base_delay: float = Field(
+        0.5, gt=0, description="Initial backoff delay in seconds."
     )
     openai_api_key: str = Field(..., description="OpenAI API access token.")
     logfire_token: str | None = Field(
@@ -56,6 +65,9 @@ def load_settings() -> Settings:
         "context_id": config.context_id,
         "inspiration": config.inspiration,
         "concurrency": config.concurrency,
+        "request_timeout": config.request_timeout,
+        "retries": config.retries,
+        "retry_base_delay": config.retry_base_delay,
     }
     try:
         # Validate and merge configuration from file and environment.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -18,6 +18,9 @@ def test_load_settings_reads_env(monkeypatch) -> None:
     assert settings.openai_api_key == "token"
     assert settings.model == "openai:gpt-4o-mini"
     assert settings.log_level == "INFO"
+    assert settings.request_timeout == 60
+    assert settings.retries == 5
+    assert settings.retry_base_delay == 0.5
 
 
 def test_load_settings_requires_key(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- make request timeouts and retry backoff configurable via settings
- refactor file loaders to use `pathlib.Path`
- tighten logging and typing; add stricter mypy defaults

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Library stubs not installed for "tqdm" and missing imports)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL certificate verification error)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*


------
https://chatgpt.com/codex/tasks/task_e_6896e5fa5bf4832ba3f9daf34e9b0785