### PR TITLE
refactor: update logfire attribute usage

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -264,10 +264,12 @@ class ServiceAmbitionGenerator:
             """
 
             async with sem:
-                with logfire.span("process_service"):
-                    logfire.set_attribute("service.id", service.service_id)  # type: ignore[attr-defined]
+                # Record service metadata on the span so that traces include the
+                # originating service identifier and customer segment.
+                with logfire.span("process_service") as span:
+                    span.set_attribute("service.id", service.service_id)
                     if service.customer_type:
-                        logfire.set_attribute("customer_type", service.customer_type)  # type: ignore[attr-defined]
+                        span.set_attribute("customer_type", service.customer_type)
                     logger.info("Processing service %s", service.name)
                     try:
                         result = await self.process_service(service)


### PR DESCRIPTION
## Summary
- replace deprecated `logfire.set_attribute` calls with span `set_attribute`
- return `ServiceEvolution` using service object

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLError)*
- `poetry run pytest` *(fails: multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68996882a69c832bbdb6e317fe7f7b40