### PR TITLE
feat: track token usage metrics

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -304,6 +304,8 @@ class ServiceAmbitionGenerator:
             if limiter is None:  # pragma: no cover - defensive
                 raise RuntimeError("Limiter not initialized")
             async with limiter(weight_estimate):
+                if self._metrics:
+                    self._metrics.record_tokens(weight_estimate)
                 # Record service metadata on the span so that traces include the
                 # originating service identifier and customer segment.
                 with logfire.span("process_service") as span:

--- a/tests/test_backpressure.py
+++ b/tests/test_backpressure.py
@@ -121,7 +121,7 @@ async def test_multi_weight_acquisition_release_counts():
 
 
 def test_rolling_metrics_reports(monkeypatch):
-    """Metrics emit request rate and error rate."""
+    """Metrics emit request, error and token rates."""
 
     calls: list[SimpleNamespace] = []
 
@@ -132,7 +132,8 @@ def test_rolling_metrics_reports(monkeypatch):
     metrics = RollingMetrics(window=1)
     metrics.record_request()
     metrics.record_error()
+    metrics.record_tokens(5)
     metrics.record_request()
 
     names = {c.name for c in calls}
-    assert {"requests_per_second", "error_rate"} <= names
+    assert {"requests_per_second", "error_rate", "tokens_per_second"} <= names


### PR DESCRIPTION
## Summary
- extend RollingMetrics with token tracking and emit `tokens_per_second`
- record token estimates in service processing and expose metric
- test token metric emission

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Error importing plugin 'pydantic.mypy': No module named 'pydantic')*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError: certificate verify failed)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68a3a8c828c4832b973d6d5566d1a241