### PR TITLE
Fix settings initialisation and model configuration

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -69,25 +69,25 @@ def load_settings() -> Settings:
     """
 
     config = load_app_config()
-    data = {
-        "model": config.model,
-        "reasoning": config.reasoning,
-        "log_level": config.log_level,
-        "prompt_dir": config.prompt_dir,
-        "context_id": config.context_id,
-        "inspiration": config.inspiration,
-        "concurrency": config.concurrency,
-        "batch_size": config.batch_size,
-        "request_timeout": config.request_timeout,
-        "retries": config.retries,
-        "retry_base_delay": config.retry_base_delay,
-        "features_per_role": config.features_per_role,
-    }
-    env_file = Path(".env")
-    env_kwargs = {"_env_file": env_file} if env_file.exists() else {}
+    env_file_path = Path(".env")
+    env_file = env_file_path if env_file_path.exists() else None
     try:
         # Validate and merge configuration from file, env file and environment.
-        return Settings(**data, **env_kwargs)
+        return Settings(
+            model=config.model,
+            reasoning=config.reasoning,
+            log_level=config.log_level,
+            prompt_dir=config.prompt_dir,
+            context_id=config.context_id,
+            inspiration=config.inspiration,
+            concurrency=config.concurrency,
+            batch_size=config.batch_size,
+            request_timeout=config.request_timeout,
+            retries=config.retries,
+            retry_base_delay=config.retry_base_delay,
+            features_per_role=config.features_per_role,
+            _env_file=env_file,
+        )
     except ValidationError as exc:
         # Summarise validation issues so the caller receives clear feedback.
         details = "; ".join(


### PR DESCRIPTION
## Summary
- construct Settings with explicit keyword arguments and env file support
- build OpenAI model settings using typed dict without dynamic expansion

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `poetry run pytest` *(fails: No module named 'logfire')*

------
https://chatgpt.com/codex/tasks/task_e_689ed08455a0832b98f2f86bf5827fce