### PR TITLE
refactor: allow optional feature ids

### DIFF
--- a/prompts/plateau_prompt.md
+++ b/prompts/plateau_prompt.md
@@ -21,9 +21,6 @@ using the previously supplied description.
 - "features" must include keys for each role: {roles}.
 - Each role key must map to an array containing at least {required_count} feature objects.
 - Every feature must provide:
-  - "feature_id": unique string identifier.
-    - Format: "FEAT-{plateau}-{{role}}-{{kebab-case-short-name}}" (e.g., FEAT-2-learners-smart-enrolment).
-    - Ensure IDs are unique across all roles in this response.
   - "name": short feature title.
   - "description": explanation of the feature.
   - "score": object describing CMMI maturity with:
@@ -44,7 +41,6 @@ using the previously supplied description.
   "features": {{
     "learners": [
       {{
-        "feature_id": "FEAT-{plateau}-learners-smart-enrolment",
         "name": "Smart enrolment",
         "description": "Students enrol through a streamlined digital process with real-time validation.",
         "score": {{

--- a/src/models.py
+++ b/src/models.py
@@ -425,13 +425,12 @@ class PlateauDescriptionsResponse(StrictModel):
 class FeatureItem(BaseModel):
     model_config = ConfigDict(extra="forbid")
     feature_id: Annotated[
-        str,
+        str | None,
         Field(
             min_length=1,
-            pattern=r"^FEAT-\d+-(learners|academics|professional_staff)-[a-z0-9]+(?:-[a-z0-9]+)*$",
-            description="Format: FEAT-{plateau}-{role}-{kebab-case-short-name}",
+            description="Unique feature identifier assigned post-processing.",
         ),
-    ]
+    ] = None
     name: Annotated[str, Field(min_length=1)]
     description: Annotated[str, Field(min_length=1)]
     score: MaturityScore
@@ -451,18 +450,6 @@ class PlateauFeaturesResponse(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
     features: FeaturesBlock
-
-    @model_validator(mode="after")
-    def unique_feature_ids(self):
-        all_items = (
-            self.features.learners
-            + self.features.academics
-            + self.features.professional_staff
-        )
-        ids = [f.feature_id for f in all_items]
-        if len(ids) != len(set(ids)):
-            raise ValueError("feature_id values must be unique across all roles")
-        return self
 
 
 class RoleFeaturesResponse(BaseModel):

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -223,8 +223,12 @@ class PlateauGenerator:
             Plateau feature populated with the provided metadata.
         """
 
+        feature_id = item.feature_id
+        if feature_id is None:
+            raw = f"{item.name}|{role}".encode()
+            feature_id = hashlib.sha1(raw, usedforsecurity=False).hexdigest()
         return PlateauFeature(
-            feature_id=item.feature_id,
+            feature_id=feature_id,
             name=item.name,
             description=item.description,
             score=item.score,
@@ -278,7 +282,6 @@ class PlateauGenerator:
         example = {
             "features": [
                 {
-                    "feature_id": f"FEAT-{level}-{role}-example",
                     "name": "Example feature",
                     "description": "Example description.",
                     "score": {
@@ -454,7 +457,6 @@ class PlateauGenerator:
         example = {
             "features": [
                 {
-                    "feature_id": f"FEAT-{level}-{role}-example",
                     "name": "Example feature",
                     "description": "Example description.",
                     "score": {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -62,29 +62,29 @@ def test_plateau_feature_validates_score() -> None:
         )
 
 
-def test_feature_item_accepts_plateau_numbers() -> None:
-    """Feature IDs should include plateau numbers."""
+def test_feature_item_allows_missing_id() -> None:
+    """feature_id should be optional."""
 
     item = FeatureItem(
-        feature_id="FEAT-2-learners-sample",
         name="n",
         description="d",
         score=MaturityScore(level=1, label="Initial", justification="j"),
     )
 
-    assert item.feature_id.startswith("FEAT-2")
+    assert item.feature_id is None
 
 
-def test_feature_item_rejects_invalid_ids() -> None:
-    """Nonconforming feature IDs should raise ``ValidationError``."""
+def test_feature_item_accepts_arbitrary_id() -> None:
+    """Any non-empty string should be accepted as feature_id."""
 
-    with pytest.raises(ValidationError):
-        FeatureItem(
-            feature_id="FEAT-X-learners-test",
-            name="n",
-            description="d",
-            score=MaturityScore(level=1, label="Initial", justification="j"),
-        )
+    item = FeatureItem(
+        feature_id="custom-id",
+        name="n",
+        description="d",
+        score=MaturityScore(level=1, label="Initial", justification="j"),
+    )
+
+    assert item.feature_id == "custom-id"
 
 
 def test_contribution_requires_fields() -> None:


### PR DESCRIPTION
## Summary
- make feature_id optional in FeatureItem and drop uniqueness validator
- remove feature_id from plateau prompt and generator examples
- hash name|role when feature_id is missing and update tests accordingly

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy --ignore-missing-imports`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_models.py tests/test_plateau_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_68a47e045414832bbe6e449152fd491f