### PR TITLE
docs: add model options table and web search guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,27 @@ Stage-specific model overrides live under the `models` block in
 }
 ```
 
+| Stage        | Default model               | Fast/cheap alternative |
+|--------------|-----------------------------|------------------------|
+| Descriptions | `openai:o4-mini`            | Already cost optimised |
+| Features     | `openai:gpt-5`              | `openai:o4-mini`       |
+| Mapping      | `openai:o4-mini`            | Already cost optimised |
+| Search       | `openai:gpt-4o-search-preview` | n/a |
+
+OpenAI recommends using cost‑optimised models like `o4-mini` when latency or
+price is a concern and higher‑capacity models such as `gpt-5` for best quality
+results. See the [model selection guide](https://platform.openai.com/docs/guides/model-selection)
+for details.
+
 OpenAI's experimental web search tool can be enabled via the `web_search`
 setting or the `--web-search/--no-web-search` CLI flags. The sample
 configuration leaves this disabled.
+
+### When to enable web search
+
+Enable web search only when prompts require external lookups, such as verifying
+recent facts or gathering up‑to‑date statistics. The preview tool adds latency
+and cost, so keep it disabled for self‑contained tasks.
 
 System prompts are assembled from modular markdown components located in the
 `prompts/` directory. Use `--prompt-dir` to point at an alternate component

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -27,6 +27,28 @@ in the same file.
 Include `--seed <value>` to make backoff jitter and model sampling
 deterministic when supported by the provider.
 
+### Model selection
+
+Defaults come from `config/app.json`:
+
+| Stage        | Default model               | Fast/cheap alternative |
+|--------------|-----------------------------|------------------------|
+| Descriptions | `openai:o4-mini`            | Already cost optimised |
+| Features     | `openai:gpt-5`              | `openai:o4-mini`       |
+| Mapping      | `openai:o4-mini`            | Already cost optimised |
+| Search       | `openai:gpt-4o-search-preview` | n/a |
+
+OpenAI advises using lower‑capacity models like `o4-mini` for budget‑sensitive
+workloads and reserving larger models such as `gpt-5` for highest quality
+results. See the [model selection guide](https://platform.openai.com/docs/guides/model-selection)
+for more guidance.
+
+### When to enable web search
+
+Pass `--web-search` when prompts require external lookups, such as verifying
+recent facts or sourcing current statistics. The preview tool adds latency and
+cost, so leave it disabled for self‑contained tasks.
+
 ## Output schema
 
 Each line in the output file is a JSON object with:

--- a/src/cli.py
+++ b/src/cli.py
@@ -300,23 +300,29 @@ def main() -> None:
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument(
         "--model",
-        help="Chat model name. Can also be set via the MODEL env variable.",
+        help=(
+            "Global chat model name (default openai:gpt-5). "
+            "Can also be set via the MODEL env variable."
+        ),
     )
     common.add_argument(
         "--descriptions-model",
-        help="Model for plateau descriptions",
+        help="Model for plateau descriptions (default openai:o4-mini)",
     )
     common.add_argument(
         "--features-model",
-        help="Model for feature generation",
+        help=(
+            "Model for feature generation (default openai:gpt-5; "
+            "use openai:o4-mini for lower cost)"
+        ),
     )
     common.add_argument(
         "--mapping-model",
-        help="Model for feature mapping",
+        help="Model for feature mapping (default openai:o4-mini)",
     )
     common.add_argument(
         "--search-model",
-        help="Model for web search",
+        help="Model for web search (default openai:gpt-4o-search-preview)",
     )
     common.add_argument(
         "-v",
@@ -371,7 +377,10 @@ def main() -> None:
         "--web-search",
         action=argparse.BooleanOptionalAction,
         default=None,
-        help="Enable or disable web search for model browsing",
+        help=(
+            "Enable web search when prompts need external lookups. "
+            "Adds latency and cost"
+        ),
     )
 
     subparsers = parser.add_subparsers(dest="command", required=True)


### PR DESCRIPTION
## Summary
- document default vs budget model options for each stage based on OpenAI's guidance
- explain when to enable `--web-search`
- clarify model and search options in CLI help

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: missing stubs and type errors)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: missing optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a420f253e0832b9eda722f62222678