### PR TITLE
feat: embed service description in plateau prompt

### DIFF
--- a/prompts/plateau_prompt.md
+++ b/prompts/plateau_prompt.md
@@ -2,6 +2,9 @@
 
 Generate service features for the {service_name} service at plateau {plateau}.
 
+## Service description (for reference; do not repeat verbatim)
+{service_description}
+
 ## Instructions
 
 - Reference the situational context, definitions and inspirations to maintain consistent terminology.


### PR DESCRIPTION
## Summary
- embed service description reference block into plateau feature generation prompt to ground outputs and reduce chat drift

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL certificate verify failed)*
- `poetry run pytest` *(fails: TypeError: unsupported operand type(s) for /: 'str' and 'str'; async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_689a6ef1fda4832ba011d83693d909d6