### PR TITLE
Default logging to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ entries from this file.
 Use the `generate-evolution` subcommand to score each service against all
 configured plateau features and customer segments. It reads services from an
 input JSON Lines file and writes a `ServiceEvolution` record for each line in
-the output file. Enable verbose logs with `-v` or `-vv`.
+the output file. Logs are written to `service.log` in the current working
+directory. Enable verbose logs with `-v` or `-vv`.
 
 Basic invocation:
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -26,7 +26,7 @@ from loader import (
     load_services,
 )
 from models import ServiceInput
-from monitoring import init_logfire
+from monitoring import LOG_FILE_NAME, init_logfire
 from persistence import atomic_write, read_lines
 from plateau_generator import PlateauGenerator
 from settings import load_settings
@@ -55,7 +55,9 @@ def _configure_logging(args: argparse.Namespace, settings) -> None:
         level_name = "DEBUG"
 
     logging.basicConfig(
-        level=getattr(logging, level_name.upper(), logging.INFO), force=True
+        filename=LOG_FILE_NAME,
+        level=getattr(logging, level_name.upper(), logging.INFO),
+        force=True,
     )
     if settings.logfire_token:
         # Initialize logfire only when a token is configured

--- a/src/monitoring.py
+++ b/src/monitoring.py
@@ -15,6 +15,9 @@ import os
 
 logger = logging.getLogger(__name__)
 
+# Default log file used across the application
+LOG_FILE_NAME = "service.log"
+
 
 class JsonFormatter(logging.Formatter):
     """Simple structured logging formatter."""
@@ -32,7 +35,7 @@ def _configure_json_logging(level: int) -> None:
     """Attach a JSON formatter to the root logger."""
 
     root_logger = logging.getLogger()
-    handler = logging.StreamHandler()
+    handler = logging.FileHandler(LOG_FILE_NAME)
     handler.setLevel(level)
     handler.setFormatter(JsonFormatter())
     root_logger.handlers.clear()

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -185,10 +185,10 @@ class PlateauGenerator:
             plateau_name: Human readable name of the plateau.
 
         The function requests a plateau-specific service description and a list
-        of features for learners, academics and professional staff. Responses must contain at
-        least ``required_count`` features for each customer type. Raw features
-        are converted to :class:`PlateauFeature` objects and enriched using
-        :func:`map_features` before being returned as part of a
+        of features for learners, academics and professional staff. Responses
+        must contain at least ``required_count`` features for each customer
+        type. Raw features are converted to :class:`PlateauFeature` objects and
+        enriched using :func:`map_features` before being returned as part of a
         :class:`PlateauResult`. A :class:`ValueError` is raised if the agent
         returns invalid JSON or an insufficient number of features.
         """

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -61,15 +61,17 @@ def test_init_logfire_replaces_root_handlers(monkeypatch):
     root_logger.handlers.clear()
 
 
-def test_init_logfire_uses_json_fallback(monkeypatch, capsys):
+def test_init_logfire_uses_json_fallback(tmp_path, monkeypatch):
     root_logger = logging.getLogger()
     root_logger.handlers.clear()
     root_logger.setLevel(logging.INFO)
     monkeypatch.delenv("LOGFIRE_TOKEN", raising=False)
+    monkeypatch.chdir(tmp_path)
 
     monitoring.init_logfire()
     logging.getLogger().info("hello")
-    output = capsys.readouterr().err.strip()
-    assert json.loads(output)["message"] == "hello"
+    logging.getLogger().handlers[0].flush()
+    with open(monitoring.LOG_FILE_NAME, encoding="utf-8") as fh:
+        assert json.loads(fh.read())["message"] == "hello"
 
     root_logger.handlers.clear()


### PR DESCRIPTION
## Summary
- write logs to `service.log` instead of stderr
- adjust CLI and monitoring tests for file-based logging
- document new log location

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing src/cli.py src/monitoring.py src/plateau_generator.py tests/test_cli.py tests/test_monitoring.py`
- `poetry run ruff check --fix src/cli.py src/monitoring.py src/plateau_generator.py tests/test_cli.py tests/test_monitoring.py`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL certificate verify failed)*
- `poetry run pytest` *(fails: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6899edec6268832bb5572345745edd06