### PR TITLE
fix: ensure coroutine passed to asyncio.run

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -11,7 +11,7 @@ import random
 import sys
 from itertools import islice
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Coroutine, Iterable, cast
 
 import logfire
 from pydantic_ai import Agent
@@ -330,7 +330,8 @@ def main() -> None:
 
     result = args.func(args, settings)
     if inspect.isawaitable(result):  # pragma: no cover - depends on command
-        asyncio.run(result)
+        # Cast ensures that asyncio.run receives a proper Coroutine
+        asyncio.run(cast(Coroutine[Any, Any, Any], result))
 
     logfire.force_flush()
 


### PR DESCRIPTION
## Summary
- cast awaitable CLI results to Coroutine before passing to `asyncio.run`

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: missing stubs for third-party modules)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL certificate verify failed)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'logfire')*


------
https://chatgpt.com/codex/tasks/task_e_689ec9332d10832ba46c540d7218ac30