### PR TITLE
feat: retry partial feature and mapping responses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "opentelemetry-instrumentation-requests",
     "tqdm",
     "types-tqdm (>=4.67.0.20250809,<5.0.0.0)",
+    "scikit-learn",
 ]
 
 [project.scripts]

--- a/src/models.py
+++ b/src/models.py
@@ -424,10 +424,10 @@ class FeatureItem(BaseModel):
 
 class FeaturesBlock(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    # Required arrays, each with ≥5 items
-    learners: Annotated[List[FeatureItem], Field(min_length=5)]
-    academics: Annotated[List[FeatureItem], Field(min_length=5)]
-    professional_staff: Annotated[List[FeatureItem], Field(min_length=5)]
+    # Feature lists for each role; lists may be empty when responses are partial.
+    learners: Annotated[List[FeatureItem], Field(default_factory=list)]
+    academics: Annotated[List[FeatureItem], Field(default_factory=list)]
+    professional_staff: Annotated[List[FeatureItem], Field(default_factory=list)]
 
 
 class PlateauFeaturesResponse(BaseModel):
@@ -448,6 +448,13 @@ class PlateauFeaturesResponse(BaseModel):
         if len(ids) != len(set(ids)):
             raise ValueError("feature_id values must be unique across all roles")
         return self
+
+
+class RoleFeaturesResponse(BaseModel):
+    """Schema used when repairing missing role features."""
+
+    model_config = ConfigDict(extra="forbid")
+    features: list[FeatureItem]
 
 
 def _normalize_mapping_values(
@@ -562,6 +569,7 @@ __all__ = [
     "MaturityScore",
     "PlateauFeature",
     "PlateauFeaturesResponse",
+    "RoleFeaturesResponse",
     "PlateauResult",
     "StageModels",
     "ReasoningConfig",


### PR DESCRIPTION
## Summary
- handle partial feature lists by re-requesting missing role items
- retry mapping generation with TF-IDF ranked catalogue slices
- cover feature and mapping repair logic with tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic_ai' and other missing dependencies)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError contacting pypi.org)*
- `poetry run pytest` *(fails: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68a2fa9160d8832ba299362bd2677713