### PR TITLE
docs: add issue template and review guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,25 @@
+# Issue Template
+
+## Summary
+A concise description of the problem or enhancement.
+
+## Steps to Reproduce
+If reporting a bug, provide the minimal steps to reproduce the issue.
+
+## Expected Behavior
+Describe what you expected to happen.
+
+## Actual Behavior
+Describe what actually happened.
+
+## Environment
+- OS:
+- Python version:
+- Additional details:
+
+## Additional Context
+Add any other context, logs, or screenshots about the issue here.
+
+## Acceptance Criteria
+List the conditions that must be satisfied for this issue to be resolved.
+- [ ] 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,11 @@ This repository uses automated code quality tooling for all Python sources.
 
 - Keep README and other docs in sync with code changes.
 - Maintain accurate docstrings for all public APIs.
+
+## Issue Tracking and PR Hygiene
+
+- During code review, capture bugs, enhancements, and questions as GitHub issues using the repository's issue template.
+- Use `gh issue create --title <title> --body <body>` and follow the template's sections for summary, reproduction steps, expected vs. actual behaviour, environment details, and additional context.
+- Link issues to pull requests with keywords like `Fixes #123` or `Closes #123` in commit messages or the PR description.
+- Ensure each pull request references relevant issues and keeps its commits focused and descriptive.
+- Include clear acceptance criteria in every issue to define completion.


### PR DESCRIPTION
## Summary
- add GitHub issue template for consistent reporting
- document issue tracking and PR hygiene in AGENTS

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: No module named 'pytest', 'openai', etc.)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'logfire', 'pydantic', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a3d85705cc832bbd94e225091594fc