### PR TITLE
fix: handle nested mapping structures

### DIFF
--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -247,6 +247,67 @@ async def test_map_feature_flattens_nested_mappings(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_map_feature_flattens_repeated_mapping_keys(monkeypatch) -> None:
+    template = "{mapping_labels} {mapping_sections} {mapping_fields} {features}"
+
+    def fake_loader(name, *_, **__):
+        return template
+
+    monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
+    monkeypatch.setattr(
+        "mapping.load_mapping_items",
+        lambda types, *a, **k: {
+            "information": [MappingItem(id="INF-1", name="User Data", description="d")],
+            "applications": [MappingItem(id="APP-1", name="App", description="d")],
+            "technologies": [MappingItem(id="TEC-1", name="Tech", description="d")],
+        },
+    )
+    session = DummySession(
+        [
+            json.dumps(
+                {
+                    "features": [
+                        {
+                            "feature_id": "f1",
+                            "mappings": {
+                                "data": {
+                                    "data": [{"item": "INF-1", "contribution": "c"}]
+                                },
+                                "applications": {
+                                    "applications": [
+                                        {"item": "APP-1", "contribution": "c"}
+                                    ]
+                                },
+                                "technology": {
+                                    "mappings": {
+                                        "technology": [
+                                            {"item": "TEC-1", "contribution": "c"}
+                                        ]
+                                    }
+                                },
+                            },
+                        }
+                    ]
+                }
+            )
+        ]
+    )
+    feature = PlateauFeature(
+        feature_id="f1",
+        name="Integration",
+        description="Allows external access",
+        score=0.5,
+        customer_type="learners",
+    )
+
+    result = await map_feature(session, feature)  # type: ignore[arg-type]
+
+    assert result.mappings["data"][0].item == "INF-1"
+    assert result.mappings["applications"][0].item == "APP-1"
+    assert result.mappings["technology"][0].item == "TEC-1"
+
+
+@pytest.mark.asyncio
 async def test_map_features_returns_mappings(monkeypatch) -> None:
     template = "{mapping_labels} {mapping_sections} {mapping_fields} {features}"
 


### PR DESCRIPTION
## Summary
- normalise mapping responses that repeat mapping type keys
- cover nested mapping scenarios with tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing src/models.py tests/test_mapping.py`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(command not found: bandit)*
- `poetry run pip-audit` *(command not found: pip-audit)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6899f9d39e44832bbebaaa5ca7d15a3f