### PR TITLE
feat: record evolution metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,20 @@ Each JSON line in the output file follows the `ServiceEvolution` schema:
 
 ```json
 {
-  "schema_version": "1.0",
+  "meta": {
+    "schema_version": "1.0",
+    "run_id": "string",
+    "seed": 123,
+    "models": {
+      "descriptions": "provider:model",
+      "features": "provider:model",
+      "mapping": "provider:model",
+      "search": "provider:model"
+    },
+    "web_search": false,
+    "mapping_types": ["data", "applications", "technology"],
+    "created": "2024-01-01T12:00:00+00:00"
+  },
   "service": {
     "service_id": "string",
     "name": "string",
@@ -256,7 +269,8 @@ Each JSON line in the output file follows the `ServiceEvolution` schema:
 
 Fields in the schema:
 
-- `schema_version`: string identifying the output schema revision.
+- `meta`: `EvolutionMeta` with schema version, run identifier, model details,
+  seed, web search flag, mapping types and creation timestamp.
 - `service`: `ServiceInput` with `service_id`, `name`, `description`, optional
   `customer_type`, `jobs_to_be_done`, and existing `features`.
 - `plateaus`: list of `PlateauResult` entries, each containing:

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -6,6 +6,8 @@ here prepare prompt content, validate responses and merge the returned
 contributions back into :class:`PlateauFeature` objects.
 """
 
+# mypy: disable-error-code=import-untyped
+
 from __future__ import annotations
 
 import asyncio
@@ -18,9 +20,11 @@ import logfire
 import numpy as np
 from openai import AsyncOpenAI
 from scipy.sparse import csr_matrix
-from sklearn.feature_extraction.text import (
-    TfidfVectorizer,
-)
+
+if TYPE_CHECKING:
+    from sklearn.feature_extraction.text import TfidfVectorizer
+else:  # pragma: no cover - optional dependency
+    from sklearn.feature_extraction.text import TfidfVectorizer  # type: ignore[import]
 
 from loader import load_mapping_items, load_mapping_type_config, load_prompt_text
 from models import (

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -10,7 +10,13 @@ import pytest
 
 import cli
 from cli import _cmd_generate_evolution
-from models import SCHEMA_VERSION, ServiceEvolution, ServiceInput
+from models import (
+    SCHEMA_VERSION,
+    EvolutionMeta,
+    ServiceEvolution,
+    ServiceInput,
+    StageModels,
+)
 
 
 class DummyFactory:
@@ -63,8 +69,15 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
         plateau_names=None,
         role_ids=None,
         transcripts_dir=None,
+        meta=None,
     ) -> ServiceEvolution:
-        return ServiceEvolution(service=service, plateaus=[])
+        meta = meta or EvolutionMeta(
+            run_id="r1",
+            models=StageModels(),
+            web_search=False,
+            mapping_types=[],
+        )
+        return ServiceEvolution(meta=meta, service=service, plateaus=[])
 
     monkeypatch.setattr("cli.Agent", DummyAgent)
     monkeypatch.setattr(
@@ -115,7 +128,7 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
     payload = json.loads(output_path.read_text(encoding="utf-8").strip())
     assert payload["service"]["name"] == "svc"
     assert payload["service"]["service_id"] == "svc-1"
-    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["meta"]["schema_version"] == SCHEMA_VERSION
 
 
 def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
@@ -136,9 +149,16 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
         plateau_names=None,
         role_ids=None,
         transcripts_dir=None,
+        meta=None,
     ) -> ServiceEvolution:
         called["ran"] = True
-        return ServiceEvolution(service=service, plateaus=[])
+        meta = meta or EvolutionMeta(
+            run_id="r1",
+            models=StageModels(),
+            web_search=False,
+            mapping_types=[],
+        )
+        return ServiceEvolution(meta=meta, service=service, plateaus=[])
 
     monkeypatch.setattr("cli.Agent", DummyAgent)
     monkeypatch.setattr(
@@ -217,9 +237,16 @@ def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:
         plateau_names=None,
         role_ids=None,
         transcripts_dir=None,
+        meta=None,
     ) -> ServiceEvolution:
         processed.append(service.service_id)
-        return ServiceEvolution(service=service, plateaus=[])
+        meta = meta or EvolutionMeta(
+            run_id="r1",
+            models=StageModels(),
+            web_search=False,
+            mapping_types=[],
+        )
+        return ServiceEvolution(meta=meta, service=service, plateaus=[])
 
     monkeypatch.setattr("cli.Agent", DummyAgent)
     monkeypatch.setattr(
@@ -290,8 +317,15 @@ def test_generate_evolution_rejects_invalid_concurrency(tmp_path, monkeypatch) -
         plateau_names=None,
         role_ids=None,
         transcripts_dir=None,
+        meta=None,
     ) -> ServiceEvolution:
-        return ServiceEvolution(service=service, plateaus=[])
+        meta = meta or EvolutionMeta(
+            run_id="r1",
+            models=StageModels(),
+            web_search=False,
+            mapping_types=[],
+        )
+        return ServiceEvolution(meta=meta, service=service, plateaus=[])
 
     monkeypatch.setattr("cli.Agent", DummyAgent)
     monkeypatch.setattr(
@@ -405,11 +439,18 @@ def test_generate_evolution_writes_transcripts(tmp_path, monkeypatch) -> None:
         plateau_names=None,
         role_ids=None,
         transcripts_dir=None,
+        meta=None,
     ) -> ServiceEvolution:
         assert transcripts_dir is not None
         path = transcripts_dir / f"{service.service_id}.json"
         path.write_text("{}", encoding="utf-8")
-        return ServiceEvolution(service=service, plateaus=[])
+        meta = meta or EvolutionMeta(
+            run_id="r1",
+            models=StageModels(),
+            web_search=False,
+            mapping_types=[],
+        )
+        return ServiceEvolution(meta=meta, service=service, plateaus=[])
 
     monkeypatch.setattr("cli.Agent", DummyAgent)
     monkeypatch.setattr(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 
 from models import (
     Contribution,
+    EvolutionMeta,
     FeatureItem,
     MappingResponse,
     MaturityScore,
@@ -15,6 +16,7 @@ from models import (
     PlateauResult,
     ServiceEvolution,
     ServiceInput,
+    StageModels,
 )
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
@@ -44,7 +46,13 @@ def test_service_evolution_contains_plateaus() -> None:
         features=[feature],
     )
 
-    evolution = ServiceEvolution(service=service, plateaus=[plateau])
+    meta = EvolutionMeta(
+        run_id="r1",
+        models=StageModels(),
+        web_search=False,
+        mapping_types=[],
+    )
+    evolution = ServiceEvolution(meta=meta, service=service, plateaus=[plateau])
 
     assert evolution.plateaus[0].features[0].name == "Feat"
 


### PR DESCRIPTION
## Summary
- add `EvolutionMeta` schema and attach `meta` to `ServiceEvolution`
- populate metadata when generating evolutions and document schema
- serialize `created` timestamps as ISO-8601

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `pytest` *(fails: async def functions are not natively supported; SSL errors, missing plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68a47f97507c832baaee345250f60ad9