### PR TITLE
docs: document remapping workflow and mapping flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ subcommands to select the desired operation:
 ```bash
 poetry run service-ambitions generate-ambitions --input-file sample-services.jsonl --output-file ambitions.jsonl
 poetry run service-ambitions generate-evolution --input-file sample-services.jsonl --output-file evolution.jsonl
+poetry run service-ambitions generate-mapping --input-file evolution.jsonl --output-file remapped.jsonl
 ```
 
 Alternatively, use the provided shell script which forwards all arguments to the CLI:
@@ -95,6 +96,7 @@ Alternatively, use the provided shell script which forwards all arguments to the
 ```bash
 ./run.sh generate-ambitions --input-file sample-services.jsonl --output-file ambitions.jsonl
 ./run.sh generate-evolution --input-file sample-services.jsonl --output-file evolution.jsonl
+./run.sh generate-mapping --input-file evolution.jsonl --output-file remapped.jsonl
 ```
 
 ## Usage
@@ -109,6 +111,28 @@ to display a progress bar during long runs; it is suppressed automatically in
 CI environments or when stdout is not a TTY. Provide `--seed` to make
 stochastic behaviour such as backoff jitter deterministic during tests and
 demos.
+
+### Remapping mode
+
+Use `generate-mapping` to refresh mapping contributions for existing evolution
+results. It reads an evolution JSON Lines file and writes an updated file with
+new mapping data. Adjust mapping behaviour with:
+
+- `--mapping-batch-size` – number of features per mapping request batch. Smaller
+  batches shorten prompts but increase API calls.
+- `--mapping-parallel-types` – dispatch mapping types concurrently. Disable with
+  `--no-mapping-parallel-types` to process them sequentially when rate limits are
+  tight.
+
+Example invocation:
+
+```bash
+./run.sh generate-mapping --input-file evolution.jsonl --output-file remapped.jsonl \
+  --mapping-batch-size 20 --no-mapping-parallel-types
+```
+
+See [generate-mapping](docs/generate-mapping.md) for detailed behaviour and
+troubleshooting.
 
 ## Adaptive backpressure
 

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -7,6 +7,9 @@ evaluates all plateaus in this file alongside all roles defined in
 `data/roles.json`. Plateau name to level mappings are derived from the order of
 the JSON entries.
 
+To re-run mapping on an existing evolution output, see
+[generate-mapping](generate-mapping.md).
+
 ## Running
 
 Example command:

--- a/docs/generate-mapping.md
+++ b/docs/generate-mapping.md
@@ -1,0 +1,41 @@
+# Generate mapping
+
+Remap feature mappings for existing service evolution results.
+
+## Running
+
+Example command:
+
+```bash
+poetry run service-ambitions generate-mapping \
+  --input-file evolution.jsonl \
+  --output-file remapped.jsonl \
+  --mapping-batch-size 20 --mapping-parallel-types
+```
+
+`--mapping-batch-size` controls how many features are sent in each mapping
+request. Smaller batches shorten prompts but require more API calls; larger
+batches reduce round trips at the cost of bigger prompts and potential context
+limit pressure.
+
+`--mapping-parallel-types` dispatches mapping requests for each mapping type
+concurrently. Disable it with `--no-mapping-parallel-types` to process types
+sequentially when working under tight rate limits.
+
+## Input format
+
+Provide a JSON Lines file produced by `generate-evolution`. Each line should be a
+`ServiceEvolution` object containing plateau features. Existing mapping data, if
+present, is replaced.
+
+## Output format
+
+The output mirrors the input structure with refreshed mapping contributions under
+each feature. Mapping lists include an `item` identifier and a numeric
+`contribution` score in the range `[0.1, 1.0]`.
+
+## Troubleshooting
+
+- Ensure `OPENAI_API_KEY` is set and valid.
+- Use `--dry-run` to validate input files without making API calls.
+- Check network access and API quotas if mapping requests fail repeatedly.


### PR DESCRIPTION
## Summary
- document remapping mode in README with batch and parallel mapping options
- add generate-mapping reference guide with input/output and troubleshooting
- cross-link mapping docs from evolution guide

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Module has no attribute "get_encoding" and other errors)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`


------
https://chatgpt.com/codex/tasks/task_e_68a47f06f6e4832bb79ffa4f2194294a