### PR TITLE
Fix tuple error message for missing plateau features

### DIFF
--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -210,14 +210,10 @@ class PlateauGenerator:
                 items = payload.features.get(role, [])
                 # Fail fast if the model omitted any required features for a role.
                 if len(items) < self.required_count:
+                    # Construct a clear error message instead of returning a tuple
                     msg = (
-                        (
-                            (
-                                f"Expected at least {self.required_count} features for"
-                                f" '{role}',"
-                            ),
-                        ),
-                        f" got {len(items)}",
+                        f"Expected at least {self.required_count} features for"
+                        f" '{role}', got {len(items)}"
                     )
                     raise ValueError(msg)
             features = self._collect_features(payload)


### PR DESCRIPTION
## Summary
- improve `PlateauGenerator` error reporting when feature count is insufficient

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'logfire')*


------
https://chatgpt.com/codex/tasks/task_e_689ab4e78128832bbc2413e7d1c2573f