### PR TITLE
Add token estimation utility with optional tiktoken support

### DIFF
--- a/src/token_utils.py
+++ b/src/token_utils.py
@@ -1,0 +1,32 @@
+"""Utility helpers for estimating token counts.
+
+This module exposes :func:`estimate_tokens`, which uses ``tiktoken`` when
+available and otherwise falls back to a simple heuristic.
+"""
+
+from __future__ import annotations
+
+try:
+    import tiktoken
+except Exception:  # pragma: no cover - in case of unexpected import errors
+    tiktoken = None
+
+
+def estimate_tokens(prompt: str, expected_output: int) -> int:
+    """Estimate the total tokens needed for a prompt and its response.
+
+    Args:
+        prompt: The textual prompt that will be sent to the model.
+        expected_output: The anticipated number of tokens in the model's reply.
+
+    Returns:
+        The estimated total number of tokens for the prompt plus the expected
+        output.
+    """
+    if tiktoken is not None:
+        # Use the installed ``tiktoken`` package for accurate token counts.
+        encoding = tiktoken.get_encoding("cl100k_base")
+        return len(encoding.encode(prompt)) + expected_output
+
+    # Fallback to a rough heuristic when ``tiktoken`` is unavailable.
+    return len(prompt) // 4 + expected_output

--- a/tests/test_token_utils.py
+++ b/tests/test_token_utils.py
@@ -1,0 +1,32 @@
+"""Tests for the :mod:`token_utils` module."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+
+import token_utils
+
+
+def test_estimate_tokens_with_tiktoken(monkeypatch) -> None:
+    """Ensure ``estimate_tokens`` uses ``tiktoken`` when available."""
+    dummy_module = types.ModuleType("tiktoken")
+    dummy_module.get_encoding = lambda name: SimpleNamespace(
+        encode=lambda text: list(text)
+    )
+    monkeypatch.setitem(sys.modules, "tiktoken", dummy_module)
+    importlib.reload(token_utils)
+
+    prompt = "hello"
+    assert token_utils.estimate_tokens(prompt, 2) == len(prompt) + 2
+
+
+def test_estimate_tokens_without_tiktoken(monkeypatch) -> None:
+    """Fallback path when ``tiktoken`` is not installed."""
+    monkeypatch.setitem(sys.modules, "tiktoken", None)
+    importlib.reload(token_utils)
+
+    prompt = "hello world"
+    assert token_utils.estimate_tokens(prompt, 3) == len(prompt) // 4 + 3


### PR DESCRIPTION
## Summary
- add `estimate_tokens` helper using tiktoken when available with heuristic fallback
- cover tiktoken and fallback paths with unit tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy src/token_utils.py tests/test_token_utils.py` *(fails: Error importing plugin "pydantic.mypy")*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: certificate verify failed)*
- `poetry run pytest tests/test_token_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a326e1d3ec832ba10ffc688acd045f