### PR TITLE
chore: upgrade to Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       - name: Install Poetry
         run: pip install poetry
       - name: Cache Poetry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [
     { name = "Jolyon Suthers", email = "201621+fenrick@users.noreply.github.com" }
 ]
-requires-python = ">= 3.11,<4"
+requires-python = ">= 3.13,<4"
 dependencies = [
     "openai",
     "pydantic-ai",


### PR DESCRIPTION
## Summary
- use Python 3.13 in CI
- require Python 3.13 in project metadata

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Missing libraries and unused ignores)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL certificate verification failed)*
- `poetry run pytest -q` *(fails: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_6898096e4d14832ba29551b680e4499c