### PR TITLE
Use tiktoken for plateau token estimates

### DIFF
--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -32,6 +32,7 @@ from models import (
     ServiceInput,
 )
 from token_scheduler import TokenScheduler
+from token_utils import estimate_tokens
 
 # Snapshot of plateau definitions sourced from configuration.
 _PLATEAU_DEFS = load_plateau_definitions()
@@ -131,9 +132,9 @@ class PlateauGenerator:
 
     @staticmethod
     def _predict_token_load(text: str) -> int:
-        """Return a crude token count prediction for ``text``."""
+        """Return a token count prediction for ``text``."""
 
-        return max(1, len(text.split()))
+        return max(1, estimate_tokens(text, 0))
 
     @logfire.instrument()
     def _request_descriptions(

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -73,6 +73,20 @@ def _feature_payload(count: int, level: int = 1) -> str:
     return json.dumps(payload)
 
 
+def test_predict_token_load_uses_estimate_tokens(monkeypatch) -> None:
+    """Token load predictions should call ``estimate_tokens``."""
+
+    called: dict[str, tuple[str, int]] = {}
+
+    def fake_estimate(text: str, expected: int) -> int:
+        called["args"] = (text, expected)
+        return 9
+
+    monkeypatch.setattr("plateau_generator.estimate_tokens", fake_estimate)
+    assert PlateauGenerator._predict_token_load("hello") == 9
+    assert called["args"] == ("hello", 0)
+
+
 def test_build_plateau_prompt_preserves_role_placeholder(monkeypatch) -> None:
     """_build_plateau_prompt should retain role placeholders."""
 


### PR DESCRIPTION
## Summary
- leverage tiktoken-based `estimate_tokens` when predicting plateau token load
- test plateau token predictions to ensure tiktoken estimator is used

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(command not found)*
- `poetry run pip-audit` *(command not found)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'logfire')*

------
https://chatgpt.com/codex/tasks/task_e_68a3aaaad97c832b9b812b75347613c4