### PR TITLE
fix: run CLI without installed entrypoint

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,4 +4,7 @@
 
 set -euo pipefail
 
-poetry run service-ambitions "$@"
+# Use the CLI module directly rather than relying on an installed
+# entry point.  The project is configured with `package-mode = false`
+# so `service-ambitions` is not available on the `PATH`.
+poetry run python src/cli.py "$@"


### PR DESCRIPTION
## Summary
- call the CLI module directly instead of relying on an absent `service-ambitions` command

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*
- `poetry install` *(fails: All attempts to connect to pypi.org failed)*
- `./run.sh --help` *(fails: No module named 'logfire')*

------
https://chatgpt.com/codex/tasks/task_e_68993bc5fc5c832b84f7aa3d37a5bb7c