### PR TITLE
Add schema versioning and TTY-aware progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ output file will also be in JSON Lines format. Use `--concurrency` to control
 parallel workers, `--max-services` to limit how many entries are processed, and
 `--dry-run` to validate inputs without calling the API. Pass `--progress` to
 display a progress bar during long runs; it is suppressed automatically in CI
-environments. Provide `--seed` to make stochastic behaviour such as backoff
-jitter deterministic during tests and demos.
+environments or when stdout is not a TTY. Provide `--seed` to make stochastic
+behaviour such as backoff jitter deterministic during tests and demos.
 
 ## Plateau-first workflow
 
@@ -129,6 +129,7 @@ Each JSON line in the output file follows the `ServiceEvolution` schema:
 
 ```json
 {
+  "schema_version": "1.0",
   "service": {
     "service_id": "string",
     "name": "string",
@@ -160,6 +161,7 @@ Each JSON line in the output file follows the `ServiceEvolution` schema:
 
 Fields in the schema:
 
+- `schema_version`: string identifying the output schema revision.
 - `service`: `ServiceInput` with `service_id`, `name`, `description`, optional
   `customer_type`, `jobs_to_be_done`, and existing `features`.
 - `plateaus`: list of `PlateauResult` entries, each containing:

--- a/src/cli.py
+++ b/src/cli.py
@@ -7,6 +7,7 @@ import asyncio
 import logging
 import os
 import random
+import sys
 from itertools import islice
 from pathlib import Path
 from typing import Iterable
@@ -100,7 +101,7 @@ async def _cmd_generate_ambitions(args: argparse.Namespace, settings) -> None:
         if args.resume:
             svc_iter = (s for s in svc_iter if s.service_id not in processed_ids)
 
-        show_progress = args.progress and not os.environ.get("CI")
+        show_progress = args.progress and sys.stdout.isatty()
         services_list: list[ServiceInput] | None = None
         services: Iterable[ServiceInput]
         if args.dry_run or show_progress:
@@ -202,7 +203,7 @@ async def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
     new_ids: set[str] = set()
     with open(part_path, "w", encoding="utf-8") as output:
         tasks = [asyncio.create_task(process_service(svc)) for svc in services]
-        show_progress = args.progress and not os.environ.get("CI")
+        show_progress = args.progress and sys.stdout.isatty()
         progress = tqdm(total=len(tasks)) if show_progress else None
         for task in asyncio.as_completed(tasks):
             svc_id, name, payload = await task

--- a/src/models.py
+++ b/src/models.py
@@ -13,6 +13,8 @@ from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+SCHEMA_VERSION = "1.0"
+
 
 class StrictModel(BaseModel):
     """Base model with strict settings to prevent shape drift."""
@@ -225,6 +227,10 @@ class ServiceEvolution(StrictModel):
     represents the full evolution output for a given :class:`ServiceInput`.
     """
 
+    schema_version: str = Field(
+        default=SCHEMA_VERSION,
+        description="Version of the ServiceEvolution schema.",
+    )
     service: ServiceInput = Field(..., description="Service being evaluated.")
     plateaus: list[PlateauResult] = Field(
         default_factory=list, description="Evaluated plateaus for the service."
@@ -313,6 +319,7 @@ __all__ = [
     "Contribution",
     "PlateauResult",
     "ServiceEvolution",
+    "SCHEMA_VERSION",
     "DescriptionResponse",
     "FeatureItem",
     "PlateauFeaturesResponse",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,7 +27,7 @@ def test_cli_generates_output(tmp_path, monkeypatch):
     (base / "response_structure.md").write_text("r", encoding="utf-8")
 
     input_file = tmp_path / "services.jsonl"
-    input_file.write_text('{"name": "alpha"}\n{"name": "beta"}\n')
+    input_file.write_text('{"name": "alpha"}\n{"name": "beta"}\n', encoding="utf-8")
 
     output_file = tmp_path / "output.jsonl"
 
@@ -67,7 +67,7 @@ def test_cli_generates_output(tmp_path, monkeypatch):
 
     cli.main()
 
-    lines = output_file.read_text().strip().splitlines()
+    lines = output_file.read_text(encoding="utf-8").strip().splitlines()
     assert [json.loads(line) for line in lines] == [
         {"service": "alpha", "prompt": "You"}
     ]
@@ -145,7 +145,7 @@ def test_cli_switches_context(tmp_path, monkeypatch):
     (base / "task_definition.md").write_text("t", encoding="utf-8")
     (base / "response_structure.md").write_text("r", encoding="utf-8")
     input_file = tmp_path / "services.jsonl"
-    input_file.write_text('{"name": "alpha"}\n')
+    input_file.write_text('{"name": "alpha"}\n', encoding="utf-8")
     output_file = tmp_path / "output.jsonl"
 
     settings = SimpleNamespace(
@@ -180,7 +180,7 @@ def test_cli_switches_context(tmp_path, monkeypatch):
 
     cli.main()
 
-    line = json.loads(output_file.read_text().strip())
+    line = json.loads(output_file.read_text(encoding="utf-8").strip())
     assert line["prompt"].startswith("Beta")
 
 
@@ -196,7 +196,7 @@ def test_cli_model_instantiation_arguments(tmp_path, monkeypatch):
     (base / "task_definition.md").write_text("t", encoding="utf-8")
     (base / "response_structure.md").write_text("r", encoding="utf-8")
     input_file = tmp_path / "services.jsonl"
-    input_file.write_text('{"name": "alpha"}\n')
+    input_file.write_text('{"name": "alpha"}\n', encoding="utf-8")
     output_file = tmp_path / "output.jsonl"
 
     settings = SimpleNamespace(
@@ -318,7 +318,7 @@ def test_cli_enables_logfire(tmp_path, monkeypatch):
     (base / "task_definition.md").write_text("t", encoding="utf-8")
     (base / "response_structure.md").write_text("r", encoding="utf-8")
     input_file = tmp_path / "services.jsonl"
-    input_file.write_text('{"name": "alpha"}\n')
+    input_file.write_text('{"name": "alpha"}\n', encoding="utf-8")
     output_file = tmp_path / "output.jsonl"
 
     settings = SimpleNamespace(
@@ -522,6 +522,8 @@ def test_cli_resume_skips_processed(tmp_path, monkeypatch):
     cli.main()
 
     assert processed == ["2"]
-    lines = output_file.read_text().strip().splitlines()
+    lines = output_file.read_text(encoding="utf-8").strip().splitlines()
     assert len(lines) == 2
-    assert (tmp_path / "processed_ids.txt").read_text().splitlines() == ["1", "2"]
+    assert (tmp_path / "processed_ids.txt").read_text(
+        encoding="utf-8"
+    ).splitlines() == ["1", "2"]

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from cli import _cmd_generate_evolution
-from models import ServiceEvolution, ServiceInput
+from models import SCHEMA_VERSION, ServiceEvolution, ServiceInput
 
 
 @pytest.mark.asyncio
@@ -24,7 +24,8 @@ async def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
                 "jobs_to_be_done": ["job"],
             }
         )
-        + "\n"
+        + "\n",
+        encoding="utf-8",
     )
 
     def fake_build_model(
@@ -76,9 +77,10 @@ async def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
 
     await _cmd_generate_evolution(args, settings)
 
-    payload = json.loads(output_path.read_text().strip())
+    payload = json.loads(output_path.read_text(encoding="utf-8").strip())
     assert payload["service"]["name"] == "svc"
     assert payload["service"]["service_id"] == "svc-1"
+    assert payload["schema_version"] == SCHEMA_VERSION
 
 
 @pytest.mark.asyncio
@@ -95,7 +97,8 @@ async def test_generate_evolution_uses_agent_model(tmp_path, monkeypatch) -> Non
                 "jobs_to_be_done": [],
             }
         )
-        + "\n"
+        + "\n",
+        encoding="utf-8",
     )
 
     captured: dict[str, object] = {}
@@ -172,7 +175,8 @@ async def test_generate_evolution_respects_concurrency(tmp_path, monkeypatch) ->
                 "jobs_to_be_done": [],
             }
         )
-        + "\n"
+        + "\n",
+        encoding="utf-8",
     )
 
     class DummyAgent:
@@ -376,6 +380,8 @@ async def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:
     await _cmd_generate_evolution(args, settings)
 
     assert processed == ["s2"]
-    lines = output_path.read_text().strip().splitlines()
+    lines = output_path.read_text(encoding="utf-8").strip().splitlines()
     assert len(lines) == 2
-    assert (tmp_path / "processed_ids.txt").read_text().splitlines() == ["s1", "s2"]
+    assert (tmp_path / "processed_ids.txt").read_text(
+        encoding="utf-8"
+    ).splitlines() == ["s1", "s2"]


### PR DESCRIPTION
## Summary
- suppress progress bar output unless stdout is a TTY
- version ServiceEvolution schema and embed `schema_version` in JSONL
- standardise UTF-8 encoding in tests and docs

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(command not found)*
- `poetry run pip-audit` *(command not found)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'logfire', 'pydantic_ai', 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6896f7f24f0c832bb25566c529a9ef14