### PR TITLE
refactor: use f-strings in logging messages

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -74,7 +74,7 @@ async def _cmd_generate_ambitions(args: argparse.Namespace, settings) -> None:
 
     # Prefer model specified on the CLI, falling back to settings
     model_name = args.model or settings.model
-    logger.info("Generating ambitions using model %s", model_name)
+    logger.info(f"Generating ambitions using model {model_name}")
 
     model = build_model(
         model_name,
@@ -121,7 +121,7 @@ async def _cmd_generate_ambitions(args: argparse.Namespace, settings) -> None:
             services = svc_iter
 
         if args.dry_run:
-            logger.info("Validated %d services", len(services_list or []))
+            logger.info(f"Validated {len(services_list or [])} services")
             return
 
         if show_progress:
@@ -144,7 +144,7 @@ async def _cmd_generate_ambitions(args: argparse.Namespace, settings) -> None:
         processed_ids = new_ids
 
     atomic_write(processed_path, sorted(processed_ids))
-    logger.info("Results written to %s", output_path)
+    logger.info(f"Results written to {output_path}")
 
 
 def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
@@ -182,7 +182,7 @@ def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
         services = [s for s in svc_iter if s.service_id not in processed_ids]
 
     if args.dry_run:
-        logger.info("Validated %d services", len(services))
+        logger.info(f"Validated {len(services)} services")
         return
 
     new_ids: set[str] = set()
@@ -201,7 +201,7 @@ def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
             evolution = generator.generate_service_evolution(service)
             output.write(f"{evolution.model_dump_json()}\n")
             new_ids.add(service.service_id)
-            logger.info("Generated evolution for %s", service.name)
+            logger.info(f"Generated evolution for {service.name}")
             if progress:
                 progress.update(1)
     if progress:

--- a/src/conversation.py
+++ b/src/conversation.py
@@ -51,7 +51,7 @@ class ConversationSession:
             history.
         """
         ctx = "SERVICE_CONTEXT:\n" + service_input.model_dump_json()
-        logger.debug("Adding service material to history: %s", ctx)
+        logger.debug(f"Adding service material to history: {ctx}")
         self._history.append(
             messages.ModelRequest(parts=[messages.UserPromptPart(ctx)])
         )
@@ -82,12 +82,12 @@ class ConversationSession:
             agent's raw response text.
         """
 
-        logger.debug("Sending prompt: %s", prompt)
+        logger.debug(f"Sending prompt: {prompt}")
         result = self.client.run_sync(
             prompt, message_history=self._history, output_type=output_type
         )
         self._history.extend(result.new_messages())
-        logger.debug("Received response: %s", result.output)
+        logger.debug(f"Received response: {result.output}")
         return result.output
 
 

--- a/src/generator.py
+++ b/src/generator.py
@@ -259,16 +259,12 @@ class ServiceAmbitionGenerator:
                     span.set_attribute("service.id", service.service_id)
                     if service.customer_type:
                         span.set_attribute("customer_type", service.customer_type)
-                    logger.info("Processing service %s", service.name)
+                    logger.info(f"Processing service {service.name}")
                     try:
                         result = await self.process_service(service)
                     except Exception as exc:
                         # Continue processing other services but record the failure.
-                        logger.error(
-                            "Failed to process service %s: %s",
-                            service.name,
-                            exc,
-                        )
+                        logger.error(f"Failed to process service {service.name}: {exc}")
                         return
                     line = AmbitionModel.model_validate(result).model_dump_json()
                     async with lock:
@@ -313,7 +309,7 @@ class ServiceAmbitionGenerator:
         try:
             return await self._process_all(services, output_path, progress)
         except Exception as exc:
-            logger.error("Failed to write results to %s: %s", output_path, exc)
+            logger.error(f"Failed to write results to {output_path}: {exc}")
             raise
         finally:
             self._prompt = None

--- a/src/loader.py
+++ b/src/loader.py
@@ -71,10 +71,10 @@ def _read_file(path: Path) -> str:
         with path.open("r", encoding="utf-8") as file:
             return file.read().strip()
     except FileNotFoundError:
-        logger.error("Prompt file not found: %s", path)
+        logger.error(f"Prompt file not found: {path}")
         raise
     except Exception as exc:
-        logger.error("Error reading prompt file %s: %s", path, exc)
+        logger.error(f"Error reading prompt file {path}: {exc}")
         raise RuntimeError(
             f"An error occurred while reading the prompt file: {exc}"
         ) from exc
@@ -97,7 +97,7 @@ def _read_json_file(path: Path, schema: type[T]) -> T:
     except FileNotFoundError:
         raise
     except Exception as exc:
-        logger.error("Error reading JSON file %s: %s", path, exc)
+        logger.error(f"Error reading JSON file {path}: {exc}")
         raise RuntimeError(
             f"An error occurred while reading the JSON file: {exc}"
         ) from exc
@@ -214,7 +214,7 @@ def load_plateau_definitions(
     try:
         return _read_json_file(path, list[ServiceFeaturePlateau])
     except Exception as exc:
-        logger.error("Invalid plateau definition data in %s: %s", path, exc)
+        logger.error(f"Invalid plateau definition data in {path}: {exc}")
         raise RuntimeError(f"Invalid plateau definitions: {exc}") from exc
 
 
@@ -245,7 +245,7 @@ def load_roles(
     try:
         return _read_json_file(path, list[Role])
     except Exception as exc:
-        logger.error("Invalid role data in %s: %s", path, exc)
+        logger.error(f"Invalid role data in {path}: {exc}")
         raise RuntimeError(f"Invalid roles: {exc}") from exc
 
 

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -151,7 +151,7 @@ def _merge_mapping_results(
                 # feature generation can continue when the agent omits a
                 # category.  An empty list is stored for the mapping type.
                 logger.warning(
-                    "Missing mappings: feature=%s key=%s", feature.feature_id, key
+                    f"Missing mappings: feature={feature.feature_id} key={key}"
                 )
             else:
                 valid_values: list[Contribution] = []
@@ -161,10 +161,8 @@ def _merge_mapping_results(
                         # can proceed without manual intervention. These
                         # entries may be regenerated in a future run.
                         logger.warning(
-                            "Dropping unknown %s ID %s for feature %s",
-                            key,
-                            item.item,
-                            feature.feature_id,
+                            f"Dropping unknown {key} ID {item.item} for feature"
+                            f" {feature.feature_id}"
                         )
                         continue
                     valid_values.append(item)
@@ -193,11 +191,11 @@ def map_features(
 
     for key, cfg in mapping_types.items():
         prompt = _build_mapping_prompt(results, {key: cfg})
-        logger.debug("Requesting %s mappings for %s features", key, len(results))
+        logger.debug(f"Requesting {key} mappings for {len(results)} features")
         try:
             payload = session.ask(prompt, output_type=MappingResponse)
         except Exception as exc:
-            logger.error("Invalid JSON from mapping response: %s", exc)
+            logger.error(f"Invalid JSON from mapping response: {exc}")
             raise ValueError("Agent returned invalid JSON") from exc
         results = _merge_mapping_results(results, payload, {key: cfg})
 

--- a/src/models.py
+++ b/src/models.py
@@ -211,10 +211,12 @@ class ReasoningConfig(StrictModel):
     provided without code changes.
     """
 
-    effort: Literal['minimal', 'low', 'medium', 'high'] | None = Field(
+    effort: Literal["minimal", "low", "medium", "high"] | None = Field(
         None, description="Effort level for OpenAI reasoning tasks."
     )
-    summary: Literal['detailed', 'concise'] | None = Field(None, description="Summary style for reasoning traces.")
+    summary: Literal["detailed", "concise"] | None = Field(
+        None, description="Summary style for reasoning traces."
+    )
 
     # Permit other reasoning settings that may be added by OpenAI.
     model_config = ConfigDict(extra="allow")

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -102,7 +102,7 @@ class PlateauGenerator:
         try:
             response = session.ask(prompt, output_type=DescriptionResponse)
         except Exception as exc:
-            logger.error("Invalid plateau description: %s", exc)
+            logger.error(f"Invalid plateau description: {exc}")
             raise ValueError("Agent returned invalid plateau description") from exc
         if not response.description:
             raise ValueError("'description' must be a non-empty string")
@@ -142,7 +142,7 @@ class PlateauGenerator:
         try:
             payload = session.ask(prompt, output_type=PlateauDescriptionsResponse)
         except Exception as exc:
-            logger.error("Invalid plateau descriptions: %s", exc)
+            logger.error(f"Invalid plateau descriptions: {exc}")
             raise ValueError("Agent returned invalid plateau descriptions") from exc
 
         results: dict[str, str] = {}
@@ -253,14 +253,14 @@ class PlateauGenerator:
             if description is None:
                 description = self._request_description(level, session)
             prompt = self._build_plateau_prompt(level, description)
-            logger.info("Requesting features for level=%s", level)
+            logger.info(f"Requesting features for level={level}")
 
             # Generate features within the provided conversation session so
             # history is isolated per plateau.
             try:
                 payload = session.ask(prompt, output_type=PlateauFeaturesResponse)
             except Exception as exc:
-                logger.error("Invalid JSON from feature response: %s", exc)
+                logger.error(f"Invalid JSON from feature response: {exc}")
                 raise ValueError("Agent returned invalid JSON") from exc
             for role in self.roles:
                 # ``payload.features`` uses attribute access rather than a

--- a/src/service_loader.py
+++ b/src/service_loader.py
@@ -35,16 +35,16 @@ def _load_service_entries(path: Path | str) -> Generator[ServiceInput, None, Non
                     try:
                         yield adapter.validate_json(line)
                     except Exception as exc:
-                        logger.error("Invalid service entry in %s: %s", path_obj, exc)
+                        logger.error(f"Invalid service entry in {path_obj}: {exc}")
                         raise RuntimeError("Invalid service definition") from exc
         except FileNotFoundError:
-            logger.error("Services file not found: %s", path_obj)
+            logger.error(f"Services file not found: {path_obj}")
             raise FileNotFoundError(
                 "Services file not found. Please create a %s file in the current"
                 " directory." % path_obj
             ) from None
         except Exception as exc:
-            logger.error("Error reading services file %s: %s", path_obj, exc)
+            logger.error(f"Error reading services file {path_obj}: {exc}")
             raise RuntimeError(
                 f"An error occurred while reading the services file: {exc}"
             ) from exc


### PR DESCRIPTION
## Summary
- refactor logging to use f-strings across modules for type safety
- align ReasoningConfig field definitions with linting conventions

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'logfire')*


------
https://chatgpt.com/codex/tasks/task_e_689edb68f478832b9c7f533fdf820b5f