### PR TITLE
feat: support configurable reasoning options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ manager instead of committing keys to source control.
 
 The chat model can be set with the `--model` flag or the `MODEL` environment
 variable. Model identifiers must include a provider prefix, in the form
-`<provider>:<model>`. The default is `openai:gpt-4o-mini`.
+`<provider>:<model>`. The default is `openai:gpt-5` with medium reasoning effort.
 
 System prompts are assembled from modular markdown components located in the
 `prompts/` directory. Use `--prompt-dir` to point at an alternate component
@@ -177,10 +177,11 @@ contains items with identifiers, names, and descriptions. These lists are
 injected into mapping prompts so that features can be matched against consistent
 options. Mapping prompts run separately for information, applications and
 technologies to keep each decision focused. All application configuration is
-stored in `config/app.json`; mapping types and their associated datasets live
-under the `mapping_types` section, allowing new categories to be added without
-code changes. Plateau name to level associations are defined in the
-`plateau_map` section of the same file.
+stored in `config/app.json`; the chat model and any reasoning parameters live
+at the top level, while mapping types and their associated datasets live under
+the `mapping_types` section, allowing new categories to be added without code
+changes. Plateau name to level associations are defined in the `plateau_map`
+section of the same file.
 
 ## Prompt examples
 

--- a/config/app.json
+++ b/config/app.json
@@ -1,5 +1,8 @@
 {
-  "model": "openai:gpt-4o-mini",
+  "model": "openai:gpt-5",
+  "reasoning": {
+    "effort": "medium"
+  },
   "log_level": "INFO",
   "mapping_types": {
     "data": {

--- a/src/cli.py
+++ b/src/cli.py
@@ -72,7 +72,12 @@ async def _cmd_generate_ambitions(args: argparse.Namespace, settings) -> None:
     model_name = args.model or settings.model
     logger.info("Generating ambitions using model %s", model_name)
 
-    model = build_model(model_name, settings.openai_api_key, seed=args.seed)
+    model = build_model(
+        model_name,
+        settings.openai_api_key,
+        seed=args.seed,
+        reasoning=settings.reasoning,
+    )
     concurrency = args.concurrency or settings.concurrency
     generator = ServiceAmbitionGenerator(
         model,
@@ -142,7 +147,12 @@ async def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
 
     # Allow CLI model override, defaulting to configured model
     model_name = args.model or settings.model
-    model = build_model(model_name, settings.openai_api_key, seed=args.seed)
+    model = build_model(
+        model_name,
+        settings.openai_api_key,
+        seed=args.seed,
+        reasoning=settings.reasoning,
+    )
 
     # Load and assemble the system prompt so each conversation begins with
     # the situational context, definitions and inspirations.

--- a/src/models.py
+++ b/src/models.py
@@ -161,13 +161,33 @@ class MappingTypeConfig(StrictModel):
     ]
 
 
+class ReasoningConfig(StrictModel):
+    """Optional reasoning parameters for OpenAI models.
+
+    Fields are mapped to the ``openai_reasoning_*`` settings when constructing
+    the model. Unknown keys are allowed so additional parameters can be
+    provided without code changes.
+    """
+
+    effort: str | None = Field(
+        None, description="Effort level for OpenAI reasoning tasks."
+    )
+    summary: str | None = Field(None, description="Summary style for reasoning traces.")
+
+    # Permit other reasoning settings that may be added by OpenAI.
+    model_config = ConfigDict(extra="allow")
+
+
 class AppConfig(StrictModel):
     """Top-level application configuration controlling generation behaviour."""
 
     model: Annotated[
         str,
         Field(min_length=1, description="Chat model in '<provider>:<model>' format."),
-    ] = "openai:gpt-4o-mini"
+    ] = "openai:gpt-5"
+    reasoning: ReasoningConfig | None = Field(
+        None, description="Optional reasoning configuration for the model."
+    )
     log_level: Annotated[
         str, Field(min_length=1, description="Logging verbosity level.")
     ] = "INFO"
@@ -362,6 +382,7 @@ __all__ = [
     "PlateauFeaturesResponse",
     "MappingFeature",
     "AppConfig",
+    "ReasoningConfig",
     "MappingItem",
     "MappingTypeConfig",
     "MappingResponse",

--- a/src/settings.py
+++ b/src/settings.py
@@ -14,12 +14,16 @@ from pydantic import Field, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from loader import load_app_config
+from models import ReasoningConfig
 
 
 class Settings(BaseSettings):
     """Application settings combining file-based and environment configuration."""
 
     model: str = Field(..., description="Chat model in '<provider>:<model>' format.")
+    reasoning: ReasoningConfig | None = Field(
+        None, description="Optional reasoning configuration for the model."
+    )
     log_level: str = Field(..., description="Logging verbosity level.")
     prompt_dir: Path = Field(..., description="Directory containing prompt components.")
     context_id: str = Field(..., description="Situational context identifier.")
@@ -64,6 +68,7 @@ def load_settings() -> Settings:
     config = load_app_config()
     data = {
         "model": config.model,
+        "reasoning": config.reasoning,
         "log_level": config.log_level,
         "prompt_dir": config.prompt_dir,
         "context_id": config.context_id,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,7 @@ def test_cli_generates_output(tmp_path, monkeypatch):
         batch_size=5,
         openai_api_key="dummy",
         logfire_token=None,
+        reasoning=None,
     )
 
     async def fake_process_service(self, service, prompt=None):
@@ -99,6 +100,7 @@ def test_cli_dry_run_skips_processing(tmp_path, monkeypatch):
         batch_size=5,
         openai_api_key="dummy",
         logfire_token=None,
+        reasoning=None,
     )
 
     called = {"ran": False}
@@ -160,6 +162,7 @@ def test_cli_switches_context(tmp_path, monkeypatch):
         batch_size=5,
         openai_api_key="dummy",
         logfire_token=None,
+        reasoning=None,
     )
 
     async def fake_process_service(self, service, prompt=None):
@@ -212,11 +215,12 @@ def test_cli_model_instantiation_arguments(tmp_path, monkeypatch):
         batch_size=5,
         openai_api_key="dummy",
         logfire_token=None,
+        reasoning=None,
     )
 
     captured: dict[str, str] = {}
 
