### PR TITLE
chore: configure tooling for token utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ tool and then install the project's dependencies with:
 poetry install
 ```
 
+For more accurate token estimation, include the optional ``tiktoken`` extra:
+
+```bash
+poetry install -E tiktoken
+```
+
 After installation the `service-ambitions` console script is available.
 Run the CLI through Poetry to ensure it uses the managed environment. Use
 subcommands to select the desired operation:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
     "scikit-learn",
 ]
 
+[project.optional-dependencies]
+tiktoken = ["tiktoken"]
+
 [project.scripts]
 service-ambitions = "cli:main"
 
@@ -52,6 +55,7 @@ target-version = ["py313"]
 [tool.ruff]
 line-length = 88
 target-version = "py313"
+src = ["src", "tests"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B"]
@@ -61,6 +65,11 @@ plugins = ["pydantic.mypy"]
 warn_redundant_casts = true
 disallow_any_generics = true
 warn_unused_ignores = true
+files = ["src", "tests"]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
+testpaths = ["tests"]
+
+[tool.bandit]
+targets = ["src"]


### PR DESCRIPTION
## Summary
- include optional `tiktoken` extra
- extend tool configs so `src` and `tests` are covered
- document how to install the optional tokenizer dependency

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(command not found: bandit)*
- `poetry run pip-audit` *(command not found: pip-audit)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'logfire')*

------
https://chatgpt.com/codex/tasks/task_e_68a3a78fc36c832b8482cf24a239d8bb