### PR TITLE
Refine retry policy to only transient errors

### DIFF
--- a/tests/test_async_processing.py
+++ b/tests/test_async_processing.py
@@ -45,7 +45,8 @@ def test_process_service_retries(monkeypatch):
         async def run(self, user_prompt: str, output_type):  # pragma: no cover - stub
             attempts["count"] += 1
             if attempts["count"] < 3:
-                raise RuntimeError("temporary")
+                # Connection errors are considered transient and should retry.
+                raise ConnectionError("temporary")
             return await super().run(user_prompt, output_type)
 
     async def fast_sleep(_: float) -> None:
@@ -72,3 +73,28 @@ def test_process_service_retries(monkeypatch):
 def test_generator_rejects_invalid_concurrency():
     with pytest.raises(ValueError):
         generator.ServiceAmbitionGenerator(SimpleNamespace(), concurrency=0)
+
+
+def test_with_retry_fails_fast_on_non_transient(monkeypatch):
+    """Non-transient errors are not retried."""
+
+    calls = {"count": 0}
+
+    async def fail():
+        calls["count"] += 1
+        raise ValueError("boom")
+
+    # Ensure a failure does not trigger a backoff sleep.
+    async def fast_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr(generator.asyncio, "sleep", fast_sleep)
+
+    with pytest.raises(ValueError):
+        asyncio.run(
+            generator._with_retry(
+                lambda: fail(), request_timeout=0.1, attempts=5, base=0.01
+            )
+        )
+
+    assert calls["count"] == 1


### PR DESCRIPTION
## Summary
- limit retry handling to timeout, connection, and OpenAI transient errors
- add tests ensuring transient errors retry and non-transient errors fail fast

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'logfire')*


------
https://chatgpt.com/codex/tasks/task_e_6896ebc7793c832bb0dda46d906d61bb