-    def fake_build_model(model_name: str, api_key: str, *, seed=None):
+    def fake_build_model(model_name: str, api_key: str, *, seed=None, reasoning=None):
         captured["model"] = model_name
         captured["api_key"] = api_key
         captured["seed"] = seed
@@ -275,11 +279,12 @@ def test_cli_seed_sets_random(tmp_path, monkeypatch):
         batch_size=5,
         openai_api_key="dummy",
         logfire_token=None,
+        reasoning=None,
     )
 
     captured: dict[str, int | None] = {}
 
-    def fake_build_model(model_name: str, api_key: str, *, seed=None):
+    def fake_build_model(model_name: str, api_key: str, *, seed=None, reasoning=None):
         captured["seed"] = seed
         return "test"
 
@@ -336,6 +341,7 @@ def test_cli_enables_logfire(tmp_path, monkeypatch):
         batch_size=5,
         openai_api_key="dummy",
         logfire_token="lf-key",
+        reasoning=None,
     )
 
     async def fake_process_service(self, service, prompt=None):
@@ -401,6 +407,7 @@ def test_cli_rejects_invalid_concurrency(monkeypatch):
         batch_size=5,
         openai_api_key="dummy",
         logfire_token=None,
+        reasoning=None,
     )
     monkeypatch.setattr(cli, "load_settings", lambda: settings)
 
@@ -445,6 +452,7 @@ def test_cli_verbose_logging(tmp_path, monkeypatch, capsys):
         batch_size=5,
         openai_api_key="dummy",
         logfire_token=None,
+        reasoning=None,
     )
 
     async def fake_process_service(self, service, prompt=None):
@@ -503,6 +511,7 @@ def test_cli_resume_skips_processed(tmp_path, monkeypatch):
         concurrency=1,
         openai_api_key="dummy",
         logfire_token=None,
+        reasoning=None,
     )
 
     processed: list[str] = []

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -29,7 +29,11 @@ async def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
     )
 
     def fake_build_model(
-        model_name: str, api_key: str, *, seed: int | None = None
+        model_name: str,
+        api_key: str,
+        *,
+        seed: int | None = None,
+        reasoning=None,
     ) -> object:  # pragma: no cover - stub
         return object()
 
@@ -59,6 +63,7 @@ async def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
         prompt_dir="prompts",
         context_id="university",
         inspiration="general",
