### PR TITLE
Fix static method instrumentation

### DIFF
--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -130,8 +130,8 @@ class PlateauGenerator:
             schema=str(schema),
         )
 
-    @logfire.instrument()
     @staticmethod
+    @logfire.instrument()
     def _parse_feature_payload(response: str) -> PlateauFeaturesResponse:
         """Return validated plateau feature details."""
 


### PR DESCRIPTION
## Summary
- ensure logfire instrumentation works on static `_parse_feature_payload`

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_6899913826a0832b97deb011057d27bd