### PR TITLE
Refactor feature mapping to iterate per type

### DIFF
--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -52,12 +52,30 @@ async def test_map_feature_returns_mappings(monkeypatch) -> None:
                         {
                             "feature_id": "f1",
                             "data": [{"item": "INF-1", "contribution": "c"}],
+                        }
+                    ]
+                }
+            ),
+            json.dumps(
+                {
+                    "features": [
+                        {
+                            "feature_id": "f1",
                             "applications": [{"item": "APP-1", "contribution": "c"}],
+                        }
+                    ]
+                }
+            ),
+            json.dumps(
+                {
+                    "features": [
+                        {
+                            "feature_id": "f1",
                             "technology": [{"item": "TEC-1", "contribution": "c"}],
                         }
                     ]
                 }
-            )
+            ),
         ]
     )
     feature = PlateauFeature(
@@ -104,12 +122,30 @@ async def test_map_feature_injects_reference_data(monkeypatch) -> None:
                         {
                             "feature_id": "f1",
                             "data": [{"item": "INF-1", "contribution": "c"}],
+                        }
+                    ]
+                }
+            ),
+            json.dumps(
+                {
+                    "features": [
+                        {
+                            "feature_id": "f1",
                             "applications": [{"item": "APP-1", "contribution": "c"}],
+                        }
+                    ]
+                }
+            ),
+            json.dumps(
+                {
+                    "features": [
+                        {
+                            "feature_id": "f1",
                             "technology": [{"item": "TEC-1", "contribution": "c"}],
                         }
                     ]
                 }
-            )
+            ),
         ]
     )
     feature = PlateauFeature(
@@ -121,10 +157,10 @@ async def test_map_feature_injects_reference_data(monkeypatch) -> None:
     )
     await map_feature(session, feature)  # type: ignore[arg-type]
 
-    assert len(session.prompts) == 1
+    assert len(session.prompts) == 3
     assert "User Data" in session.prompts[0]
-    assert "Learning Platform" in session.prompts[0]
-    assert "AI Engine" in session.prompts[0]
+    assert "Learning Platform" in session.prompts[1]
+    assert "AI Engine" in session.prompts[2]
 
 
 @pytest.mark.asyncio
@@ -180,12 +216,30 @@ async def test_map_features_returns_mappings(monkeypatch) -> None:
                         {
                             "feature_id": "f1",
                             "data": [{"item": "INF-1", "contribution": "c"}],
+                        }
+                    ]
+                }
+            ),
+            json.dumps(
+                {
+                    "features": [
+                        {
+                            "feature_id": "f1",
                             "applications": [{"item": "APP-1", "contribution": "c"}],
+                        }
+                    ]
+                }
+            ),
+            json.dumps(
+                {
+                    "features": [
+                        {
+                            "feature_id": "f1",
                             "technology": [{"item": "TEC-1", "contribution": "c"}],
                         }
                     ]
                 }
-            )
+            ),
         ]
     )
     feature = PlateauFeature(
@@ -200,6 +254,8 @@ async def test_map_features_returns_mappings(monkeypatch) -> None:
 
     assert result[0].mappings["data"][0].item == "INF-1"
     assert "User Data" in session.prompts[0]
+    assert "App" in session.prompts[1]
+    assert "Tech" in session.prompts[2]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- iterate plateau feature mapping over each mapping type individually
- update mapping tests to expect separate prompts per type

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: missing library stubs for openai, logfire, pydantic_ai, etc.)*
- `bandit -r src -ll`
- `pip-audit` *(fails: certificate verify failed)*
- `pytest tests/test_mapping.py`


------
https://chatgpt.com/codex/tasks/task_e_6899a1867dd0832b8a29290503a17837