### PR TITLE
Fix AppConfig prompt_dir validation to accept Path

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -141,7 +141,7 @@ class AppConfig(StrictModel):
     ] = "INFO"
     prompt_dir: Annotated[
         Path,
-        Field(min_length=1, description="Directory containing prompt components."),
+        Field(description="Directory containing prompt components."),
     ] = Path("prompts")
     context_id: Annotated[
         str, Field(min_length=1, description="Situational context identifier.")


### PR DESCRIPTION
## Summary
- remove unsupported `min_length` constraint from `prompt_dir`

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*
- `poetry run pytest` *(fails: No module named 'pydantic')*
- `./run.sh --help` *(fails: No module named 'logfire')*


------
https://chatgpt.com/codex/tasks/task_e_68993f82e088832b9f80d673ac5d7381