### PR TITLE
test: include evolution meta in service evolution tests

### DIFF
--- a/src/mapping.py
+++ b/src/mapping.py
@@ -18,7 +18,7 @@ import logfire
 import numpy as np
 from openai import AsyncOpenAI
 from scipy.sparse import csr_matrix
-from sklearn.feature_extraction.text import (
+from sklearn.feature_extraction.text import (  # type: ignore[import-untyped]
     TfidfVectorizer,
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,13 @@ Ensures OpenAI calls are stubbed and a deterministic API key is present.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from typing import Any, Callable
 from unittest.mock import AsyncMock
 
 import pytest
+
+from models import SCHEMA_VERSION, EvolutionMeta
 
 
 @pytest.fixture(autouse=True)
@@ -31,3 +35,19 @@ def _mock_openai(monkeypatch):
             )
     except Exception:
         pass
+
+
+@pytest.fixture
+def meta_factory() -> Callable[..., EvolutionMeta]:
+    """Return a factory that builds ``EvolutionMeta`` instances for tests."""
+
+    def _factory(**overrides: Any) -> EvolutionMeta:
+        data: dict[str, Any] = {
+            "schema_version": SCHEMA_VERSION,
+            "generated_at": datetime(2000, 1, 1, tzinfo=timezone.utc),
+            "generator": "tests",
+        }
+        data.update(overrides)
+        return EvolutionMeta(**data)
+
+    return _factory

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -34,7 +34,7 @@ async def _noop_init_embeddings() -> None:
 cli.init_embeddings = _noop_init_embeddings
 
 
-def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
+def test_generate_evolution_writes_results(tmp_path, monkeypatch, meta_factory) -> None:
     """_cmd_generate_evolution should write evolution results to disk."""
     input_path = tmp_path / "services.jsonl"
     output_path = tmp_path / "out.jsonl"
@@ -64,7 +64,7 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
         role_ids=None,
         transcripts_dir=None,
     ) -> ServiceEvolution:
-        return ServiceEvolution(service=service, plateaus=[])
+        return ServiceEvolution(meta=meta_factory(), service=service, plateaus=[])
 
     monkeypatch.setattr("cli.Agent", DummyAgent)
     monkeypatch.setattr(
@@ -115,10 +115,11 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
     payload = json.loads(output_path.read_text(encoding="utf-8").strip())
     assert payload["service"]["name"] == "svc"
     assert payload["service"]["service_id"] == "svc-1"
-    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["meta"]["schema_version"] == SCHEMA_VERSION
+    assert "generated_at" in payload["meta"]
 
 
-def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
+def test_generate_evolution_dry_run(tmp_path, monkeypatch, meta_factory) -> None:
     """Dry run should skip processing and not write output."""
     input_path = tmp_path / "services.jsonl"
     output_path = tmp_path / "out.jsonl"
@@ -138,7 +139,7 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
         transcripts_dir=None,
     ) -> ServiceEvolution:
         called["ran"] = True
-        return ServiceEvolution(service=service, plateaus=[])
+        return ServiceEvolution(meta=meta_factory(), service=service, plateaus=[])
 
     monkeypatch.setattr("cli.Agent", DummyAgent)
     monkeypatch.setattr(
@@ -190,7 +191,7 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
     assert not called["ran"]
 
 
-def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:
+def test_generate_evolution_resume(tmp_path, monkeypatch, meta_factory) -> None:
     """Resume should append new results and track processed IDs."""
     input_path = tmp_path / "services.jsonl"
     output_path = tmp_path / "out.jsonl"
@@ -219,7 +220,7 @@ def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:
         transcripts_dir=None,
     ) -> ServiceEvolution:
         processed.append(service.service_id)
