### PR TITLE
Handle nested mapping key duplicates

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -369,6 +369,14 @@ class MappingFeature(StrictModel):
                 # Otherwise merge the mapping dictionary directly.
                 mapping.update(value)
                 continue
+            if isinstance(value, dict):
+                # Some agents repeat the mapping type key and nest the actual
+                # list within it, e.g. {"applications": {"applications": [...]}}.
+                # Flatten this structure by extracting the inner list.
+                nested = value.get(key)
+                if isinstance(nested, list):
+                    mapping[key] = nested
+                    continue
             # Collect any other keys as mapping types.
             mapping[key] = value
         data["mappings"] = mapping

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -82,3 +82,21 @@ def test_mapping_response_handles_nested_mappings() -> None:
     result = MappingResponse.model_validate(payload)
 
     assert result.features[0].mappings["data"][0].item == "INF-1"
+
+
+def test_mapping_response_flattens_duplicate_keys() -> None:
+    """Duplicate mapping type keys should flatten to the inner list."""
+    payload = {
+        "features": [
+            {
+                "feature_id": "f1",
+                "applications": {
+                    "applications": [{"item": "APP-1", "contribution": "c"}]
+                },
+            }
+        ]
+    }
+
+    result = MappingResponse.model_validate(payload)
+
+    assert result.features[0].mappings["applications"][0].item == "APP-1"


### PR DESCRIPTION
## Summary
- flatten mapping responses that repeat the mapping type key
- test flattening of duplicate mapping keys

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLError: CERTIFICATE_VERIFY_FAILED)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'logfire')*


------
https://chatgpt.com/codex/tasks/task_e_6899c4cb95c8832ba7168b8e7def7fe4