### PR TITLE
feat: add configurable token weighting

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -1,37 +1,27 @@
 {
-  "model": "openai:gpt-5",
-  "models": {
-    "descriptions": "openai:o4-mini",
-    "features": "openai:gpt-5",
-    "mapping": "openai:o4-mini",
-    "search": "openai:gpt-4o-search-preview"
-  },
-  "reasoning": {
-    "effort": "medium"
-  },
-  "web_search": false,
-  "log_level": "INFO",
-  "mapping_types": {
-    "data": {
-      "dataset": "information",
-      "label": "Data"
+    "model": "openai:gpt-5",
+    "models": {
+        "descriptions": "openai:o4-mini",
+        "features": "openai:gpt-5",
+        "mapping": "openai:o4-mini",
+        "search": "openai:gpt-4o-search-preview",
     },
-    "applications": {
-      "dataset": "applications",
-      "label": "Applications"
+    "reasoning": {"effort": "medium"},
+    "web_search": false,
+    "log_level": "INFO",
+    "mapping_types": {
+        "data": {"dataset": "information", "label": "Data"},
+        "applications": {"dataset": "applications", "label": "Applications"},
+        "technology": {"dataset": "technologies", "label": "Technologies"},
     },
-    "technology": {
-      "dataset": "technologies",
-      "label": "Technologies"
-    }
-  },
-  "prompt_dir": "prompts",
-  "context_id": "university",
-  "inspiration": "general",
-  "concurrency": 5,
-  "batch_size": 25,
-  "request_timeout": 60,
-  "retries": 5,
-  "retry_base_delay": 0.5,
-  "features_per_role": 5
+    "prompt_dir": "prompts",
+    "context_id": "university",
+    "inspiration": "general",
+    "concurrency": 5,
+    "token_weighting": true,
+    "batch_size": 25,
+    "request_timeout": 60,
+    "retries": 5,
+    "retry_base_delay": 0.5,
+    "features_per_role": 5,
 }

--- a/src/cli.py
+++ b/src/cli.py
@@ -104,6 +104,7 @@ async def _cmd_generate_ambitions(args: argparse.Namespace, settings) -> None:
         retries=settings.retries,
         retry_base_delay=settings.retry_base_delay,
         expected_output_tokens=args.expected_output_tokens,
+        token_weighting=settings.token_weighting,
     )
 
     part_path = output_path.with_suffix(

--- a/src/models.py
+++ b/src/models.py
@@ -293,6 +293,10 @@ class AppConfig(StrictModel):
         ge=1,
         description="Number of services to process concurrently.",
     )
+    token_weighting: bool = Field(
+        True,
+        description="Weight semaphore permits by estimated token usage.",
+    )
     batch_size: int | None = Field(
         None,
         ge=1,

--- a/src/settings.py
+++ b/src/settings.py
@@ -32,6 +32,9 @@ class Settings(BaseSettings):
     concurrency: int = Field(
         ..., ge=1, description="Number of services to process concurrently."
     )
+    token_weighting: bool = Field(
+        True, description="Weight semaphore permits by estimated token usage."
+    )
     batch_size: int | None = Field(
         None, ge=1, description="Number of services to schedule per batch."
     )
@@ -95,6 +98,7 @@ def load_settings() -> Settings:
             context_id=config.context_id,
             inspiration=config.inspiration,
             concurrency=config.concurrency,
+            token_weighting=config.token_weighting,
             batch_size=config.batch_size,
             request_timeout=config.request_timeout,
             retries=config.retries,

--- a/tests/test_async_processing.py
+++ b/tests/test_async_processing.py
@@ -248,7 +248,58 @@ async def test_weighted_acquisition(monkeypatch, tmp_path):
     await gen._process_all(services, str(tmp_path / "out.jsonl"))
     assert sorted(captured) == [1, 3]
     names = {c.name for c in metrics_calls}
-    assert "tokens_per_second" in names
+    assert {"tokens_per_second", "tokens_in_flight"} <= names
+
+
+@pytest.mark.asyncio()
+async def test_process_all_without_token_weighting(tmp_path, monkeypatch):
+    """Token weighting may be disabled to use uniform permits."""
+
+    captured: list[int] = []
+    metrics_calls: list[SimpleNamespace] = []
+
+    class DummyLimiter:
+        def __call__(self, weight: int = 1):
+            captured.append(weight)
+
+            @asynccontextmanager
+            async def manager():
+                yield
+
+            return manager()
+
+        def throttle(self, _delay: float) -> None:  # pragma: no cover - no-op
+            pass
+
+    async def fake_process_service(self, service, prompt=None):
+        return {"id": service.service_id}
+
+    def fail_estimate(prompt: str, expected: int) -> int:  # pragma: no cover
+        raise AssertionError("estimate_tokens should be bypassed")
+
+    monkeypatch.setattr(generator, "estimate_tokens", fail_estimate)
+    monkeypatch.setattr(
+        generator.ServiceAmbitionGenerator, "process_service", fake_process_service
+    )
+    monkeypatch.setattr(
+        backpressure.logfire,
+        "metric",
+        lambda n, v: metrics_calls.append(SimpleNamespace(name=n, value=v)),
+    )
+
+    gen = generator.ServiceAmbitionGenerator(SimpleNamespace(), token_weighting=False)
+    gen._prompt = "p"
+    gen._limiter = DummyLimiter()
+    gen._metrics = generator.RollingMetrics(window=1)
+    services = [
+        ServiceInput(service_id="svc1", name="s1", description="d", jobs_to_be_done=[]),
+        ServiceInput(service_id="svc2", name="s2", description="d", jobs_to_be_done=[]),
+    ]
+    await gen._process_all(services, str(tmp_path / "out.jsonl"))
+    assert captured == [1, 1]
+    names = {c.name for c in metrics_calls}
+    assert "tokens_per_second" not in names
+    assert "tokens_in_flight" not in names
 
 
 @pytest.mark.asyncio()

--- a/tests/test_backpressure.py
+++ b/tests/test_backpressure.py
@@ -132,8 +132,14 @@ def test_rolling_metrics_reports(monkeypatch):
     metrics = RollingMetrics(window=1)
     metrics.record_request()
     metrics.record_error()
-    metrics.record_tokens(5)
+    metrics.record_start_tokens(5)
+    metrics.record_end_tokens(5)
     metrics.record_request()
 
     names = {c.name for c in calls}
-    assert {"requests_per_second", "error_rate", "tokens_per_second"} <= names
+    assert {
+        "requests_per_second",
+        "error_rate",
+        "tokens_per_second",
+        "tokens_in_flight",
+    } <= names

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,6 +60,7 @@ def test_cli_generates_output(tmp_path, monkeypatch):
         reasoning=None,
         models=None,
         web_search=False,
+        token_weighting=True,
     )
 
     async def fake_process_service(self, service, prompt=None):
@@ -121,6 +122,7 @@ def test_cli_dry_run_skips_processing(tmp_path, monkeypatch):
         reasoning=None,
         models=None,
         web_search=False,
+        token_weighting=True,
     )
 
     called = {"ran": False}