-        return ServiceEvolution(service=service, plateaus=[])
+        return ServiceEvolution(meta=meta_factory(), service=service, plateaus=[])
 
     monkeypatch.setattr("cli.Agent", DummyAgent)
     monkeypatch.setattr(
@@ -273,7 +274,9 @@ def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:
     assert processed_path.read_text(encoding="utf-8").splitlines() == ["s1", "s2"]
 
 
-def test_generate_evolution_rejects_invalid_concurrency(tmp_path, monkeypatch) -> None:
+def test_generate_evolution_rejects_invalid_concurrency(
+    tmp_path, monkeypatch, meta_factory
+) -> None:
     """Invalid concurrency should raise an error rather than deadlock."""
 
     input_path = tmp_path / "services.jsonl"
@@ -291,7 +294,7 @@ def test_generate_evolution_rejects_invalid_concurrency(tmp_path, monkeypatch) -
         role_ids=None,
         transcripts_dir=None,
     ) -> ServiceEvolution:
-        return ServiceEvolution(service=service, plateaus=[])
+        return ServiceEvolution(meta=meta_factory(), service=service, plateaus=[])
 
     monkeypatch.setattr("cli.Agent", DummyAgent)
     monkeypatch.setattr(
@@ -376,7 +379,9 @@ def test_cli_parses_mapping_options(tmp_path, monkeypatch) -> None:
     assert called["args"].mapping_parallel_types is False
 
 
-def test_generate_evolution_writes_transcripts(tmp_path, monkeypatch) -> None:
+def test_generate_evolution_writes_transcripts(
+    tmp_path, monkeypatch, meta_factory
+) -> None:
     """_cmd_generate_evolution writes per-service transcripts to disk."""
 
     input_path = tmp_path / "services.jsonl"
@@ -409,7 +414,7 @@ def test_generate_evolution_writes_transcripts(tmp_path, monkeypatch) -> None:
         assert transcripts_dir is not None
         path = transcripts_dir / f"{service.service_id}.json"
         path.write_text("{}", encoding="utf-8")
-        return ServiceEvolution(service=service, plateaus=[])
+        return ServiceEvolution(meta=meta_factory(), service=service, plateaus=[])
 
     monkeypatch.setattr("cli.Agent", DummyAgent)
     monkeypatch.setattr(

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -9,7 +9,13 @@ from typing import cast
 from pydantic_ai import Agent
 
 from conversation import ConversationSession
-from models import Contribution, PlateauFeature, ServiceEvolution, ServiceInput
+from models import (
+    SCHEMA_VERSION,
+    Contribution,
+    PlateauFeature,
+    ServiceEvolution,
+    ServiceInput,
+)
 from plateau_generator import PlateauGenerator
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
@@ -114,6 +120,7 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
         ["learners", "academics", "professional_staff"],
     )
     assert isinstance(evolution, ServiceEvolution)
+    assert evolution.meta.schema_version == SCHEMA_VERSION
     assert len(evolution.plateaus) == 4
     assert sum(len(p.features) for p in evolution.plateaus) == 60
     assert all(len(p.features) >= 15 for p in evolution.plateaus)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -20,7 +20,7 @@ from models import (
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 
-def test_service_evolution_contains_plateaus() -> None:
+def test_service_evolution_contains_plateaus(meta_factory) -> None:
     """Constructing a ServiceEvolution should retain nested models."""
 
     service = ServiceInput(
@@ -44,7 +44,9 @@ def test_service_evolution_contains_plateaus() -> None:
         features=[feature],
     )
 
-    evolution = ServiceEvolution(service=service, plateaus=[plateau])
+    evolution = ServiceEvolution(
+        meta=meta_factory(), service=service, plateaus=[plateau]
+    )
 
     assert evolution.plateaus[0].features[0].name == "Feat"
 


### PR DESCRIPTION
## Summary
- add `meta_factory` fixture to construct `EvolutionMeta` for tests
- update ServiceEvolution tests to pass metadata and assert `payload["meta"]`
- silence mypy error on sklearn import

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run mypy`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`


------
https://chatgpt.com/codex/tasks/task_e_68a47f9926b0832bbf11af758091a900