### PR TITLE
refine logging and mapping error handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ mypy = "*"
 bandit = "*"
 "pip-audit" = "*"
 pytest = "*"
+hypothesis = "*"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from mapping import map_feature, map_features
+from mapping import MappingError, map_feature, map_features
 from models import MappingItem, PlateauFeature
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
@@ -243,5 +243,5 @@ async def test_map_features_validates_lists(monkeypatch) -> None:
         customer_type="learners",
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(MappingError):
         await map_features(session, [feature])  # type: ignore[arg-type]

--- a/tests/test_serviceinput_hypothesis.py
+++ b/tests/test_serviceinput_hypothesis.py
@@ -1,0 +1,45 @@
+"""Property-based tests for ServiceInput model."""
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from models import ServiceFeature, ServiceInput
+
+
+@given(
+    service_id=st.text(min_size=1),
+    name=st.text(min_size=1),
+    customer_type=st.one_of(st.none(), st.text(min_size=1)),
+    description=st.text(min_size=1),
+    jobs=st.lists(st.text(min_size=1), min_size=1, max_size=5),
+    features=st.lists(
+        st.builds(
+            ServiceFeature,
+            feature_id=st.text(min_size=1),
+            name=st.text(min_size=1),
+            description=st.text(min_size=1),
+        ),
+        max_size=3,
+    ),
+)
+def test_service_input_validates(
+    service_id, name, customer_type, description, jobs, features
+):
+    """ServiceInput accepts a wide range of valid values."""
+    model = ServiceInput(
+        service_id=service_id,
+        name=name,
+        customer_type=customer_type,
+        description=description,
+        jobs_to_be_done=jobs,
+        features=features,
+    )
+    assert model.service_id == service_id
+
+
+def test_service_input_rejects_empty_id():
+    """Empty identifiers should be rejected."""
+    with pytest.raises(ValidationError):
+        ServiceInput(service_id="", name="n", description="d", jobs_to_be_done=["j"])


### PR DESCRIPTION
## Summary
- propagate root logger level/format when enabling Logfire and fall back to structured JSON logging
- auto-load `.env` configuration in settings
- introduce `MappingError` for missing feature mappings
- add property-based test for `ServiceInput` and include Hypothesis dev dependency

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/ag-ui-protocol/0.1.8/json)*
- `poetry run pytest` *(fails: RuntimeError: An error occurred while reading the JSON file: Unable to apply constraint 'min_length' to supplied value prompts)*

------
https://chatgpt.com/codex/tasks/task_e_6896ffe717ec832b84864f0b3433494c