### PR TITLE
refactor: isolate service loading utilities

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -25,12 +25,12 @@ from loader import (
     load_evolution_prompt,
     load_plateau_definitions,
     load_roles,
-    load_services,
 )
 from models import ServiceInput
 from monitoring import LOG_FILE_NAME, init_logfire
 from persistence import atomic_write, read_lines
 from plateau_generator import PlateauGenerator
+from service_loader import load_services
 from settings import load_settings
 
 logger = logging.getLogger(__name__)

--- a/src/service_loader.py
+++ b/src/service_loader.py
@@ -1,0 +1,75 @@
+"""Iterators for service definition files.
+
+This module provides :class:`ServiceLoader` and :func:`load_services` for
+reading newline-delimited JSON service definitions and yielding validated
+:class:`~models.ServiceInput` instances.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Generator, Iterator
+
+import logfire
+from pydantic import TypeAdapter
+
+from models import ServiceInput
+
+logger = logging.getLogger(__name__)
+
+
+@logfire.instrument()
+def _load_service_entries(path: Path | str) -> Generator[ServiceInput, None, None]:
+    """Yield services from ``path`` while validating each JSON line."""
+
+    path_obj = Path(path)
+    with logfire.span("Calling service_loader.load_services"):
+        adapter = TypeAdapter(ServiceInput)
+        try:
+            with path_obj.open("r", encoding="utf-8") as file:
+                for line in file:
+                    line = line.strip()
+                    if not line:
+                        continue  # Skip blank lines
+                    try:
+                        yield adapter.validate_json(line)
+                    except Exception as exc:  # pragma: no cover - logging
+                        logger.error("Invalid service entry in %s: %s", path_obj, exc)
+                        raise RuntimeError("Invalid service definition") from exc
+        except FileNotFoundError:  # pragma: no cover - logging
+            logger.error("Services file not found: %s", path_obj)
+            raise FileNotFoundError(
+                "Services file not found. Please create a %s file in the current"
+                " directory." % path_obj
+            ) from None
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error("Error reading services file %s: %s", path_obj, exc)
+            raise RuntimeError(
+                f"An error occurred while reading the services file: {exc}"
+            ) from exc
+
+
+class ServiceLoader:
+    """Iterator and context manager for service definitions."""
+
+    def __init__(self, path: Path | str) -> None:
+        self._path = path
+
+    def __iter__(self) -> Iterator[ServiceInput]:
+        return _load_service_entries(self._path)
+
+    def __enter__(self) -> Iterator[ServiceInput]:
+        return self.__iter__()
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - no cleanup
+        return None
+
+
+def load_services(path: Path | str) -> ServiceLoader:
+    """Return an iterable over services defined in ``path``."""
+
+    return ServiceLoader(path)
+
+
+__all__ = ["load_services", "ServiceLoader"]

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -12,9 +12,9 @@ from loader import (
     load_prompt,
     load_prompt_text,
     load_roles,
-    load_services,
 )
 from models import JobToBeDone
+from service_loader import load_services
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 


### PR DESCRIPTION
## Summary
- factor out service loading logic into a dedicated `service_loader` module
- update CLI and tests to use the new module and simplify `loader`

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run ruff check .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'logfire')*

------
https://chatgpt.com/codex/tasks/task_e_689ec097ce30832b80e804a0aa76850d