### PR TITLE
Clarify feature ID format and uniqueness in plateau prompt

### DIFF
--- a/prompts/plateau_prompt.md
+++ b/prompts/plateau_prompt.md
@@ -16,6 +16,8 @@ Generate service features for the {service_name} service at plateau {plateau}.
 - Each key must map to an array containing at least {required_count} feature objects.
 - Every feature must provide:
     - "feature_id": unique string identifier.
+        - Format: "FEAT-{plateau}-{segment}-{kebab-case-short-name}" (e.g., FEAT-2-learners-smart-enrolment).
+        - Ensure IDs are unique across all segments in this response.
     - "name": short feature title.
     - "description": explanation of the feature.
     - "score": floating-point maturity between 0 and 1.


### PR DESCRIPTION
## Summary
- Specify feature_id format FEAT-{plateau}-{segment}-{kebab-case-short-name}
- Instruct generator to keep feature IDs unique across all segments

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_689a6f1d9498832b9fc9a957774e6000