### PR TITLE
Escape plateau prompt placeholders to avoid KeyError

### DIFF
--- a/prompts/plateau_prompt.md
+++ b/prompts/plateau_prompt.md
@@ -20,7 +20,7 @@ Generate service features for the {service_name} service at plateau {plateau}.
 - Each key must map to an array containing at least {required_count} feature objects.
 - Every feature must provide:
   - "feature_id": unique string identifier.
-    - Format: "FEAT-{plateau}-{role}-{kebab-case-short-name}" (e.g., FEAT-2-learners-smart-enrolment).
+    - Format: "FEAT-{plateau}-{{role}}-{{kebab-case-short-name}}" (e.g., FEAT-2-learners-smart-enrolment).
     - Ensure IDs are unique across all roles in this response.
   - "name": short feature title.
   - "description": explanation of the feature.

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -72,6 +72,28 @@ def _feature_payload(count: int) -> str:
     return json.dumps(payload)
 
 
+def test_build_plateau_prompt_preserves_role_placeholder(monkeypatch) -> None:
+    """_build_plateau_prompt should retain role placeholders."""
+
+    template = 'Format: "FEAT-{plateau}-{{role}}-{{kebab-case-short-name}}"'
+    monkeypatch.setattr(
+        "plateau_generator.load_prompt_text", lambda *args, **kwargs: template
+    )
+    session = DummySession([])
+    generator = PlateauGenerator(cast(ConversationSession, session))
+    generator._service = ServiceInput(
+        service_id="s",
+        name="svc",
+        customer_type="type",
+        description="d",
+        jobs_to_be_done=[{"name": "job"}],
+    )
+
+    prompt = generator._build_plateau_prompt(2, "d")
+
+    assert "FEAT-2-{role}-{kebab-case-short-name}" in prompt
+
+
 @pytest.mark.asyncio
 async def test_generate_plateau_returns_results(monkeypatch) -> None:
     template = "{required_count} {service_name} {service_description} {plateau} {roles}"


### PR DESCRIPTION
## Summary
- escape `{role}` and `{kebab-case-short-name}` placeholders in plateau prompt to avoid formatting errors
- add unit test ensuring `_build_plateau_prompt` retains role placeholder

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/anyio/4.10.0/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)')))*)
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_689ab0941c78832b97c7f0e1ecafe6c1