### PR TITLE
fix: load_roles handles direct file paths

### DIFF
--- a/src/loader.py
+++ b/src/loader.py
@@ -225,11 +225,11 @@ def load_roles(
     base_dir: Path | str = Path("data"),
     filename: Path | str = Path("roles.json"),
 ) -> list[Role]:
-    """Return role definitions from ``base_dir``.
+    """Return role definitions from ``base_dir`` or a direct file path.
 
     Args:
-        base_dir: Directory containing data files.
-        filename: Roles definitions file name.
+        base_dir: Directory containing data files or the roles file itself.
+        filename: Roles definitions file name when ``base_dir`` is a directory.
 
     Returns:
         List of :class:`Role` records.
@@ -239,7 +239,10 @@ def load_roles(
         RuntimeError: If the file cannot be read or parsed.
     """
 
-    path = Path(base_dir) / Path(filename)
+    base_path = Path(base_dir)
+    # If ``base_dir`` points to a directory append ``filename``; otherwise treat
+    # it as the full path to the roles file.
+    path = base_path / Path(filename) if base_path.is_dir() else base_path
     try:
         return _read_json_file(path, list[Role])
     except Exception as exc:  # pylint: disable=broad-except

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -11,6 +11,7 @@ from loader import (
     load_plateau_definitions,
     load_prompt,
     load_prompt_text,
+    load_roles,
     load_services,
 )
 from models import JobToBeDone
@@ -168,6 +169,19 @@ def test_load_plateau_definitions(tmp_path):
     )
     plateaus = load_plateau_definitions(str(base))
     assert plateaus[0].name == "Alpha"
+
+
+def test_load_roles_accepts_file_path(tmp_path):
+    """``load_roles`` accepts a direct file path or a data directory."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    roles_file = data_dir / "roles.json"
+    roles_file.write_text('[{"role_id": "r1", "label": "Role"}]', encoding="utf-8")
+
+    from_dir = load_roles(str(data_dir))
+    from_file = load_roles(str(roles_file))
+    assert from_dir == from_file
+    assert from_file[0].role_id == "r1"
 
 
 def test_load_services_reads_jsonl(tmp_path):


### PR DESCRIPTION
## Summary
- fix load_roles to accept a roles file path directly or a directory
- add regression test for loading roles from a file path

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(command not found: bandit)*
- `poetry run pip-audit` *(command not found: pip-audit)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_689a998cdda4832baecb8a1b9e424ba0