### PR TITLE
test: expand token and backpressure coverage

### DIFF
--- a/tests/test_backpressure.py
+++ b/tests/test_backpressure.py
@@ -62,6 +62,29 @@ async def test_slow_start_resets_after_grace():
     assert sem.limit == 4
 
 
+async def test_consecutive_throttles_ramp_conservatively():
+    """Repeated throttles double ramp interval and delay recovery."""
+
+    sem = AdaptiveSemaphore(4, ramp_interval=0.05, grace_period=0.2)
+    sem.throttle(0.05)
+    # Allow first throttle to reduce permits.
+    await asyncio.sleep(0.01)
+    sem.throttle(0.05)
+    await asyncio.sleep(0.02)
+
+    # Limit is halved twice and ramp interval doubled.
+    assert sem.limit == 1
+    assert sem._ramp_interval == pytest.approx(0.1, abs=0.01)
+
+    # Before delay + ramp interval no permits are restored.
+    await asyncio.sleep(0.09)
+    assert sem.limit == 1
+
+    # After the recovery window begins, capacity ramps up slowly.
+    await asyncio.sleep(0.06)
+    assert sem.limit == 2
+
+
 async def test_weighted_permits_respected():
     """Weighted acquisition blocks until enough permits are free."""
 
@@ -79,6 +102,22 @@ async def test_weighted_permits_respected():
     await asyncio.gather(first, second)
 
     assert order == [1, 2]
+
+
+async def test_multi_weight_acquisition_release_counts():
+    """Acquire and release multiple permits while tracking counts."""
+
+    sem = AdaptiveSemaphore(5)
+    await sem.acquire(3)
+    assert sem.limit == 5
+    assert sem._sem._value == 2
+    await sem.acquire(2)
+    assert sem._sem._value == 0
+    sem.release(3)
+    assert sem._sem._value == 3
+    sem.release(2)
+    assert sem._sem._value == 5
+    assert sem.limit == 5
 
 
 def test_rolling_metrics_reports(monkeypatch):

--- a/tests/test_token_utils.py
+++ b/tests/test_token_utils.py
@@ -30,3 +30,25 @@ def test_estimate_tokens_without_tiktoken(monkeypatch) -> None:
 
     prompt = "hello world"
     assert token_utils.estimate_tokens(prompt, 3) == len(prompt) // 4 + 3
+
+
+def test_estimate_tokens_empty_prompt_with_tiktoken(monkeypatch) -> None:
+    """Empty prompts still account for expected output when using tiktoken."""
+
+    dummy_module = types.ModuleType("tiktoken")
+    dummy_module.get_encoding = lambda name: SimpleNamespace(
+        encode=lambda text: list(text)
+    )
+    monkeypatch.setitem(sys.modules, "tiktoken", dummy_module)
+    importlib.reload(token_utils)
+
+    assert token_utils.estimate_tokens("", 5) == 5
+
+
+def test_estimate_tokens_empty_prompt_without_tiktoken(monkeypatch) -> None:
+    """Empty prompts fall back to expected output when tiktoken missing."""
+
+    monkeypatch.setitem(sys.modules, "tiktoken", None)
+    importlib.reload(token_utils)
+
+    assert token_utils.estimate_tokens("", 7) == 7


### PR DESCRIPTION
## Summary
- add tests for AdaptiveSemaphore slow-start under consecutive 429s
- verify multi-weight acquisition and release accounting
- cover empty prompts in token estimation with and without tiktoken

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Cannot find implementation or library stub for module named "openai")*
- `poetry run bandit -r src -ll` *(fails: Command not found: bandit)*
- `poetry run pip-audit` *(fails: Command not found: pip-audit)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68a3a31e7bbc832bbdfcf9e0e4e4fea4