### PR TITLE
Add property, rate-limit, and golden output tests

### DIFF
--- a/tests/golden/sample_run.jsonl
+++ b/tests/golden/sample_run.jsonl
@@ -1,0 +1,1 @@
+{"service": "{\"service_id\":\"svc\",\"name\":\"alpha\",\"customer_type\":null,\"description\":\"desc\",\"jobs_to_be_done\":[{\"name\":\"job\"}],\"features\":[]}"}

--- a/tests/test_golden_output.py
+++ b/tests/test_golden_output.py
@@ -1,0 +1,40 @@
+"""Verify generator output against a locked golden file."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import generator
+from models import ServiceInput
+
+
+class DummyAgent:
+    """Agent echoing the service prompt for deterministic output."""
+
+    def __init__(self, model, instructions):
+        self.model = model
+        self.instructions = instructions
+
+    async def run(self, user_prompt: str, output_type):  # noqa: D401 - simple stub
+        return SimpleNamespace(
+            output=SimpleNamespace(model_dump=lambda: {"service": user_prompt})
+        )
+
+
+def test_sample_run_matches_golden(monkeypatch, tmp_path):
+    """A small end-to-end run should match the stored golden JSONL file."""
+
+    monkeypatch.setattr(generator, "Agent", DummyAgent)
+    service = ServiceInput(
+        service_id="svc",
+        name="alpha",
+        description="desc",
+        jobs_to_be_done=[{"name": "job"}],
+    )
+    gen = generator.ServiceAmbitionGenerator(SimpleNamespace())
+    out_path = tmp_path / "out.jsonl"
+    asyncio.run(gen.generate_async([service], "prompt", str(out_path)))
+    expected = (Path(__file__).parent / "golden" / "sample_run.jsonl").read_text()
+    assert out_path.read_text() == expected

--- a/tests/test_rate_limit_concurrency.py
+++ b/tests/test_rate_limit_concurrency.py
@@ -1,0 +1,64 @@
+"""Concurrency tests validating rate-limit recovery behaviour."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import backpressure
+import generator
+from backpressure import AdaptiveSemaphore
+
+
+class DummyRateLimitError(Exception):
+    """Rate limit error stub exposing ``Retry-After`` headers."""
+
+    def __init__(self) -> None:
+        self.response = SimpleNamespace(headers={"Retry-After": "0"})
+
+
+def test_with_retry_restores_permits(monkeypatch) -> None:
+    """Rate-limit waves should throttle concurrency and then recover."""
+
+    async def run() -> None:
+        limiter = AdaptiveSemaphore(permits=2)
+        throttled = {"count": 0}
+
+        def recording_throttle(delay: float) -> None:
+            throttled["count"] += 1
+            limiter.throttle(delay)
+
+        attempts = {"count": 0}
+
+        async def flaky() -> str:
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise DummyRateLimitError()
+            return "ok"
+
+        async def fast_sleep(_: float) -> None:
+            return None
+
+        monkeypatch.setattr(generator.asyncio, "sleep", fast_sleep)
+        monkeypatch.setattr(backpressure.asyncio, "sleep", fast_sleep)
+        monkeypatch.setattr(generator, "RateLimitError", DummyRateLimitError)
+        monkeypatch.setattr(
+            generator,
+            "TRANSIENT_EXCEPTIONS",
+            generator.TRANSIENT_EXCEPTIONS + (DummyRateLimitError,),
+        )
+
+        result = await generator._with_retry(  # type: ignore[attr-defined]
+            flaky,
+            request_timeout=0.1,
+            attempts=2,
+            base=0.1,
+            on_retry_after=recording_throttle,
+        )
+        await asyncio.sleep(0)
+
+        assert result == "ok"
+        assert throttled["count"] == 1
+        assert limiter.limit == 2
+
+    asyncio.run(run())

--- a/tests/test_roundtrip_models.py
+++ b/tests/test_roundtrip_models.py
@@ -1,0 +1,89 @@
+"""Property-based tests ensuring schema round-trips preserve data."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from models import (
+    CMMI_LABELS,
+    Contribution,
+    MappingFeature,
+    MappingResponse,
+    MaturityScore,
+    PlateauFeature,
+)
+
+# Basic string strategy limiting size and alphabet to keep examples small.
+TEXT = st.text(min_size=1, max_size=20)
+
+# Strategy generating valid ``Contribution`` instances.
+contributions = st.builds(
+    Contribution,
+    item=TEXT,
+    contribution=st.floats(min_value=0.1, max_value=1.0),
+)
+
+
+# Strategy producing mapping dictionaries with up to three types and five items each.
+def mapping_dict() -> st.SearchStrategy[Dict[str, List[Contribution]]]:
+    return st.dictionaries(
+        TEXT,
+        st.lists(contributions, max_size=5),
+        max_size=3,
+    )
+
+
+# Strategy for ``MaturityScore`` ensuring label matches level.
+def maturity_scores() -> st.SearchStrategy[MaturityScore]:
+    def build(level: int) -> MaturityScore:
+        return MaturityScore(
+            level=level,
+            label=CMMI_LABELS[level],
+            justification="j",
+        )
+
+    return st.integers(min_value=1, max_value=5).map(build)
+
+
+# Strategy for ``PlateauFeature`` round-trip testing.
+@st.composite
+def plateau_features(draw) -> PlateauFeature:
+    return PlateauFeature(
+        feature_id=draw(TEXT),
+        name=draw(TEXT),
+        description=draw(TEXT),
+        score=draw(maturity_scores()),
+        customer_type=draw(TEXT),
+        mappings=draw(mapping_dict()),
+    )
+
+
+# Strategy for ``MappingFeature`` used in ``MappingResponse`` tests.
+@st.composite
+def mapping_features(draw) -> MappingFeature:
+    return MappingFeature(
+        feature_id=draw(TEXT),
+        mappings=draw(mapping_dict()),
+    )
+
+
+@given(plateau_features())
+def test_plateau_feature_round_trip(feature: PlateauFeature) -> None:
+    """Dumping and reloading ``PlateauFeature`` should yield an identical model."""
+
+    payload = feature.model_dump()
+    result = PlateauFeature.model_validate(payload)
+    assert result.model_dump() == payload
+
+
+@given(st.lists(mapping_features(), min_size=1, max_size=4))
+def test_mapping_response_round_trip(features: list[MappingFeature]) -> None:
+    """``MappingResponse`` serialisation round-trips correctly."""
+
+    response = MappingResponse(features=features)
+    payload = response.model_dump()
+    result = MappingResponse.model_validate(payload)
+    assert result.model_dump() == payload


### PR DESCRIPTION
## Summary
- add property-based round-trip tests for PlateauFeature and MappingResponse schemas
- simulate rate-limit recovery using _with_retry in concurrency test
- lock generator output to a golden JSON sample for regression safety

## Testing
- `black --preview --enable-unstable-feature string_processing .`
- `ruff check .`
- `mypy .` *(fails: Cannot find implementation or library stub for module named "openai")*
- `bandit -r src -ll`
- `pip-audit` *(fails: SSLCertVerificationError: certificate verify failed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'logfire')*
- `pytest tests/test_roundtrip_models.py tests/test_rate_limit_concurrency.py tests/test_golden_output.py`

------
https://chatgpt.com/codex/tasks/task_e_68a3d1cba138832bbe97c5e2027fdb1e