### PR TITLE
feat: parse CMMI maturity scores

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,11 @@ Each JSON line in the output file follows the `ServiceEvolution` schema:
           "feature_id": "string",
           "name": "string",
           "description": "string",
-          "score": 0.0,
+          "score": {
+            "level": 3,
+            "label": "Defined",
+            "justification": "string"
+          },
           "customer_type": "string",
           "data": [{ "item": "string", "contribution": "string" }],
           "applications": [{ "item": "string", "contribution": "string" }],
@@ -165,7 +169,7 @@ Fields in the schema:
     - `service_description`: narrative for the service at that plateau.
     - `features`: list of `PlateauFeature` entries with:
         - `feature_id`, `name`, and `description`.
-        - `score`: float between `0.0` and `1.0`.
+        - `score`: object with CMMI maturity `level`, `label` and `justification`.
         - `customer_type`: audience benefiting from the feature.
         - `data`, `applications`, `technology`: lists of `Contribution` objects
           describing why a mapped item supports the feature.
@@ -204,7 +208,10 @@ Generate service features for the {service_name} service at plateau {plateau}.
   - "feature_id": unique string identifier.
   - "name": short feature title.
   - "description": explanation of the feature.
-  - "score": floating-point maturity between 0 and 1.
+  - "score": object describing CMMI maturity with:
+    - "level": integer 1–5.
+    - "label": matching CMMI maturity name.
+    - "justification": brief rationale for the level.
 - Do not include any text outside the JSON object.
 ```
 

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -46,7 +46,11 @@ Each line in the output file is a JSON object with:
           "feature_id": "string",
           "name": "string",
           "description": "string",
-          "score": 0.0,
+          "score": {
+            "level": 3,
+            "label": "Defined",
+            "justification": "string"
+          },
           "customer_type": "string",
           "data": [{ "item": "string", "contribution": "string" }],
           "applications": [{ "item": "string", "contribution": "string" }],

--- a/docs/sd01-flow-of-evolution-prompts.md
+++ b/docs/sd01-flow-of-evolution-prompts.md
@@ -120,7 +120,7 @@ Generate service features for the Learning & Teaching service at plateau 1.
     - "feature_id": unique string identifier.
     - "name": short feature title.
     - "description": explanation of the feature.
-    - "score": floating-point maturity between 0 and 1.
+    - "score": object describing CMMI maturity with "level", "label" and "justification".
 - Do not include any text outside the JSON object.
 - The response must adhere to the JSON schema provided below.
 
@@ -131,15 +131,15 @@ Generate service features for the Learning & Teaching service at plateau 1.
   "properties": {
     "learners": {
       "type": "array",
-      "items": {"type": "object","properties": {"feature_id": {"type": "string"},"name": {"type": "string"},"description": {"type": "string"},"score": {"type": "number"}},"required": ["feature_id","name","description","score"]}
+      "items": {"type": "object","properties": {"feature_id": {"type": "string"},"name": {"type": "string"},"description": {"type": "string"},"score": {"type": "object","properties": {"level": {"type": "integer"},"label": {"type": "string"},"justification": {"type": "string"}},"required": ["level","label","justification"]}},"required": ["feature_id","name","description","score"]}
     },
     "staff": {
       "type": "array",
-      "items": {"type": "object","properties": {"feature_id": {"type": "string"},"name": {"type": "string"},"description": {"type": "string"},"score": {"type": "number"}},"required": ["feature_id","name","description","score"]}
+      "items": {"type": "object","properties": {"feature_id": {"type": "string"},"name": {"type": "string"},"description": {"type": "string"},"score": {"type": "object","properties": {"level": {"type": "integer"},"label": {"type": "string"},"justification": {"type": "string"}},"required": ["level","label","justification"]}},"required": ["feature_id","name","description","score"]}
     },
     "community": {
       "type": "array",
-      "items": {"type": "object","properties": {"feature_id": {"type": "string"},"name": {"type": "string"},"description": {"type": "string"},"score": {"type": "number"}},"required": ["feature_id","name","description","score"]}
+      "items": {"type": "object","properties": {"feature_id": {"type": "string"},"name": {"type": "string"},"description": {"type": "string"},"score": {"type": "object","properties": {"level": {"type": "integer"},"label": {"type": "string"},"justification": {"type": "string"}},"required": ["level","label","justification"]}},"required": ["feature_id","name","description","score"]}
     }
   },
   "required": ["learners","staff","community"]

--- a/prompts/plateau_prompt.md
+++ b/prompts/plateau_prompt.md
@@ -18,7 +18,12 @@ Generate service features for the {service_name} service at plateau {plateau}.
     - "feature_id": unique string identifier.
     - "name": short feature title.
     - "description": explanation of the feature.
-    - "score": floating-point maturity between 0 and 1.
+    - "score": object describing CMMI maturity with:
+        - "level": integer 1–5.
+        - "label": matching CMMI maturity name.
+        - "justification": brief rationale for the level.
+- CMMI levels: 1 Initial, 2 Managed, 3 Defined, 4 Quantitatively Managed, 5 Optimizing.
+- Use the full range and differentiate features within a plateau.
 - Do not include any text outside the JSON object.
 - The response must adhere to the JSON schema provided below.
 

--- a/src/models.py
+++ b/src/models.py
@@ -233,11 +233,32 @@ class AppConfig(StrictModel):
     )
 
 
+class MaturityScore(StrictModel):
+    """CMMI maturity assessment for a feature."""
+
+    level: Annotated[
+        int,
+        Field(
+            ge=1,
+            le=5,
+            description="CMMI maturity level where 1 is Initial and 5 Optimizing.",
+        ),
+    ]
+    label: Annotated[
+        str,
+        Field(min_length=1, description="CMMI maturity label matching the level."),
+    ]
+    justification: Annotated[
+        str,
+        Field(min_length=1, description="Reasoning behind the chosen maturity level."),
+    ]
+
+
 class PlateauFeature(StrictModel):
     """Feature assessed during a service plateau.
 
-    Each feature includes a normalised ``score`` and optional mapping
-    contributions that reference external catalogues.
+    Each feature includes a CMMI ``score`` and optional mapping contributions
+    that reference external catalogues.
     """
 
     feature_id: Annotated[
@@ -245,8 +266,8 @@ class PlateauFeature(StrictModel):
     ]
     name: Annotated[str, Field(min_length=1, description="Feature name.")]
     description: str = Field(..., description="Explanation of the feature.")
-    score: float = Field(
-        ..., ge=0.0, le=1.0, description="Normalised performance score between 0 and 1."
+    score: MaturityScore = Field(
+        ..., description="CMMI maturity assessment for the feature."
     )
     customer_type: Annotated[
         str, Field(min_length=1, description="Audience that benefits from the feature.")
@@ -311,8 +332,8 @@ class FeatureItem(StrictModel):
     ]
     name: Annotated[str, Field(min_length=1, description="Short feature title.")]
     description: str = Field(..., description="Explanation of the feature.")
-    score: float = Field(
-        ..., ge=0.0, le=1.0, description="Maturity score between 0 and 1."
+    score: MaturityScore = Field(
+        ..., description="CMMI maturity assessment for the feature."
     )
 
 
@@ -417,6 +438,7 @@ __all__ = [
     "ServiceFeaturePlateau",
     "PlateauFeature",
     "Contribution",
+    "MaturityScore",
     "PlateauResult",
     "ServiceEvolution",
     "SCHEMA_VERSION",

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -43,7 +43,11 @@ def _feature_payload(count: int) -> str:
             "feature_id": f"f{i}",
             "name": f"Feat {i}",
             "description": f"Desc {i}",
-            "score": 0.5,
+            "score": {
+                "level": 3,
+                "label": "Defined",
+                "justification": "test",
+            },
         }
         for i in range(count)
     ]

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from mapping import map_feature, map_features
-from models import MappingItem, PlateauFeature
+from models import MappingItem, MaturityScore, PlateauFeature
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
@@ -82,7 +82,7 @@ async def test_map_feature_returns_mappings(monkeypatch) -> None:
         feature_id="f1",
         name="Integration",
         description="Allows external access",
-        score=0.5,
+        score=MaturityScore(level=3, label="Defined", justification="j"),
         customer_type="learners",
     )
 
@@ -152,7 +152,7 @@ async def test_map_feature_injects_reference_data(monkeypatch) -> None:
         feature_id="f1",
         name="Integration",
         description="Allows external access",
-        score=0.5,
+        score=MaturityScore(level=3, label="Defined", justification="j"),
         customer_type="learners",
     )
     await map_feature(session, feature)  # type: ignore[arg-type]
@@ -184,7 +184,7 @@ async def test_map_feature_rejects_invalid_json(monkeypatch) -> None:
         feature_id="f1",
         name="Integration",
         description="desc",
-        score=0.5,
+        score=MaturityScore(level=3, label="Defined", justification="j"),
         customer_type="learners",
     )
     with pytest.raises(ValueError):
@@ -235,7 +235,7 @@ async def test_map_feature_flattens_nested_mappings(monkeypatch) -> None:
         feature_id="f1",
         name="Integration",
         description="Allows external access",
-        score=0.5,
+        score=MaturityScore(level=3, label="Defined", justification="j"),
         customer_type="learners",
     )
 
@@ -296,7 +296,7 @@ async def test_map_feature_flattens_repeated_mapping_keys(monkeypatch) -> None:
         feature_id="f1",
         name="Integration",
         description="Allows external access",
-        score=0.5,
+        score=MaturityScore(level=3, label="Defined", justification="j"),
         customer_type="learners",
     )
 
@@ -362,7 +362,7 @@ async def test_map_features_returns_mappings(monkeypatch) -> None:
         feature_id="f1",
         name="Integration",
         description="Allows external access",
-        score=0.5,
+        score=MaturityScore(level=3, label="Defined", justification="j"),
         customer_type="learners",
     )
 
@@ -411,7 +411,7 @@ async def test_map_features_allows_empty_lists(monkeypatch) -> None:
         feature_id="f1",
         name="Integration",
         description="Allows external access",
-        score=0.5,
+        score=MaturityScore(level=3, label="Defined", justification="j"),
         customer_type="learners",
     )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from models import (  # noqa: E402  pylint: disable=wrong-import-position
     Contribution,
     MappingResponse,
+    MaturityScore,
     PlateauFeature,
     PlateauResult,
     ServiceEvolution,
@@ -32,7 +33,7 @@ def test_service_evolution_contains_plateaus() -> None:
         feature_id="f1",
         name="Feat",
         description="D",
-        score=0.75,
+        score=MaturityScore(level=3, label="Defined", justification="std"),
         customer_type="learners",
     )
     plateau = PlateauResult(
@@ -55,7 +56,7 @@ def test_plateau_feature_validates_score() -> None:
             feature_id="f1",
             name="Feat",
             description="D",
-            score=2.0,
+            score=MaturityScore(level=6, label="Invalid", justification="bad"),
             customer_type="learners",
         )
 

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -13,6 +13,7 @@ from conversation import (
 )  # noqa: E402  pylint: disable=wrong-import-position
 from models import (  # noqa: E402  pylint: disable=wrong-import-position
     Contribution,
+    MaturityScore,
     PlateauFeature,
     PlateauResult,
     ServiceInput,
@@ -49,7 +50,11 @@ def _feature_payload(count: int) -> str:
             "feature_id": f"f{i}",
             "name": f"Feature {i}",
             "description": f"Desc {i}",
-            "score": 0.5,
+            "score": {
+                "level": 3,
+                "label": "Defined",
+                "justification": "test",
+            },
         }
         for i in range(count)
     ]
@@ -196,21 +201,21 @@ async def test_generate_service_evolution_filters(monkeypatch) -> None:
                 feature_id=f"l{level}",
                 name="L",
                 description="d",
-                score=0.5,
+                score=MaturityScore(level=3, label="Defined", justification="j"),
                 customer_type="learners",
             ),
             PlateauFeature(
                 feature_id=f"s{level}",
                 name="S",
                 description="d",
-                score=0.5,
+                score=MaturityScore(level=3, label="Defined", justification="j"),
                 customer_type="academics",
             ),
             PlateauFeature(
                 feature_id=f"c{level}",
                 name="C",
                 description="d",
-                score=0.5,
+                score=MaturityScore(level=3, label="Defined", justification="j"),
                 customer_type="professional_staff",
             ),
         ]


### PR DESCRIPTION
## Summary
- model plateau feature scores as CMMI maturity objects
- update tests and docs for CMMI score parsing

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: certificate verify failed)*
- `poetry run pytest` *(fails: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_689a6f30eda0832b95b739eda4be9963