### PR TITLE
feat: add async plateau and evolution concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ Alternatively, use the provided shell script which forwards all arguments to the
 output file will also be in JSON Lines format. Use `--concurrency` to control
 parallel workers, `--max-services` to limit how many entries are processed, and
 `--dry-run` to validate inputs without calling the API. Evolution processing
-happens in batches sized by the `batch_size` setting in `config/app.json`. Pass `--progress` to
-display a progress bar during long runs; it is suppressed automatically in CI
-environments or when stdout is not a TTY. Provide `--seed` to make stochastic
-behaviour such as backoff jitter deterministic during tests and demos.
+runs concurrently with a worker pool bounded by this setting. Pass `--progress`
+to display a progress bar during long runs; it is suppressed automatically in
+CI environments or when stdout is not a TTY. Provide `--seed` to make
+stochastic behaviour such as backoff jitter deterministic during tests and
+demos.
 
 ## Plateau-first workflow
 

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -19,9 +19,10 @@ poetry run service-ambitions generate-evolution \
 
 Use `--roles-file` to supply an alternative roles definition file when needed.
 
-Services are processed in batches controlled by the `batch_size` setting in
-`config/app.json` to avoid scheduling all tasks at once. The required number of
-features per role comes from the `features_per_role` setting in the same file.
+Services run concurrently using a bounded worker pool configured via the
+`--concurrency` flag or the `concurrency` setting in `config/app.json`. The
+required number of features per role comes from the `features_per_role` setting
+in the same file.
 
 Include `--seed <value>` to make backoff jitter and model sampling
 deterministic when supported by the provider.


### PR DESCRIPTION
## Summary
- add asynchronous ask API and session cloning for concurrent plateau and mapping calls
- parallelize mapping types and plateau generation; expose async service evolution
- process services concurrently in generate-evolution CLI and update docs

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(fails: bandit not installed)*
- `poetry run pip-audit` *(fails: pip-audit not installed)*
- `pytest tests/test_cli_generate_evolution.py` *(fails: No module named 'logfire')*


------
https://chatgpt.com/codex/tasks/task_e_68a2e415e2cc832b9068baeedec221b4