+        reasoning=None,
     )
     args = argparse.Namespace(
         input_file=str(input_path),
@@ -104,7 +109,11 @@ async def test_generate_evolution_uses_agent_model(tmp_path, monkeypatch) -> Non
     captured: dict[str, object] = {}
 
     def fake_build_model(
-        model_name: str, api_key: str, *, seed: int | None = None
+        model_name: str,
+        api_key: str,
+        *,
+        seed: int | None = None,
+        reasoning=None,
     ) -> object:
         captured["model_name"] = model_name
         captured["api_key"] = api_key
@@ -139,6 +148,7 @@ async def test_generate_evolution_uses_agent_model(tmp_path, monkeypatch) -> Non
         prompt_dir="prompts",
         context_id="ctx",
         inspiration="insp",
+        reasoning=None,
     )
     args = argparse.Namespace(
         input_file=str(input_path),
@@ -187,7 +197,11 @@ async def test_generate_evolution_respects_concurrency(tmp_path, monkeypatch) ->
             self.instructions = instructions
 
     def fake_build_model(
-        model_name: str, api_key: str, *, seed: int | None = None
+        model_name: str,
+        api_key: str,
+        *,
+        seed: int | None = None,
+        reasoning=None,
     ) -> object:  # pragma: no cover - stub
         return object()
 
@@ -227,6 +241,7 @@ async def test_generate_evolution_respects_concurrency(tmp_path, monkeypatch) ->
         prompt_dir="prompts",
         context_id="ctx",
         inspiration="insp",
+        reasoning=None,
     )
     args = argparse.Namespace(
         input_file=str(input_path),
@@ -255,7 +270,11 @@ async def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
     input_path.write_text('{"service_id": "s1", "name": "svc"}\n', encoding="utf-8")
 
     def fake_build_model(
-        model_name: str, api_key: str, *, seed: int | None = None
+        model_name: str,
+        api_key: str,
+        *,
+        seed: int | None = None,
+        reasoning=None,
     ) -> object:  # pragma: no cover - stub
         return object()
 
@@ -290,6 +309,7 @@ async def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
         prompt_dir="prompts",
         context_id="ctx",
         inspiration="insp",
+        reasoning=None,
     )
     args = argparse.Namespace(
         input_file=str(input_path),
@@ -326,7 +346,11 @@ async def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:
     (tmp_path / "processed_ids.txt").write_text("s1\n", encoding="utf-8")
 
     def fake_build_model(
-        model_name: str, api_key: str, *, seed: int | None = None
+        model_name: str,
+        api_key: str,
+        *,
+        seed: int | None = None,
+        reasoning=None,
     ) -> object:
         return object()
 
@@ -361,6 +385,7 @@ async def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:
         prompt_dir="prompts",
         context_id="ctx",
         inspiration="insp",
+        reasoning=None,
     )
     args = argparse.Namespace(
         input_file=str(input_path),

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -175,3 +175,17 @@ def test_load_app_config(tmp_path):
     config = load_app_config(str(base))
     assert "beta" in config.mapping_types
     assert config.plateau_map["Foundational"] == 1
+
+
+def test_load_app_config_reasoning(tmp_path):
+    base = tmp_path / "config"
+    base.mkdir()
+    (base / "app.json").write_text(
+        '{"reasoning": {"effort": "high", "summary": "detailed"}}',
+        encoding="utf-8",
+    )
+    load_app_config.cache_clear()
+    config = load_app_config(str(base))
+    assert config.reasoning is not None
+    assert config.reasoning.effort == "high"
+    assert config.reasoning.summary == "detailed"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -16,11 +16,13 @@ def test_load_settings_reads_env(monkeypatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "token")
     settings = load_settings()
     assert settings.openai_api_key == "token"
-    assert settings.model == "openai:gpt-4o-mini"
+    assert settings.model == "openai:gpt-5"
     assert settings.log_level == "INFO"
     assert settings.request_timeout == 60
     assert settings.retries == 5
     assert settings.retry_base_delay == 0.5
+    assert settings.reasoning is not None
+    assert settings.reasoning.effort == "medium"
 
 
 def test_load_settings_requires_key(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- allow reasoning parameters to be configured in `config/app.json`
- pass configured reasoning options through settings to model builder
- document reasoning settings and add tests for configuration loading
- default to `openai:gpt-5` with medium reasoning effort

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'logfire', 'pydantic_ai', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689974726814832b9e3fc27a3b496be7