### PR TITLE
fix: flatten nested mapping responses

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -357,13 +357,20 @@ class MappingFeature(StrictModel):
             if key == "feature_id":
                 # Preserve the identifying field untouched.
                 continue
-            if key == "mappings" and isinstance(data[key], dict):
-                # Merge pre-nested mapping structures produced by some agents
-                # rather than nesting the ``mappings`` key within itself.
-                mapping.update(data.pop(key))
-            else:
-                # Collect any other keys as mapping types.
-                mapping[key] = data.pop(key)
+            value = data.pop(key)
+            if key == "mappings" and isinstance(value, dict):
+                # Some agents nest mapping information under an extra "mappings"
+                # key. Flatten that structure when encountered.
+                nested = value.get("mappings")
+                if isinstance(nested, dict):
+                    # Drop the redundant layer and merge into the mapping.
+                    mapping.update(nested)
+                    continue
+                # Otherwise merge the mapping dictionary directly.
+                mapping.update(value)
+                continue
+            # Collect any other keys as mapping types.
+            mapping[key] = value
         data["mappings"] = mapping
         return data
 

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -156,6 +156,61 @@ async def test_map_feature_rejects_invalid_json(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_map_feature_flattens_nested_mappings(monkeypatch) -> None:
+    template = "{mapping_labels} {mapping_sections} {mapping_fields} {features}"
+
+    def fake_loader(name, *_, **__):
+        return template
+
+    monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
+    monkeypatch.setattr(
+        "mapping.load_mapping_items",
+        lambda types, *a, **k: {
+            "information": [MappingItem(id="INF-1", name="User Data", description="d")],
+            "applications": [MappingItem(id="APP-1", name="App", description="d")],
+            "technologies": [MappingItem(id="TEC-1", name="Tech", description="d")],
+        },
+    )
+    session = DummySession(
+        [
+            json.dumps(
+                {
+                    "features": [
+                        {
+                            "feature_id": "f1",
+                            "mappings": {
+                                "mappings": {
+                                    "data": [{"item": "INF-1", "contribution": "c"}],
+                                    "applications": [
+                                        {"item": "APP-1", "contribution": "c"}
+                                    ],
+                                    "technology": [
+                                        {"item": "TEC-1", "contribution": "c"}
+                                    ],
+                                }
+                            },
+                        }
+                    ]
+                }
+            )
+        ]
+    )
+    feature = PlateauFeature(
+        feature_id="f1",
+        name="Integration",
+        description="Allows external access",
+        score=0.5,
+        customer_type="learners",
+    )
+
+    result = await map_feature(session, feature)  # type: ignore[arg-type]
+
+    assert result.mappings["data"][0].item == "INF-1"
+    assert result.mappings["applications"][0].item == "APP-1"
+    assert result.mappings["technology"][0].item == "TEC-1"
+
+
+@pytest.mark.asyncio
 async def test_map_features_returns_mappings(monkeypatch) -> None:
     template = "{mapping_labels} {mapping_sections} {mapping_fields} {features}"
 


### PR DESCRIPTION
## Summary
- flatten nested mapping responses when agent nests mappings under extra key
- add regression test covering nested mappings

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*
- `poetry run pytest tests/test_mapping.py` *(fails: ModuleNotFoundError: No module named 'logfire')*

------
https://chatgpt.com/codex/tasks/task_e_6899a0d51af8832b935c369b6c8747d6