### PR TITLE
docs: add example configuration template

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 ## Configuration
 
+Copy the sample configuration and customise it for your environment:
+
+```
+cp config/app.example.json config/app.json
+```
+
+Then edit `config/app.json` to set models, reasoning presets and other options.
+
 The CLI requires an OpenAI API key available in the `OPENAI_API_KEY` environment
 variable. Settings are loaded via Pydantic, which reads from a `.env` file if
 present. The application will exit if the key is missing. LLM interactions are

--- a/config/app.example.json
+++ b/config/app.example.json
@@ -1,0 +1,47 @@
+{
+  // Default LLM used for most prompts.
+  // Replace with the provider and model you prefer, e.g., "openai:gpt-4".
+  "model": "openai:YOUR_MODEL",
+
+  "models": {
+    // Model used for plateau descriptions.
+    "descriptions": "openai:YOUR_DESCRIPTIONS_MODEL",
+    // Model used for feature generation.
+    "features": "openai:YOUR_FEATURES_MODEL",
+    // Model used for mapping tasks.
+    "mapping": "openai:YOUR_MAPPING_MODEL",
+    // Model used for search operations.
+    "search": "openai:YOUR_SEARCH_MODEL"
+  },
+
+  // Reasoning effort controls depth of analysis ("low", "medium", or "high").
+  "reasoning": {"effort": "YOUR_REASONING_PRESET"},
+
+  // Toggle to enable OpenAI's experimental web search capability.
+  "web_search": false,
+
+  // Adjust log level as needed: DEBUG, INFO, WARNING, ERROR.
+  "log_level": "INFO",
+
+  "mapping_types": {
+    "data": {"dataset": "information", "label": "Data"},
+    "applications": {"dataset": "applications", "label": "Applications"},
+    "technology": {"dataset": "technologies", "label": "Technologies"}
+  },
+
+  // Directory containing prompt components.
+  "prompt_dir": "prompts",
+  // Identifier for context-specific prompts.
+  "context_id": "YOUR_CONTEXT_ID",
+  // Optional inspiration list to influence outputs.
+  "inspiration": "general",
+
+  // Concurrency and batching controls for API requests.
+  "concurrency": 5,
+  "token_weighting": true,
+  "batch_size": 25,
+  "request_timeout": 60,
+  "retries": 5,
+  "retry_base_delay": 0.5,
+  "features_per_role": 5
+}


### PR DESCRIPTION
## Summary
- add `config/app.example.json` with placeholder model and reasoning settings
- document copying the example config before editing

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Missing named argument "descriptions" for "StageModels" and others)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`

------
https://chatgpt.com/codex/tasks/task_e_68a47fef6ae4832bb8ce5b93f618c046