### PR TITLE
Ensure plateau feature responses include required features key

### DIFF
--- a/prompts/plateau_prompt.md
+++ b/prompts/plateau_prompt.md
@@ -16,8 +16,9 @@ Generate service features for the {service_name} service at plateau {plateau}.
 - Use short, simple sentences and active voice.
 - Avoid unnecessary jargon or “consultant speak” – explain concepts in layperson’s terms unless technical detail is needed.
 - If you must use technical terms or acronyms, briefly describe them for clarity.
-- Return a single JSON object with keys for each role: {roles}.
-- Each key must map to an array containing at least {required_count} feature objects.
+- Return a single JSON object with a top-level "features" key.
+- "features" must include keys for each role: {roles}.
+- Each role key must map to an array containing at least {required_count} feature objects.
 - Every feature must provide:
   - "feature_id": unique string identifier.
     - Format: "FEAT-{plateau}-{{role}}-{{kebab-case-short-name}}" (e.g., FEAT-2-learners-smart-enrolment).
@@ -34,6 +35,29 @@ Generate service features for the {service_name} service at plateau {plateau}.
 - Return ONLY valid JSON. No Markdown. No backticks. No commentary. No trailing commas.
 - If you are about to include any text outside JSON, stop and return JSON only.
 - The response must adhere to the JSON schema provided below.
+
+## Example output
+
+```json
+{
+  "features": {
+    "learners": [
+      {
+        "feature_id": "FEAT-{plateau}-learners-smart-enrolment",
+        "name": "Smart enrolment",
+        "description": "Students enrol through a streamlined digital process with real-time validation.",
+        "score": {
+          "level": 3,
+          "label": "Defined",
+          "justification": "Process is documented and standardised."
+        }
+      }
+    ],
+    "academics": [],
+    "professional_staff": []
+  }
+}
+```
 
 ## Response structure
 

--- a/src/models.py
+++ b/src/models.py
@@ -353,14 +353,13 @@ class FeatureItem(StrictModel):
 class PlateauFeaturesResponse(StrictModel):
     """Schema for plateau feature generation responses.
 
-    Features are grouped by role identifier to simplify downstream rendering. If
-    the agent omits the ``features`` key, an empty mapping is assumed so model
-    validation succeeds and downstream checks can raise descriptive errors.
+    Features are grouped by role identifier to simplify downstream rendering.
+    The ``features`` key is required and must contain arrays of feature items
+    for each role.
     """
 
     features: dict[str, list[FeatureItem]] = Field(
-        default_factory=dict,
-        description="Generated features keyed by role.",
+        ..., description="Generated features keyed by role."
     )
 
 

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -179,7 +179,7 @@ def test_generate_plateau_missing_features(monkeypatch) -> None:
     with pytest.raises(ValueError) as exc:
         generator.generate_plateau(1, "Foundational")
 
-    assert "Expected at least" in str(exc.value)
+    assert "invalid JSON" in str(exc.value)
 
 
 def test_request_description_invalid_json(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Require `features` in plateau feature schema
- Guide agents to nest role arrays under a top-level `features` object and provide an example
- Adjust plateau generation tests for new validation behavior

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*
- `poetry run pytest` *(fails: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_689ad732ed8c832b9ddd31e95e19f251