### PR TITLE
docs: document mapping performance options

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,24 @@ Basic invocation:
 Processing happens concurrently; control parallel workers with `--concurrency`
 which defaults to the `concurrency` value in your settings.
 
+Mapping requests are batched. Adjust `--mapping-batch-size` to control how many
+features are sent per mapping request; the default is 30. Smaller batches create
+shorter prompts and quicker responses but increase API calls. Larger batches
+reduce round trips at the cost of bigger prompts, higher latency and a greater
+risk of hitting model context limits.
+
+For each batch the CLI maps Data, Applications and Technologies in parallel.
+This behaviour is enabled by default via `--mapping-parallel-types`. Disable it
+with `--no-mapping-parallel-types` to process mapping types sequentially when
+rate limits are tight.
+
+Example invocation tuning mapping behaviour:
+
+```bash
+./run.sh generate-evolution --input-file sample-services.jsonl \
+  --output-file evolution.jsonl --mapping-batch-size 20 --no-mapping-parallel-types
+```
+
 ### Conversation seed
 
 The model conversation is seeded with service metadata so each request retains


### PR DESCRIPTION
## Summary
- clarify `generate-evolution` mapping performance flags in README
- provide example usage for batching and parallel mapping

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run python -m mypy .` *(fails: Missing named argument "search" for "StageModels" and other errors)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`


------
https://chatgpt.com/codex/tasks/task_e_68a446646208832bb0fba76e4b6b10dc