### PR TITLE
Disable Logfire auto tracing

### DIFF
--- a/src/monitoring.py
+++ b/src/monitoring.py
@@ -90,10 +90,6 @@ def init_logfire(token: str | None = None) -> None:
         if instrument:
             instrument()
 
-    installer = getattr(logfire, "install_auto_tracing", None)
-    if installer:
-        installer([], min_duration=0)
-
     handler_cls = getattr(logfire, "LogfireLoggingHandler", None)
     if handler_cls:
         # Replace any existing handlers to prevent duplicate log output.


### PR DESCRIPTION
## Summary
- stop configuring Logfire auto tracing to keep instrumentation opt-in

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*
- `./run.sh generate-evolution` *(fails: ModuleNotFoundError: No module named 'logfire')*

------
https://chatgpt.com/codex/tasks/task_e_689a943862fc832baa11c42e19cbb067