### PR TITLE
Refactor prompt loading to use shared helpers

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -20,8 +20,9 @@ from conversation import ConversationSession
 from generator import ServiceAmbitionGenerator, build_model
 from loader import (
     configure_prompt_dir,
-    load_plateau_definitions,
     load_ambition_prompt,
+    load_evolution_prompt,
+    load_plateau_definitions,
     load_services,
 )
 from models import ServiceInput

--- a/src/generator.py
+++ b/src/generator.py
@@ -359,15 +359,15 @@ def build_model(
     # Allow callers to pass provider-prefixed names such as ``openai:gpt-4``.
     model_name = model_name.split(":", 1)[-1]
     extra = {"seed": seed} if seed is not None else {}
-    settings_kwargs: dict[str, object] = {
+    settings_kwargs: dict[str, Any] = {
         "openai_builtin_tools": [{"type": "web_search_preview"}],
-        **extra,  # type: ignore[typeddict-item]
+        **extra,
     }
     if reasoning:
         # Map each reasoning field to the ``openai_reasoning_*`` parameter.
         for key, value in reasoning.model_dump(exclude_none=True).items():
             settings_kwargs[f"openai_reasoning_{key}"] = value
-    settings = OpenAIResponsesModelSettings(**settings_kwargs)
+    settings = OpenAIResponsesModelSettings(**settings_kwargs)  # type: ignore[typeddict-item]
     return OpenAIResponsesModel(model_name, settings=settings)
 
 


### PR DESCRIPTION
## Summary
- generate service feature plateau text from JSON definitions
- centralize prompt file access via `load_prompt_text`
- align CLI imports and type hints

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(failed: SSL: CERTIFICATE_VERIFY_FAILED)*
- `poetry run pytest` *(failed: TypeError: '_GeneratorContextManager' object is not iterable)*

------
https://chatgpt.com/codex/tasks/task_e_689989d1142c832bb521d869dfe3b5ba