### PR TITLE
Add pytest-xdist for parallel test execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ mypy = "*"
 bandit = "*"
 "pip-audit" = "*"
 pytest = "*"
+pytest-xdist = "*"
 hypothesis = "*"
 
 [build-system]


### PR DESCRIPTION
## Summary
- enable parallel testing by including pytest-xdist in Poetry dev dependencies

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL: CERTIFICATE_VERIFY_FAILED)*
- `poetry run pytest -n auto` *(fails: RuntimeError: Unable to apply constraint 'min_length' to supplied value prompts)*

------
https://chatgpt.com/codex/tasks/task_e_68980947f314832b8c5cdb74928c4e49