### PR TITLE
feat: enforce token limits in scheduler

### DIFF
--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -33,6 +33,7 @@ from models import (
     ServiceEvolution,
     ServiceInput,
 )
+from settings import load_settings
 from token_scheduler import TokenScheduler
 from token_utils import estimate_tokens
 
@@ -364,8 +365,11 @@ class PlateauGenerator:
         service_input: ServiceInput,
     ) -> list[PlateauResult]:
         """Return plateau results scheduled by token load."""
-
-        scheduler = TokenScheduler(max_workers=min(4, len(plateau_names)))
+        settings = load_settings()
+        scheduler = TokenScheduler(
+            max_workers=min(4, len(plateau_names)),
+            context_window=settings.context_window,
+        )
         for name in plateau_names:
             description = desc_map[name]
             tokens = self._predict_token_load(description)

--- a/src/settings.py
+++ b/src/settings.py
@@ -29,6 +29,11 @@ class Settings(BaseSettings):
     prompt_dir: Path = Field(..., description="Directory containing prompt components.")
     context_id: str = Field(..., description="Situational context identifier.")
     inspiration: str = Field(..., description="Inspirations identifier.")
+    context_window: int = Field(
+        128000,
+        ge=1,
+        description="Model's maximum prompt tokens (context window).",
+    )
     concurrency: int = Field(
         ..., ge=1, description="Number of services to process concurrently."
     )

--- a/tests/test_token_scheduler.py
+++ b/tests/test_token_scheduler.py
@@ -1,10 +1,12 @@
 import asyncio
 
+import pytest
+
 from token_scheduler import TokenScheduler
 
 
 async def _run_scheduler(completed: list[str]) -> None:
-    scheduler = TokenScheduler(max_workers=2)
+    scheduler = TokenScheduler(max_workers=2, context_window=100)
 
     async def job(duration: float, label: str) -> str:
         await asyncio.sleep(duration)
@@ -22,3 +24,10 @@ def test_shorter_tasks_complete_first() -> None:
     completed: list[str] = []
     asyncio.run(_run_scheduler(completed))
     assert completed == ["short", "medium", "long"]
+
+
+def test_submit_over_context_window_raises() -> None:
+    scheduler = TokenScheduler(max_workers=1, context_window=50)
+
+    with pytest.raises(ValueError):
+        scheduler.submit(lambda: asyncio.sleep(0), tokens=60)


### PR DESCRIPTION
## Summary
- track model context window in settings
- validate submitted tokens in `TokenScheduler`
- forward context window from `PlateauGenerator`
- test scheduler rejects tasks exceeding token limit

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: missing named arguments and type issues in tests)*
- `poetry run mypy src` *(fails: missing library stubs for sklearn)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a47f6428f0832b8aa923b2d8b19f1e