### PR TITLE
feat: add north star role to system prompts

### DIFF
--- a/src/loader.py
+++ b/src/loader.py
@@ -30,6 +30,14 @@ logger = logging.getLogger(__name__)
 # to alternative directories via ``configure_prompt_dir``.
 PROMPT_DIR = Path("prompts")
 
+# Core role statement for all system prompts. This line anchors the model's
+# objective before any contextual material is provided.
+NORTH_STAR = (
+    "You are the world's leading service designer and enterprise architect; your"
+    " job is to produce strictly-valid JSON structured outputs aligned to the"
+    " schema."
+)
+
 
 def configure_prompt_dir(path: Path | str) -> None:
     """Set the base directory for prompt templates.
@@ -306,6 +314,7 @@ def load_evolution_prompt(
 
     directory = base_dir or PROMPT_DIR
     components = [
+        NORTH_STAR,
         load_prompt_text(f"situational_context/{context_id}", directory),
         load_plateau_text(plateaus_dir, plateaus_file),
         load_definitions(definitions_dir, definitions_file, definition_keys),
@@ -354,6 +363,7 @@ def load_ambition_prompt(
 
     directory = base_dir or PROMPT_DIR
     components = [
+        NORTH_STAR,
         load_prompt_text(f"situational_context/{context_id}", directory),
         load_plateau_text(plateaus_dir, plateaus_file),
         load_definitions(definitions_dir, definitions_file, definition_keys),

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import pytest
 
 from loader import (
+    NORTH_STAR,
+    load_ambition_prompt,
     load_app_config,
     load_mapping_type_config,
     load_plateau_definitions,
@@ -43,7 +45,10 @@ def test_load_prompt_assembles_components(tmp_path):
         plateaus_dir=str(data_dir),
     )
     expected = (
-        "ctx\n\n## Service feature plateaus\n\n1. **Alpha**: plat\n\n## Defs\n\n1."
+        "You are the world's leading service designer and enterprise architect; your"
+        " job is to produce strictly-valid JSON structured outputs aligned to the"
+        " schema."
+        "\n\nctx\n\n## Service feature plateaus\n\n1. **Alpha**: plat\n\n## Defs\n\n1."
         " **d1**: defs\n2. **d2**: extra\n\ninsp\n\ntask\n\nresp"
     )
     assert prompt == expected
@@ -96,10 +101,41 @@ def test_load_prompt_with_definition_keys(tmp_path):
         plateaus_dir=str(data_dir),
     )
     expected = (
-        "ctx\n\n## Service feature plateaus\n\n"
+        "You are the world's leading service designer and enterprise architect; your"
+        " job is to produce strictly-valid JSON structured outputs aligned to the"
+        " schema."
+        "\n\nctx\n\n## Service feature plateaus\n\n"
         "1. **Alpha**: plat\n\n## Defs\n\n1. **d2**: defs2\n\ninsp\n\ntask\n\nresp"
     )
     assert prompt == expected
+
+
+def test_load_ambition_prompt_includes_north_star(tmp_path):
+    prompts_dir = tmp_path / "prompts"
+    data_dir = tmp_path / "data"
+    (prompts_dir / "situational_context").mkdir(parents=True)
+    (prompts_dir / "inspirations").mkdir(parents=True)
+    (prompts_dir / "situational_context" / "ctx.md").write_text("ctx", encoding="utf-8")
+    (prompts_dir / "inspirations" / "insp.md").write_text("insp", encoding="utf-8")
+    (prompts_dir / "task_definition.md").write_text("task", encoding="utf-8")
+    (prompts_dir / "response_structure.md").write_text("resp", encoding="utf-8")
+    data_dir.mkdir()
+    (data_dir / "definitions.json").write_text(
+        '{"title": "Defs", "bullets": [{"name": "d1", "description": "defs"}]}',
+        encoding="utf-8",
+    )
+    (data_dir / "service_feature_plateaus.json").write_text(
+        '[{"id": "P1", "name": "Alpha", "description": "plat"}]',
+        encoding="utf-8",
+    )
+    prompt = load_ambition_prompt(
+        "ctx",
+        "insp",
+        base_dir=str(prompts_dir),
+        definitions_dir=str(data_dir),
+        plateaus_dir=str(data_dir),
+    )
+    assert prompt.startswith(NORTH_STAR)
 
 
 def test_load_prompt_text_plateau(tmp_path):


### PR DESCRIPTION
## Summary
- add NORTH_STAR role line to all generated system prompts
- verify inclusion with new loader tests
- generalize role to the world's leading service designer and enterprise architect

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry install --no-root` *(fails: All attempts to connect to pypi.org failed)*
- `poetry run mypy .` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'logfire')*

------
https://chatgpt.com/codex/tasks/task_e_689a6f744c70832b8cc8fe6e1bd5d5a6