### PR TITLE
feat: add schema migration utilities

### DIFF
--- a/src/schema_migration.py
+++ b/src/schema_migration.py
@@ -1,0 +1,70 @@
+"""Schema version migration utilities."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict
+
+
+def migrate_record(
+    from_version: str, to_version: str, data: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Migrate a record between schema versions.
+
+    Args:
+        from_version: Version of the input ``data``.
+        to_version: Desired schema version. ``1.0`` → ``1.x`` is supported.
+        data: Mapping conforming to ``from_version`` of the schema.
+
+    Returns:
+        The migrated record. A deep copy is returned to avoid mutating ``data``.
+
+    Raises:
+        ValueError: If ``from_version`` and ``to_version`` are not supported.
+
+    Examples:
+        >>> migrate_record(
+        ...     "1.0",
+        ...     "1.1",
+        ...     {
+        ...         "schema_version": "1.0",
+        ...         "service": {},
+        ...         "plateaus": [
+        ...             {
+        ...                 "plateau": 1,
+        ...                 "plateau_name": "p1",
+        ...                 "service_description": "d",
+        ...             }
+        ...         ],
+        ...     },
+        ... )
+        {
+            'schema_version': '1.1',
+            'service': {},
+            'plateaus': [
+                {
+                    'plateau': 1,
+                    'plateau_name': 'p1',
+                    'description': 'd',
+                    'features': [],
+                }
+            ],
+        }
+    """
+
+    if from_version == to_version:
+        # Already on the requested version; return a copy to preserve immutability.
+        return deepcopy(data)
+
+    if from_version == "1.0" and to_version.startswith("1."):
+        # Perform the 1.0 → 1.x migration.
+        migrated = deepcopy(data)
+        migrated["schema_version"] = to_version
+        for plateau in migrated.get("plateaus", []):
+            if "service_description" in plateau:
+                plateau["description"] = plateau.pop("service_description")
+            plateau.setdefault("features", [])
+        return migrated
+
+    # Any other version combination is unsupported.
+    raise ValueError(f"Unsupported schema migration: {from_version} → {to_version}")

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -1,0 +1,34 @@
+"""Tests for schema migration utilities."""
+
+import pytest
+
+from schema_migration import migrate_record
+
+
+def test_migrate_from_1_0_to_1_1() -> None:
+    """1.0 → 1.1 adds defaults and renames fields."""
+    source = {
+        "schema_version": "1.0",
+        "service": {},
+        "plateaus": [
+            {
+                "plateau": 1,
+                "plateau_name": "p1",
+                "service_description": "desc",
+            }
+        ],
+    }
+
+    migrated = migrate_record("1.0", "1.1", source)
+
+    assert migrated["schema_version"] == "1.1"
+    plateau = migrated["plateaus"][0]
+    assert "service_description" not in plateau
+    assert plateau["description"] == "desc"
+    assert plateau["features"] == []
+
+
+def test_rejects_unsupported_versions() -> None:
+    """Unrecognised version pairs raise ``ValueError``."""
+    with pytest.raises(ValueError):
+        migrate_record("0.9", "1.0", {})


### PR DESCRIPTION
## Summary
- add `migrate_record` for schema migrations with 1.0 → 1.x path
- cover migration and error handling with unit tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing src/schema_migration.py tests/test_schema_migration.py`
- `poetry run ruff check --fix .`
- `poetry run mypy src/schema_migration.py tests/test_schema_migration.py`
- `poetry run mypy .` *(fails: Missing named argument "descriptions" for "StageModels" and more)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_schema_migration.py`

------
https://chatgpt.com/codex/tasks/task_e_68a47fb677b0832bb746e1b38944dda5