### PR TITLE
feat: add output validation and diagnostics

### DIFF
--- a/src/diagnostics.py
+++ b/src/diagnostics.py
@@ -1,0 +1,41 @@
+"""Helpers for validating generated output files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Type
+
+import logfire
+from pydantic import BaseModel
+
+
+@logfire.instrument()
+def validate_jsonl(path: Path, model: Type[BaseModel]) -> int:
+    """Validate JSON records in ``path`` against ``model``.
+
+    Args:
+        path: Location of the JSONL file to inspect.
+        model: Pydantic model used for validation of each line.
+
+    Returns:
+        The number of valid lines processed.
+
+    Raises:
+        ValueError: If any line fails validation.
+    """
+
+    count = 0
+    with path.open("r", encoding="utf-8") as handle:
+        for idx, line in enumerate(handle, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                model.model_validate_json(line)
+            except Exception as exc:  # noqa: PERF203
+                raise ValueError(f"Line {idx} invalid: {exc}") from exc
+            count += 1
+    return count
+
+
+__all__ = ["validate_jsonl"]

--- a/tests/test_async_processing.py
+++ b/tests/test_async_processing.py
@@ -175,3 +175,24 @@ def test_with_retry_honours_retry_after(monkeypatch):
     assert result == "ok"
     assert slept["delay"] == 10.0
     assert throttled["called"] == 1
+
+
+def test_generate_async_saves_transcripts(tmp_path, monkeypatch):
+    """Setting ``transcripts_dir`` writes per-service transcripts."""
+
+    monkeypatch.setattr(generator, "Agent", DummyAgent)
+    service = ServiceInput(
+        service_id="svc", name="alpha", description="d", jobs_to_be_done=[]
+    )
+    gen = generator.ServiceAmbitionGenerator(SimpleNamespace())
+    out_file = tmp_path / "out.jsonl"
+    transcripts = tmp_path / "t"
+
+    async def run() -> None:
+        await gen.generate_async(
+            [service], "prompt", str(out_file), transcripts_dir=transcripts
+        )
+
+    asyncio.run(run())
+    transcript_path = transcripts / "svc.json"
+    assert transcript_path.exists()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+from diagnostics import validate_jsonl
+
+
+class Item(BaseModel):
+    x: int
+
+
+def test_validate_jsonl(tmp_path: Path) -> None:
+    path = tmp_path / "data.jsonl"
+    path.write_text('{"x": 1}\n{"x": 2}\n', encoding="utf-8")
+    assert validate_jsonl(path, Item) == 2
+
+
+def test_validate_jsonl_raises(tmp_path: Path) -> None:
+    path = tmp_path / "bad.jsonl"
+    path.write_text('{"x": "a"}\n', encoding="utf-8")
+    with pytest.raises(ValueError):
+        validate_jsonl(path, Item)


### PR DESCRIPTION
## Summary
- stream ambition results through a single queued writer to avoid blocking I/O
- add optional transcript capture and a validate-only CLI mode
- provide reusable JSONL validation helper

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Missing imports and type errors)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL certificate verify failed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'logfire')*

------
https://chatgpt.com/codex/tasks/task_e_68a2f82c393c832bbb501b83998d9f42