### PR TITLE
docs: enforce strict JSON responses

### DIFF
--- a/prompts/description_prompt.md
+++ b/prompts/description_prompt.md
@@ -16,6 +16,8 @@ Provide a description of the service at plateau {plateau}.
 - Return a JSON object containing only a `description` field.
 - `description` must be a non-empty string explaining the service at plateau {plateau}.
 - Do not include any text outside the JSON object.
+- Return ONLY valid JSON. No Markdown. No backticks. No commentary. No trailing commas.
+- If you are about to include any text outside JSON, stop and return JSON only.
 - The response must adhere to the JSON schema provided below.
 
 ## Response structure

--- a/prompts/plateau_prompt.md
+++ b/prompts/plateau_prompt.md
@@ -20,6 +20,8 @@ Generate service features for the {service_name} service at plateau {plateau}.
     - "description": explanation of the feature.
     - "score": floating-point maturity between 0 and 1.
 - Do not include any text outside the JSON object.
+- Return ONLY valid JSON. No Markdown. No backticks. No commentary. No trailing commas.
+- If you are about to include any text outside JSON, stop and return JSON only.
 - The response must adhere to the JSON schema provided below.
 
 ## Response structure


### PR DESCRIPTION
## Summary
- enforce stricter JSON-only output requirements in description and plateau prompts

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_689a6f0941a8832b9bbdd3f70432b65d