### PR TITLE
feat: add telemetry span attributes

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,7 +101,7 @@ def test_cli_dry_run_skips_processing(tmp_path, monkeypatch):
 
     called = {"ran": False}
 
-    async def fake_generate_async(self, services, prompt, output_path, progress=None):  # type: ignore[no-untyped-def]
+    async def fake_generate_async(self, services, prompt, output_path, progress=None):
         called["ran"] = True
 
     monkeypatch.setattr(ServiceAmbitionGenerator, "generate_async", fake_generate_async)
@@ -212,7 +212,7 @@ def test_cli_model_instantiation_arguments(tmp_path, monkeypatch):
 
     captured: dict[str, str] = {}
 
-    def fake_build_model(model_name: str, api_key: str, *, seed=None):  # type: ignore[no-untyped-def]
+    def fake_build_model(model_name: str, api_key: str, *, seed=None):
         captured["model"] = model_name
         captured["api_key"] = api_key
         captured["seed"] = seed
@@ -274,7 +274,7 @@ def test_cli_seed_sets_random(tmp_path, monkeypatch):
 
     captured: dict[str, int | None] = {}
 
-    def fake_build_model(model_name: str, api_key: str, *, seed=None):  # type: ignore[no-untyped-def]
+    def fake_build_model(model_name: str, api_key: str, *, seed=None):
         captured["seed"] = seed
         return "test"
 
@@ -343,12 +343,10 @@ def test_cli_enables_logfire(tmp_path, monkeypatch):
     captured: dict[str, object] = {}
     called: dict[str, bool] = {"installed": False}
 
-    def fake_configure(**kwargs):  # type: ignore[no-untyped-def]
+    def fake_configure(**kwargs):
         captured.update(kwargs)
 
-    def fake_install(
-        modules, *, min_duration, check_imported_modules="error"
-    ):  # type: ignore[no-untyped-def]
+    def fake_install(modules, *, min_duration, check_imported_modules="error"):
         called["installed"] = True
         captured["modules"] = modules
         captured["min_duration"] = min_duration

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -29,7 +29,7 @@ class DummyAgent:
         self.called_with: list[str] = []
 
     async def run(
-        self, prompt: str, message_history: list
+        self, prompt: str, message_history: list[str]
     ):  # pragma: no cover - simple stub
         self.called_with.append(prompt)
         return SimpleNamespace(output="pong", new_messages=lambda: ["msg"])

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -21,9 +21,7 @@ def test_init_logfire_replaces_root_handlers(monkeypatch):
     installed = False
     install_args: dict[str, object] = {}
 
-    def install(
-        modules, *, min_duration, check_imported_modules="error"
-    ):  # type: ignore[no-untyped-def]
+    def install(modules, *, min_duration, check_imported_modules="error"):
         nonlocal installed
         installed = True
         install_args["modules"] = modules

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -87,7 +87,7 @@ async def test_generate_plateau_returns_results(monkeypatch) -> None:
         description="desc",
         jobs_to_be_done=["job"],
     )
-    generator._service = service  # type: ignore[attr-defined]
+    generator._service = service
 
     plateau = await generator.generate_plateau(1, "Foundational")
 
@@ -115,7 +115,7 @@ async def test_generate_plateau_raises_on_insufficient_features(monkeypatch) -> 
         description="desc",
         jobs_to_be_done=["job"],
     )
-    generator._service = service  # type: ignore[attr-defined]
+    generator._service = service
 
     with pytest.raises(ValueError):
         await generator.generate_plateau(1, "Foundational")


### PR DESCRIPTION
## Summary
- annotate service processing spans with service and customer metadata
- record plateau and customer attributes during feature generation

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*
- `poetry run pytest` *(fails: Unable to apply constraint min_length)*

------
https://chatgpt.com/codex/tasks/task_e_6896f2c034ac832bbd1228b7dcd6368b