### PR TITLE
feat: add console script entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ tool and then install the project's dependencies with:
 poetry install
 ```
 
+After installation the `service-ambitions` console script is available.
 Run the CLI through Poetry to ensure it uses the managed environment. Use
 subcommands to select the desired operation:
 
 ```bash
-poetry run python src/cli.py generate-ambitions --input-file sample-services.jsonl --output-file ambitions.jsonl
-poetry run python src/cli.py generate-evolution --input-file sample-services.jsonl --output-file evolution.jsonl
+poetry run service-ambitions generate-ambitions --input-file sample-services.jsonl --output-file ambitions.jsonl
+poetry run service-ambitions generate-evolution --input-file sample-services.jsonl --output-file evolution.jsonl
 ```
 
 Alternatively, use the provided shell script which forwards all arguments to the CLI:

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -11,7 +11,7 @@ default. Plateau name to level mappings come from `config/app.json`.
 Example command:
 
 ```bash
-poetry run python src/cli.py generate-evolution \
+poetry run service-ambitions generate-evolution \
   --input-file sample-services.jsonl \
   --output-file evolution.jsonl \
   --plateaus Foundational Enhanced Experimental Disruptive \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
     "tqdm",
 ]
 
+[project.scripts]
+service-ambitions = "cli:main"
+
 [tool.poetry.group.dev.dependencies]
 black = "*"
 ruff = "*"

--- a/run.sh
+++ b/run.sh
@@ -4,4 +4,4 @@
 
 set -euo pipefail
 
-poetry run python src/cli.py "$@"
+poetry run service-ambitions "$@"


### PR DESCRIPTION
## Summary
- expose `service-ambitions` console script for easier CLI access
- use new entry point in docs and helper script

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'logfire')*

------
https://chatgpt.com/codex/tasks/task_e_6896eed52d58832b825ae668965e6141