### PR TITLE
Add transcript verification for evolution CLI

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import inspect
+import json
 import logging
 import os
 import random
@@ -219,6 +220,13 @@ async def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
     processed_ids: set[str] = set(read_lines(processed_path)) if args.resume else set()
     existing_lines: list[str] = read_lines(output_path) if args.resume else []
 
+    transcripts_dir = (
+        Path(args.transcripts_dir)
+        if getattr(args, "transcripts_dir", None) is not None
+        else output_path.parent / "_transcripts"
+    )
+    transcripts_dir.mkdir(parents=True, exist_ok=True)
+
     with load_services(Path(args.input_file)) as svc_iter:
         if args.max_services is not None:
             svc_iter = islice(svc_iter, args.max_services)
@@ -268,6 +276,14 @@ async def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
                 async with lock:
                     output.write(line)
                     new_ids.add(service.service_id)
+                payload = {
+                    "request": service.model_dump(),
+                    "response": evolution.model_dump(),
+                }
+                transcript_path = transcripts_dir / f"{service.service_id}.json"
+                transcript_path.write_text(
+                    json.dumps(payload, ensure_ascii=False), encoding="utf-8"
+                )
                 logfire.info(f"Generated evolution for {service.name}")
             except Exception as exc:  # noqa: BLE001
                 quarantine_dir = Path("quarantine")
@@ -453,6 +469,13 @@ def main() -> None:
         "--output-file",
         default="evolution.jsonl",
         help="File to write the results",
+    )
+    evo.add_argument(
+        "--transcripts-dir",
+        help=(
+            "Directory to store per-service request/response transcripts. "
+            "Defaults to a '_transcripts' folder beside the output file."
+        ),
     )
     evo.add_argument(
         "--mapping-batch-size",


### PR DESCRIPTION
## Summary
- ensure evolution CLI writes service request/response transcripts
- cover transcript persistence in generate-evolution tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing tests/test_cli_generate_evolution.py`
- `poetry run ruff check --fix tests/test_cli_generate_evolution.py`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_cli_generate_evolution.py` *(fails: No module named 'pydantic_ai')*

------
https://chatgpt.com/codex/tasks/task_e_68a44664f028832bb1b097869be55a79