### PR TITLE
Add CLI mapping test

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -25,9 +25,9 @@ from loader import (
     load_evolution_prompt,
     load_role_ids,
 )
-from mapping import init_embeddings
+from mapping import init_embeddings, map_features_async
 from model_factory import ModelFactory
-from models import ServiceInput
+from models import ServiceEvolution, ServiceInput
 from monitoring import LOG_FILE_NAME, init_logfire, logfire
 from persistence import atomic_write, read_lines
 from plateau_generator import PlateauGenerator
@@ -410,6 +410,62 @@ async def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
     )
 
 
+async def _cmd_generate_mapping(args: argparse.Namespace, settings) -> None:
+    """Augment evolution features with mapping results."""
+
+    use_web_search = (
+        args.web_search if args.web_search is not None else settings.web_search
+    )
+    factory = ModelFactory(
+        settings.model,
+        settings.openai_api_key,
+        stage_models=getattr(settings, "models", None),
+        reasoning=settings.reasoning,
+        seed=args.seed,
+        web_search=use_web_search,
+    )
+
+    map_model = factory.get("mapping", args.mapping_model or args.model)
+    map_agent = Agent(map_model, instructions="")
+    session = ConversationSession(map_agent, stage="mapping")
+
+    mapping_batch_size = args.mapping_batch_size or settings.mapping_batch_size
+    mapping_parallel_types = (
+        args.mapping_parallel_types
+        if args.mapping_parallel_types is not None
+        else settings.mapping_parallel_types
+    )
+
+    input_path = Path(args.input_file)
+    evolutions = [
+        ServiceEvolution.model_validate_json(line)
+        for line in input_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+    features = [
+        feat
+        for evo in evolutions
+        for plateau in evo.plateaus
+        for feat in plateau.features
+    ]
+    mapped = await map_features_async(
+        session,
+        features,
+        batch_size=mapping_batch_size,
+        parallel_types=mapping_parallel_types,
+    )
+    mapped_by_id = {f.feature_id: f for f in mapped}
+    for evo in evolutions:
+        for plateau in evo.plateaus:
+            plateau.features = [mapped_by_id[f.feature_id] for f in plateau.features]
+
+    output_path = Path(args.output_file)
+    with output_path.open("w", encoding="utf-8") as out:
+        for evo in evolutions:
+            out.write(f"{evo.model_dump_json()}\n")
+
+
 def main() -> None:
     """Parse arguments and dispatch to the requested subcommand."""
 
@@ -579,6 +635,23 @@ def main() -> None:
         help="Path to the roles definition JSON file",
     )
     evo.set_defaults(func=_cmd_generate_evolution)
+
+    map_p = subparsers.add_parser(
+        "generate-mapping",
+        parents=[common],
+        help="Generate feature mappings",
+    )
+    map_p.add_argument(
+        "--input-file",
+        default="evolution.jsonl",
+        help="Path to the evolution JSONL file",
+    )
+    map_p.add_argument(
+        "--output-file",
+        default="mapped.jsonl",
+        help="File to write the results",
+    )
+    map_p.set_defaults(func=_cmd_generate_mapping)
 
     args = parser.parse_args()
 

--- a/tests/test_cli_generate_mapping.py
+++ b/tests/test_cli_generate_mapping.py
@@ -1,0 +1,122 @@
+"""Tests for the generate-mapping CLI subcommand."""
+
+import argparse
+import asyncio
+import json
+from types import SimpleNamespace
+
+import cli
+from cli import _cmd_generate_mapping
+from models import (
+    Contribution,
+    MaturityScore,
+    PlateauFeature,
+    PlateauResult,
+    ServiceEvolution,
+    ServiceInput,
+)
+
+
+class DummyFactory:
+    def __init__(self, *a, **k):
+        pass
+
+    def model_name(self, stage, override=None):
+        return "m"
+
+    def get(self, stage, override=None):
+        return object()
+
+
+class DummyAgent:
+    def __init__(self, model, instructions):
+        self.model = model
+        self.instructions = instructions
+
+
+cli.ModelFactory = DummyFactory
+cli.Agent = DummyAgent
+
+
+def test_generate_mapping_updates_features(tmp_path, monkeypatch) -> None:
+    """_cmd_generate_mapping should write mapped results to disk."""
+
+    input_path = tmp_path / "evo.jsonl"
+    output_path = tmp_path / "out.jsonl"
+
+    evo = ServiceEvolution(
+        service=ServiceInput(
+            service_id="svc-1",
+            name="svc",
+            description="d",
+            customer_type="retail",
+            jobs_to_be_done=[{"name": "job"}],
+        ),
+        plateaus=[
+            PlateauResult(
+                plateau=1,
+                plateau_name="p1",
+                service_description="desc",
+                features=[
+                    PlateauFeature(
+                        feature_id="FEAT-1-learners-test",
+                        name="feat",
+                        description="fd",
+                        score=MaturityScore(
+                            level=1, label="Initial", justification="j"
+                        ),
+                        customer_type="learners",
+                        mappings={"cat": []},
+                    )
+                ],
+            )
+        ],
+    )
+    input_path.write_text(evo.model_dump_json() + "\n", encoding="utf-8")
+
+    called: dict[str, object] = {}
+
+    async def fake_map_features_async(
+        session,
+        features,
+        mapping_types=None,
+        *,
+        batch_size,
+        parallel_types,
+    ):
+        called["batch_size"] = batch_size
+        called["parallel_types"] = parallel_types
+        for feat in features:
+            feat.mappings = {"cat": [Contribution(item="X", contribution=1.0)]}
+        return list(features)
+
+    monkeypatch.setattr(cli, "map_features_async", fake_map_features_async)
+
+    settings = SimpleNamespace(
+        model="cfg",
+        openai_api_key="key",
+        mapping_batch_size=30,
+        mapping_parallel_types=True,
+        reasoning=None,
+        models=None,
+        web_search=False,
+    )
+    args = argparse.Namespace(
+        input_file=str(input_path),
+        output_file=str(output_path),
+        model=None,
+        mapping_model=None,
+        mapping_batch_size=5,
+        mapping_parallel_types=False,
+        seed=None,
+        web_search=None,
+    )
+
+    asyncio.run(_cmd_generate_mapping(args, settings))
+
+    payload = json.loads(output_path.read_text(encoding="utf-8").strip())
+    assert payload["plateaus"][0]["features"][0]["mappings"] == {
+        "cat": [{"item": "X", "contribution": 1.0}]
+    }
+    assert called["batch_size"] == 5
+    assert called["parallel_types"] is False


### PR DESCRIPTION
## Summary
- implement generate-mapping CLI helper to enrich evolution features
- add test verifying CLI writes mapping results and forwards batching flags

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_cli_generate_mapping.py`


------
https://chatgpt.com/codex/tasks/task_e_68a47f08c2c0832ba1a02dd371fc0fba