### PR TITLE
Ensure TokenScheduler returns results in submission order

### DIFF
--- a/src/token_scheduler.py
+++ b/src/token_scheduler.py
@@ -25,7 +25,9 @@ class TokenScheduler:
         if max_workers < 1:
             raise ValueError("max_workers must be positive")
         self._max_workers = max_workers
-        self._queue: List[Tuple[int, Callable[[], Awaitable[Any]]]] = []
+        # queue holds (tokens, submission index, coroutine factory)
+        self._queue: List[Tuple[int, int, Callable[[], Awaitable[Any]]]] = []
+        self._next_index = 0
 
     def submit(self, func: Callable[[], Awaitable[Any]], tokens: int) -> None:
         """Queue a coroutine factory for execution.
@@ -34,7 +36,8 @@ class TokenScheduler:
             func: A parameterless callable returning an awaitable.
             tokens: Predicted token count for the task.
         """
-        self._queue.append((tokens, func))
+        self._queue.append((tokens, self._next_index, func))
+        self._next_index += 1
 
     async def run(self) -> List[Any]:
         """Execute queued tasks respecting token ordering.
@@ -42,12 +45,25 @@ class TokenScheduler:
         Returns:
             List of results from executed coroutines in submission order.
         """
-        self._queue.sort(key=lambda item: item[0])
+        # Sort first by token count then by submission index to keep relative
+        # ordering for equal token predictions.
+        self._queue.sort(key=lambda item: (item[0], item[1]))
         semaphore = asyncio.Semaphore(self._max_workers)
 
         async def runner(func: Callable[[], Awaitable[Any]]) -> Any:
             async with semaphore:
                 return await func()
 
-        coros = [runner(func) for _, func in self._queue]
-        return await asyncio.gather(*coros)
+        indices = [index for _, index, _ in self._queue]
+        coros = [runner(func) for _, _, func in self._queue]
+        results = await asyncio.gather(*coros)
+        # Pair results with their original submission indices so callers receive
+        # outputs in the order tasks were submitted.
+        ordered = [
+            result
+            for _, result in sorted(
+                zip(indices, results, strict=False), key=lambda item: item[0]
+            )
+        ]
+        self._queue.clear()
+        return ordered

--- a/tests/test_token_scheduler.py
+++ b/tests/test_token_scheduler.py
@@ -22,3 +22,23 @@ def test_shorter_tasks_complete_first() -> None:
     completed: list[str] = []
     asyncio.run(_run_scheduler(completed))
     assert completed == ["short", "medium", "long"]
+
+
+async def _collect_results() -> list[str]:
+    scheduler = TokenScheduler(max_workers=2)
+
+    async def job(duration: float, label: str) -> str:
+        await asyncio.sleep(duration)
+        return label
+
+    # Submit tasks with tokens out of order
+    scheduler.submit(lambda: job(0.03, "first"), tokens=30)
+    scheduler.submit(lambda: job(0.01, "second"), tokens=10)
+    scheduler.submit(lambda: job(0.02, "third"), tokens=20)
+
+    return await scheduler.run()
+
+
+def test_results_return_in_submission_order() -> None:
+    results = asyncio.run(_collect_results())
+    assert results == ["first", "second", "third"]


### PR DESCRIPTION
## Summary
- track submission index for queued tasks in TokenScheduler
- preserve submission order when executing and returning task results
- add unit test covering out-of-order token submissions

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy src/token_scheduler.py tests/test_token_scheduler.py`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_token_scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_68a480486074832bbb6c466cd1b40fa3