@@ -196,6 +198,7 @@ def test_cli_switches_context(tmp_path, monkeypatch):
         logfire_token=None,
         reasoning=None,
         web_search=False,
+        token_weighting=True,
     )
 
     async def fake_process_service(self, service, prompt=None):
@@ -260,6 +263,7 @@ def test_cli_model_instantiation_arguments(tmp_path, monkeypatch):
         logfire_token=None,
         reasoning=None,
         web_search=False,
+        token_weighting=True,
     )
 
     captured: dict[str, str] = {}
@@ -334,6 +338,7 @@ def test_cli_seed_sets_random(tmp_path, monkeypatch):
         logfire_token=None,
         reasoning=None,
         web_search=False,
+        token_weighting=True,
     )
 
     captured: dict[str, int | None] = {}
@@ -416,6 +421,7 @@ def test_cli_enables_logfire(tmp_path, monkeypatch):
         logfire_token="lf-key",
         reasoning=None,
         web_search=False,
+        token_weighting=True,
     )
 
     async def fake_process_service(self, service, prompt=None):
@@ -485,6 +491,7 @@ def test_cli_rejects_invalid_concurrency(monkeypatch):
         logfire_token=None,
         reasoning=None,
         web_search=False,
+        token_weighting=True,
     )
     monkeypatch.setattr(cli, "load_settings", lambda: settings)
 
@@ -533,6 +540,7 @@ def test_cli_passes_expected_output_tokens(tmp_path, monkeypatch):
         reasoning=None,
         models=None,
         web_search=False,
+        token_weighting=True,
     )
 
     captured: dict[str, int] = {}
@@ -546,6 +554,7 @@ def test_cli_passes_expected_output_tokens(tmp_path, monkeypatch):
         retries=5,
         retry_base_delay=0.5,
         expected_output_tokens=256,
+        token_weighting=True,
     ) -> None:
         captured["expected"] = expected_output_tokens
 
@@ -597,6 +606,7 @@ def test_cli_verbose_logging(tmp_path, monkeypatch):
         logfire_token=None,
         reasoning=None,
         web_search=False,
+        token_weighting=True,
     )
 
     async def fake_process_service(self, service, prompt=None):
@@ -737,6 +747,7 @@ def test_cli_validate_only(tmp_path, monkeypatch):
         reasoning=None,
         models=None,
         web_search=False,
+        token_weighting=True,
     )
 
     monkeypatch.setattr(cli, "load_settings", lambda: settings)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -26,6 +26,7 @@ def test_load_settings_reads_env(monkeypatch) -> None:
     assert settings.features_per_role == 5
     assert settings.mapping_batch_size == 30
     assert settings.mapping_parallel_types is True
+    assert settings.token_weighting is True
     assert settings.reasoning is not None
     assert settings.reasoning.effort == "medium"
 


### PR DESCRIPTION
## Summary
- track in-flight tokens and throughput with start/end counters
- make token-based permit weighting configurable via settings
- wire token weighting through generator and CLI

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing tests/test_async_processing.py tests/test_cli.py tests/test_backpressure.py tests/test_settings.py src/backpressure.py src/cli.py src/generator.py src/models.py src/settings.py config/app.json`
- `poetry run ruff check --fix tests/test_async_processing.py tests/test_cli.py tests/test_backpressure.py tests/test_settings.py src/backpressure.py src/cli.py src/generator.py src/models.py src/settings.py`
- `poetry run mypy .` *(fails: Error importing plugin "pydantic.mypy": No module named 'pydantic')*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a403353764832ba34df933e7398b33