### PR TITLE
Respect batch_size when scheduling services

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -96,6 +96,7 @@ async def _cmd_generate_ambitions(args: argparse.Namespace, settings) -> None:
     generator = ServiceAmbitionGenerator(
         model,
         concurrency=concurrency,
+        batch_size=settings.batch_size,
         request_timeout=settings.request_timeout,
         retries=settings.retries,
         retry_base_delay=settings.retry_base_delay,


### PR DESCRIPTION
## Summary
- limit pending tasks by processing services in batches
- pass configured batch_size to the ambition generator
- test that only one batch of services is consumed at a time

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*
- `pytest` *(fails: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68a300009dfc832b97e6c7147042d610