### PR TITLE
refactor: use f-strings for logfire messages

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -72,7 +72,7 @@ async def _cmd_generate_ambitions(args: argparse.Namespace, settings) -> None:
 
     # Prefer model specified on the CLI, falling back to settings
     model_name = args.model or settings.model
-    logfire.info("Generating ambitions using model %s", model_name)
+    logfire.info(f"Generating ambitions using model {model_name}")
 
     model = build_model(
         model_name,
@@ -119,7 +119,7 @@ async def _cmd_generate_ambitions(args: argparse.Namespace, settings) -> None:
             services = svc_iter
 
         if args.dry_run:
-            logfire.info("Validated %d services", len(services_list or []))
+            logfire.info(f"Validated {len(services_list or [])} services")
             return
 
         if show_progress:
@@ -142,7 +142,7 @@ async def _cmd_generate_ambitions(args: argparse.Namespace, settings) -> None:
         processed_ids = new_ids
 
     atomic_write(processed_path, sorted(processed_ids))
-    logfire.info("Results written to %s", output_path)
+    logfire.info(f"Results written to {output_path}")
 
 
 def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
@@ -180,7 +180,7 @@ def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
         services = [s for s in svc_iter if s.service_id not in processed_ids]
 
     if args.dry_run:
-        logfire.info("Validated %d services", len(services))
+        logfire.info(f"Validated {len(services)} services")
         return
 
     new_ids: set[str] = set()
@@ -199,7 +199,7 @@ def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
             evolution = generator.generate_service_evolution(service)
             output.write(f"{evolution.model_dump_json()}\n")
             new_ids.add(service.service_id)
-            logfire.info("Generated evolution for %s", service.name)
+            logfire.info(f"Generated evolution for {service.name}")
             if progress:
                 progress.update(1)
     if progress:

--- a/src/conversation.py
+++ b/src/conversation.py
@@ -48,7 +48,7 @@ class ConversationSession:
             history.
         """
         ctx = "SERVICE_CONTEXT:\n" + service_input.model_dump_json()
-        logfire.debug("Adding service material to history: %s", ctx)
+        logfire.debug(f"Adding service material to history: {ctx}")
         self._history.append(
             messages.ModelRequest(parts=[messages.UserPromptPart(ctx)])
         )
@@ -79,12 +79,12 @@ class ConversationSession:
             agent's raw response text.
         """
 
-        logfire.debug("Sending prompt: %s", prompt)
+        logfire.debug(f"Sending prompt: {prompt}")
         result = self.client.run_sync(
             prompt, message_history=self._history, output_type=output_type
         )
         self._history.extend(result.new_messages())
-        logfire.debug("Received response: %s", result.output)
+        logfire.debug(f"Received response: {result.output}")
         return result.output
 
 

--- a/src/generator.py
+++ b/src/generator.py
@@ -260,7 +260,8 @@ class ServiceAmbitionGenerator:
                         result = await self.process_service(service)
                     except Exception as exc:
                         # Continue processing other services but record the failure.
-                        logfire.error(f"Failed to process service {service.name}: {exc}")
+                        msg = f"Failed to process service {service.name}: {exc}"
+                        logfire.error(msg)
                         return
                     line = AmbitionModel.model_validate(result).model_dump_json()
                     async with lock:

--- a/src/loader.py
+++ b/src/loader.py
@@ -67,10 +67,10 @@ def _read_file(path: Path) -> str:
         with path.open("r", encoding="utf-8") as file:
             return file.read().strip()
     except FileNotFoundError:
-        logfire.error("Prompt file not found: %s", path)
+        logfire.error(f"Prompt file not found: {path}")
         raise
     except Exception as exc:
-        logfire.error("Error reading prompt file %s: %s", path, exc)
+        logfire.error(f"Error reading prompt file {path}: {exc}")
         raise RuntimeError(
             f"An error occurred while reading the prompt file: {exc}"
         ) from exc
@@ -92,7 +92,7 @@ def _read_json_file(path: Path, schema: type[T]) -> T:
     except FileNotFoundError:
         raise
     except Exception as exc:
-        logfire.error("Error reading JSON file %s: %s", path, exc)
+        logfire.error(f"Error reading JSON file {path}: {exc}")
         raise RuntimeError(
             f"An error occurred while reading the JSON file: {exc}"
         ) from exc
@@ -207,7 +207,7 @@ def load_plateau_definitions(
     try:
         return _read_json_file(path, list[ServiceFeaturePlateau])
     except Exception as exc:
-        logfire.error("Invalid plateau definition data in %s: %s", path, exc)
+        logfire.error(f"Invalid plateau definition data in {path}: {exc}")
         raise RuntimeError(f"Invalid plateau definitions: {exc}") from exc
 
 
@@ -237,7 +237,7 @@ def load_roles(
     try:
         return _read_json_file(path, list[Role])
     except Exception as exc:
-        logfire.error("Invalid role data in %s: %s", path, exc)
+        logfire.error(f"Invalid role data in {path}: {exc}")
         raise RuntimeError(f"Invalid roles: {exc}") from exc
 
 

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -150,7 +150,7 @@ def _merge_mapping_results(
                 # feature generation can continue when the agent omits a
                 # category.  An empty list is stored for the mapping type.
                 logfire.warning(
-                    "Missing mappings: feature=%s key=%s", feature.feature_id, key
+                    f"Missing mappings: feature={feature.feature_id} key={key}"
                 )
             else:
                 valid_values: list[Contribution] = []
@@ -160,10 +160,8 @@ def _merge_mapping_results(
                         # can proceed without manual intervention. These
                         # entries may be regenerated in a future run.
                         logfire.warning(
-                            "Dropping unknown %s ID %s for feature %s",
-                            key,
-                            item.item,
-                            feature.feature_id,
+                            f"Dropping unknown {key} ID {item.item} for feature"
+                            f" {feature.feature_id}"
                         )
                         continue
                     valid_values.append(item)
@@ -192,11 +190,11 @@ def map_features(
 
     for key, cfg in mapping_types.items():
         prompt = _build_mapping_prompt(results, {key: cfg})
-        logfire.debug("Requesting %s mappings for %s features", key, len(results))
+        logfire.debug(f"Requesting {key} mappings for {len(results)} features")
         try:
             payload = session.ask(prompt, output_type=MappingResponse)
         except Exception as exc:
-            logfire.error("Invalid JSON from mapping response: %s", exc)
+            logfire.error(f"Invalid JSON from mapping response: {exc}")
             raise ValueError("Agent returned invalid JSON") from exc
         results = _merge_mapping_results(results, payload, {key: cfg})
 

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -98,7 +98,7 @@ class PlateauGenerator:
         try:
             response = session.ask(prompt, output_type=DescriptionResponse)
         except Exception as exc:
-            logfire.error("Invalid plateau description: %s", exc)
+            logfire.error(f"Invalid plateau description: {exc}")
             raise ValueError("Agent returned invalid plateau description") from exc
         if not response.description:
             raise ValueError("'description' must be a non-empty string")
@@ -138,7 +138,7 @@ class PlateauGenerator:
         try:
             payload = session.ask(prompt, output_type=PlateauDescriptionsResponse)
         except Exception as exc:
-            logfire.error("Invalid plateau descriptions: %s", exc)
+            logfire.error(f"Invalid plateau descriptions: {exc}")
             raise ValueError("Agent returned invalid plateau descriptions") from exc
 
         results: dict[str, str] = {}
@@ -249,14 +249,14 @@ class PlateauGenerator:
             if description is None:
                 description = self._request_description(level, session)
             prompt = self._build_plateau_prompt(level, description)
-            logfire.info("Requesting features for level=%s", level)
+            logfire.info(f"Requesting features for level={level}")
 
             # Generate features within the provided conversation session so
             # history is isolated per plateau.
             try:
                 payload = session.ask(prompt, output_type=PlateauFeaturesResponse)
             except Exception as exc:
-                logfire.error("Invalid JSON from feature response: %s", exc)
+                logfire.error(f"Invalid JSON from feature response: {exc}")
                 raise ValueError("Agent returned invalid JSON") from exc
             for role in self.roles:
                 # ``payload.features`` uses attribute access rather than a

--- a/src/service_loader.py
+++ b/src/service_loader.py
@@ -31,16 +31,16 @@ def _load_service_entries(path: Path | str) -> Generator[ServiceInput, None, Non
                     try:
                         yield adapter.validate_json(line)
                     except Exception as exc:
-                        logfire.error("Invalid service entry in %s: %s", path_obj, exc)
+                        logfire.error(f"Invalid service entry in {path_obj}: {exc}")
                         raise RuntimeError("Invalid service definition") from exc
         except FileNotFoundError:
-            logfire.error("Services file not found: %s", path_obj)
+            logfire.error(f"Services file not found: {path_obj}")
             raise FileNotFoundError(
                 "Services file not found. Please create a %s file in the current"
                 " directory." % path_obj
             ) from None
         except Exception as exc:
-            logfire.error("Error reading services file %s: %s", path_obj, exc)
+            logfire.error(f"Error reading services file {path_obj}: {exc}")
             raise RuntimeError(
                 f"An error occurred while reading the services file: {exc}"
             ) from exc


### PR DESCRIPTION
## Summary
- refactor logfire logging calls to use f-strings

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_689edea818bc832ba1f2cd8ee018aa04