### PR TITLE
Handle nested mapping structures from agent responses

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -354,7 +354,15 @@ class MappingFeature(StrictModel):
         """
         mapping: dict[str, object] = {}
         for key in list(data.keys()):
-            if key != "feature_id":
+            if key == "feature_id":
+                # Preserve the identifying field untouched.
+                continue
+            if key == "mappings" and isinstance(data[key], dict):
+                # Merge pre-nested mapping structures produced by some agents
+                # rather than nesting the ``mappings`` key within itself.
+                mapping.update(data.pop(key))
+            else:
+                # Collect any other keys as mapping types.
                 mapping[key] = data.pop(key)
         data["mappings"] = mapping
         return data

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 
 from models import (  # noqa: E402  pylint: disable=wrong-import-position
     Contribution,
+    MappingResponse,
     PlateauFeature,
     PlateauResult,
     ServiceEvolution,
@@ -63,3 +64,21 @@ def test_contribution_requires_fields() -> None:
     """Missing fields should trigger a ``ValidationError``."""
     with pytest.raises(ValidationError):
         Contribution()  # type: ignore[call-arg]
+
+
+def test_mapping_response_handles_nested_mappings() -> None:
+    """Nested ``mappings`` keys should be flattened into the mappings field."""
+    payload = {
+        "features": [
+            {
+                "feature_id": "f1",
+                "mappings": {
+                    "data": [{"item": "INF-1", "contribution": "c"}],
+                },
+            }
+        ]
+    }
+
+    result = MappingResponse.model_validate(payload)
+
+    assert result.features[0].mappings["data"][0].item == "INF-1"


### PR DESCRIPTION
## Summary
- flatten `mappings` keys in `MappingFeature` to accept nested mapping structures
- test `MappingResponse` parsing of nested mapping payloads

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(command not found: bandit)*
- `poetry run pip-audit` *(command not found: pip-audit)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68999bfd3b84832bb07d5ab2738d0b06