### PR TITLE
Make web search optional for model building

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -79,6 +79,7 @@ async def _cmd_generate_ambitions(args: argparse.Namespace, settings) -> None:
         settings.openai_api_key,
         seed=args.seed,
         reasoning=settings.reasoning,
+        web_search=args.web_search,
     )
     concurrency = args.concurrency or settings.concurrency
     generator = ServiceAmbitionGenerator(
@@ -154,6 +155,7 @@ async def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
         settings.openai_api_key,
         seed=args.seed,
         reasoning=settings.reasoning,
+        web_search=args.web_search,
     )
 
     # Load and assemble the system prompt so each conversation begins with
@@ -304,6 +306,11 @@ async def main_async() -> None:
         dest="resume",
         action="store_true",
         help="Resume processing using processed_ids.txt",
+    )
+    common.add_argument(
+        "--web-search",
+        action="store_true",
+        help="Enable web search for model browsing",
     )
 
     # Define subcommands for the supported operations

--- a/src/generator.py
+++ b/src/generator.py
@@ -336,6 +336,7 @@ def build_model(
     *,
     seed: int | None = None,
     reasoning: ReasoningConfig | None = None,
+    web_search: bool = False,
 ) -> Model:
     """Return a configured Pydantic AI model.
 
@@ -344,6 +345,8 @@ def build_model(
         api_key: Optional API key for authenticating with OpenAI.
         seed: Optional seed for deterministic model responses.
         reasoning: Optional reasoning configuration passed through to the model.
+        web_search: Enable OpenAI web search tooling for model browsing. Defaults to
+            ``False``.
 
     Returns:
         A ready-to-use ``Model`` instance.
@@ -359,10 +362,12 @@ def build_model(
     # Allow callers to pass provider-prefixed names such as ``openai:gpt-4``.
     model_name = model_name.split(":", 1)[-1]
     extra = {"seed": seed} if seed is not None else {}
-    settings_kwargs: dict[str, Any] = {
-        "openai_builtin_tools": [{"type": "web_search_preview"}],
-        **extra,
-    }
+    settings_kwargs: dict[str, Any] = {**extra}
+    if web_search:
+        # Allow optional access to the ``web_search_preview`` tool which provides
+        # browsing capabilities. Disabling keeps runs deterministic and avoids
+        # additional cost for schema-only generation.
+        settings_kwargs["openai_builtin_tools"] = [{"type": "web_search_preview"}]
     if reasoning:
         # Map each reasoning field to the ``openai_reasoning_*`` parameter.
         for key, value in reasoning.model_dump(exclude_none=True).items():

--- a/tests/test_build_model.py
+++ b/tests/test_build_model.py
@@ -1,0 +1,17 @@
+"""Tests for ``build_model`` utility."""
+
+from generator import build_model
+
+
+def test_build_model_disables_web_search_by_default(monkeypatch):
+    """The model should omit web search tooling unless requested."""
+
+    model = build_model("gpt-4o-mini", "key")
+    assert getattr(model._settings, "openai_builtin_tools", None) is None
+
+
+def test_build_model_enables_web_search_when_requested(monkeypatch):
+    """Enabling the flag should attach the web search tool."""
+
+    model = build_model("gpt-4o-mini", "key", web_search=True)
+    assert model._settings.openai_builtin_tools == [{"type": "web_search_preview"}]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -234,10 +234,18 @@ def test_cli_model_instantiation_arguments(tmp_path, monkeypatch):
 
     captured: dict[str, str] = {}
 
-    def fake_build_model(model_name: str, api_key: str, *, seed=None, reasoning=None):
+    def fake_build_model(
+        model_name: str,
+        api_key: str,
+        *,
+        seed=None,
+        reasoning=None,
+        web_search=False,
+    ):
         captured["model"] = model_name
         captured["api_key"] = api_key
         captured["seed"] = seed
+        captured["web_search"] = web_search
         return "test"
 
     monkeypatch.setattr(generator, "build_model", fake_build_model)
@@ -266,6 +274,7 @@ def test_cli_model_instantiation_arguments(tmp_path, monkeypatch):
     assert captured["model"] == "test-model"
     assert captured["api_key"] == "dummy"
     assert captured["seed"] is None
+    assert captured["web_search"] is False
 
 
 def test_cli_seed_sets_random(tmp_path, monkeypatch):
@@ -296,8 +305,16 @@ def test_cli_seed_sets_random(tmp_path, monkeypatch):
 
     captured: dict[str, int | None] = {}
 
-    def fake_build_model(model_name: str, api_key: str, *, seed=None, reasoning=None):
+    def fake_build_model(
+        model_name: str,
+        api_key: str,
+        *,
+        seed=None,
+        reasoning=None,
+        web_search=False,
+    ):
         captured["seed"] = seed
+        captured["web_search"] = web_search
         return "test"
 
     async def fake_process_service(self, service, prompt=None):
@@ -325,6 +342,7 @@ def test_cli_seed_sets_random(tmp_path, monkeypatch):
     cli.main()
 
     assert captured["seed"] == 123
+    assert captured["web_search"] is False
     assert random.random() == pytest.approx(random.Random(123).random())
 
 

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -34,6 +34,7 @@ async def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
         *,
         seed: int | None = None,
         reasoning=None,
+        web_search=False,
     ) -> object:  # pragma: no cover - stub
         return object()
 
@@ -114,10 +115,12 @@ async def test_generate_evolution_uses_agent_model(tmp_path, monkeypatch) -> Non
         *,
         seed: int | None = None,
         reasoning=None,
+        web_search=False,
     ) -> object:
         captured["model_name"] = model_name
         captured["api_key"] = api_key
         captured["seed"] = seed
+        captured["web_search"] = web_search
         return "model"
 
     class DummyAgent:
@@ -169,6 +172,7 @@ async def test_generate_evolution_uses_agent_model(tmp_path, monkeypatch) -> Non
 
     assert captured["model_name"] == "special"
     assert captured["agent_model"] == "model"
+    assert captured["web_search"] is False
 
 
 @pytest.mark.asyncio
@@ -202,6 +206,7 @@ async def test_generate_evolution_respects_concurrency(tmp_path, monkeypatch) ->
         *,
         seed: int | None = None,
         reasoning=None,
+        web_search=False,
     ) -> object:  # pragma: no cover - stub
         return object()
 
@@ -275,6 +280,7 @@ async def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
         *,
         seed: int | None = None,
         reasoning=None,
+        web_search=False,
     ) -> object:  # pragma: no cover - stub
         return object()
 
@@ -351,6 +357,7 @@ async def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:
         *,
         seed: int | None = None,
         reasoning=None,
+        web_search=False,
     ) -> object:
         return object()
 


### PR DESCRIPTION
## Summary
- Add `web_search` flag to `build_model` so OpenAI browsing tools are optional
- Expose a `--web-search` CLI flag to toggle browsing
- Test model construction with and without web search

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Cannot find implementation or library stub for module named "logfire")*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): SSLError)*
- `pytest` *(fails: multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_689a7a9883ac832bafc0564637ec6d3d