### PR TITLE
Track and summarize quarantined payloads

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -30,7 +30,11 @@ from model_factory import ModelFactory
 from models import ServiceInput
 from monitoring import LOG_FILE_NAME, init_logfire, logfire
 from persistence import atomic_write, read_lines
-from plateau_generator import PlateauGenerator
+from plateau_generator import (
+    QUARANTINED_DESCRIPTIONS,
+    QUARANTINED_MAPPING_PAYLOADS,
+    PlateauGenerator,
+)
 from service_loader import load_services
 from settings import load_settings
 
@@ -591,7 +595,10 @@ def main() -> None:
     if inspect.isawaitable(result):
         # Cast ensures that asyncio.run receives a proper Coroutine
         asyncio.run(cast(Coroutine[Any, Any, Any], result))
-
+    logfire.info(
+        f"Quarantined: {len(QUARANTINED_DESCRIPTIONS)} descriptions,"
+        f" {len(QUARANTINED_MAPPING_PAYLOADS)} mapping payloads"
+    )
     logfire.force_flush()
 
 

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -18,7 +18,7 @@ import logfire
 import numpy as np
 from openai import AsyncOpenAI
 from scipy.sparse import csr_matrix
-from sklearn.feature_extraction.text import (
+from sklearn.feature_extraction.text import (  # type: ignore[import-untyped]
     TfidfVectorizer,
 )
 

--- a/tests/test_quarantine_tracking.py
+++ b/tests/test_quarantine_tracking.py
@@ -1,0 +1,103 @@
+import argparse
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import cli
+import plateau_generator
+from models import MaturityScore, PlateauFeature, ServiceInput
+
+
+class DummySession:
+    client = object()
+    stage = "stage"
+
+    def add_parent_materials(self, _service):
+        pass
+
+    def ask(self, prompt, output_type=None):
+        raise RuntimeError("boom")
+
+    async def ask_async(self, prompt, output_type=None):
+        raise RuntimeError("boom")
+
+
+def _service_input() -> ServiceInput:
+    return ServiceInput(
+        service_id="svc-1",
+        name="svc",
+        description="desc",
+        customer_type="retail",
+        jobs_to_be_done=[{"name": "job"}],
+    )
+
+
+def test_request_description_quarantines(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    gen = plateau_generator.PlateauGenerator(DummySession())
+    gen._service = _service_input()
+    plateau_generator.QUARANTINED_DESCRIPTIONS.clear()
+    monkeypatch.setattr(
+        plateau_generator, "load_prompt_text", lambda _name: "{plateau}{schema}"
+    )
+
+    with pytest.raises(ValueError):
+        gen._request_description(1, session=DummySession())
+
+    assert len(plateau_generator.QUARANTINED_DESCRIPTIONS) == 1
+    path = Path(plateau_generator.QUARANTINED_DESCRIPTIONS[0])
+    assert path.exists()
+
+
+def test_map_features_quarantines(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    gen = plateau_generator.PlateauGenerator(
+        DummySession(), mapping_session=DummySession()
+    )
+    gen._service = _service_input()
+    feature = PlateauFeature(
+        feature_id="f1",
+        name="n",
+        description="d",
+        score=MaturityScore(level=1, label="Initial", justification="j"),
+        customer_type="learners",
+    )
+    plateau_generator.QUARANTINED_MAPPING_PAYLOADS.clear()
+
+    async def fake_map(*_args, **_kwargs):
+        raise RuntimeError("mapping fail")
+
+    monkeypatch.setattr(plateau_generator, "map_features_async", fake_map)
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(gen._map_features_with_quarantine([feature], "p1"))
+
+    assert len(plateau_generator.QUARANTINED_MAPPING_PAYLOADS) == 1
+    path = Path(plateau_generator.QUARANTINED_MAPPING_PAYLOADS[0])
+    assert path.exists()
+
+
+def test_main_logs_quarantine_summary(monkeypatch) -> None:
+    monkeypatch.setattr(
+        cli, "load_settings", lambda: SimpleNamespace(logfire_token=None)
+    )
+    monkeypatch.setattr(cli, "_configure_logging", lambda *a, **k: None)
+    monkeypatch.setattr(cli.logfire, "force_flush", lambda: None)
+
+    plateau_generator.QUARANTINED_DESCRIPTIONS[:] = ["a.json"]
+    plateau_generator.QUARANTINED_MAPPING_PAYLOADS[:] = ["b.json", "c.json"]
+
+    def dummy_func(_args, _settings):
+        return None
+
+    ns = argparse.Namespace(func=dummy_func, seed=None)
+    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: ns)
+
+    messages: list[str] = []
+    monkeypatch.setattr(cli.logfire, "info", lambda m: messages.append(m))
+
+    cli.main()
+
+    assert messages[-1] == "Quarantined: 1 descriptions, 2 mapping payloads"


### PR DESCRIPTION
## Summary
- track quarantined description and mapping payload files in `PlateauGenerator`
- report a post-run summary of quarantine counts in the CLI
- cover quarantine tracking with dedicated tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy src`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_quarantine_tracking.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a47f281da0832bbcdec515f4269480