### PR TITLE
feat: add strict flag for feature mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ This behaviour is enabled by default via `--mapping-parallel-types`. Disable it
 with `--no-mapping-parallel-types` to process mapping types sequentially when
 rate limits are tight.
 
+Enable `--mapping-strict` to abort when any feature cannot be mapped after
+retries. Omit or use `--no-mapping-strict` to keep the default best-effort
+behaviour.
+
 Example invocation tuning mapping behaviour:
 
 ```bash

--- a/src/cli.py
+++ b/src/cli.py
@@ -136,6 +136,7 @@ async def _generate_evolution_for_service(
     role_ids: Sequence[str],
     mapping_batch_size: int,
     mapping_parallel_types: bool,
+    mapping_strict: bool,
     lock: asyncio.Lock,
     output,
     new_ids: set[str],
@@ -179,6 +180,7 @@ async def _generate_evolution_for_service(
                 mapping_session=map_session,
                 mapping_batch_size=mapping_batch_size,
                 mapping_parallel_types=mapping_parallel_types,
+                mapping_strict=mapping_strict,
             )
             evolution = await generator.generate_service_evolution_async(
                 service, transcripts_dir=transcripts_dir
@@ -351,6 +353,11 @@ async def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
         if args.mapping_parallel_types is not None
         else settings.mapping_parallel_types
     )
+    mapping_strict = (
+        args.mapping_strict
+        if args.mapping_strict is not None
+        else settings.mapping_strict
+    )
 
     output_path = Path(args.output_file)
     part_path, processed_path = _prepare_paths(output_path, args.resume)
@@ -385,6 +392,7 @@ async def _cmd_generate_evolution(args: argparse.Namespace, settings) -> None:
                 role_ids=role_ids,
                 mapping_batch_size=mapping_batch_size,
                 mapping_parallel_types=mapping_parallel_types,
+                mapping_strict=mapping_strict,
                 lock=lock,
                 output=output,
                 new_ids=new_ids,
@@ -475,6 +483,12 @@ def main() -> None:
         action=argparse.BooleanOptionalAction,
         default=None,
         help="Enable or disable parallel mapping type requests",
+    )
+    common.add_argument(
+        "--mapping-strict",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Raise an error when mappings remain empty after retries",
     )
     common.add_argument(
         "--token-weighting",

--- a/src/models.py
+++ b/src/models.py
@@ -326,6 +326,9 @@ class AppConfig(StrictModel):
     mapping_parallel_types: bool = Field(
         True, description="Process mapping types for all batches concurrently."
     )
+    mapping_strict: bool = Field(
+        False, description="Raise error when mappings remain empty after retry."
+    )
     mapping_types: dict[str, MappingTypeConfig] = Field(
         default_factory=dict,
         description="Mapping type definitions keyed by field name.",

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -70,6 +70,7 @@ class PlateauGenerator:
         mapping_session: ConversationSession | None = None,
         mapping_batch_size: int = 30,
         mapping_parallel_types: bool = True,
+        mapping_strict: bool = False,
     ) -> None:
         """Initialise the generator.
 
@@ -82,6 +83,8 @@ class PlateauGenerator:
             mapping_batch_size: Number of features per mapping request batch.
             mapping_parallel_types: Dispatch mapping type requests concurrently
                 across all batches when ``True``.
+            mapping_strict: Raise :class:`MappingError` when any feature remains
+                unmapped after retry attempts.
         """
         if required_count < 1:
             raise ValueError("required_count must be positive")
@@ -92,6 +95,7 @@ class PlateauGenerator:
         self.roles = list(roles or DEFAULT_ROLE_IDS)
         self.mapping_batch_size = mapping_batch_size
         self.mapping_parallel_types = mapping_parallel_types
+        self.mapping_strict = mapping_strict
         self._service: ServiceInput | None = None
 
     def _request_description(
@@ -562,6 +566,7 @@ class PlateauGenerator:
                 features,
                 batch_size=self.mapping_batch_size,
                 parallel_types=self.mapping_parallel_types,
+                strict=self.mapping_strict,
             )
             return PlateauResult(
                 plateau=level,

--- a/src/settings.py
+++ b/src/settings.py
@@ -57,6 +57,10 @@ class Settings(BaseSettings):
         True,
         description="Process mapping types for all batches concurrently.",
     )
+    mapping_strict: bool = Field(
+        False,
+        description="Raise error when mappings remain empty after retry.",
+    )
     openai_api_key: str = Field(..., description="OpenAI API access token.")
     logfire_token: str | None = Field(
         None, description="Logfire authentication token, if available."
@@ -106,6 +110,7 @@ def load_settings() -> Settings:
             features_per_role=config.features_per_role,
             mapping_batch_size=config.mapping_batch_size,
             mapping_parallel_types=config.mapping_parallel_types,
+            mapping_strict=config.mapping_strict,
             web_search=config.web_search,
             _env_file=env_file,
         )

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -87,6 +87,7 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
         features_per_role=5,
         mapping_batch_size=30,
         mapping_parallel_types=True,
+        mapping_strict=False,
         web_search=False,
         models=None,
     )
@@ -106,6 +107,7 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
         roles_file="data/roles.json",
         mapping_batch_size=None,
         mapping_parallel_types=None,
+        mapping_strict=None,
         transcripts_dir=None,
         web_search=None,
     )
@@ -161,6 +163,7 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
         features_per_role=5,
         mapping_batch_size=30,
         mapping_parallel_types=True,
+        mapping_strict=False,
         web_search=False,
         models=None,
     )
@@ -180,6 +183,7 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
         roles_file="data/roles.json",
         mapping_batch_size=None,
         mapping_parallel_types=None,
+        mapping_strict=None,
         transcripts_dir=None,
         web_search=None,
     )
@@ -242,6 +246,7 @@ def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:
         features_per_role=5,
         mapping_batch_size=30,
         mapping_parallel_types=True,
+        mapping_strict=False,
         web_search=False,
         models=None,
     )
@@ -261,6 +266,7 @@ def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:
         roles_file="data/roles.json",
         mapping_batch_size=None,
         mapping_parallel_types=None,
+        mapping_strict=None,
         transcripts_dir=None,
         web_search=None,
     )
@@ -314,6 +320,7 @@ def test_generate_evolution_rejects_invalid_concurrency(tmp_path, monkeypatch) -
         features_per_role=5,
         mapping_batch_size=30,
         mapping_parallel_types=True,
+        mapping_strict=False,
         web_search=False,
         models=None,
     )
@@ -333,6 +340,7 @@ def test_generate_evolution_rejects_invalid_concurrency(tmp_path, monkeypatch) -
         roles_file="data/roles.json",
         mapping_batch_size=None,
         mapping_parallel_types=None,
+        mapping_strict=None,
         transcripts_dir=None,
         web_search=None,
     )
@@ -374,6 +382,7 @@ def test_cli_parses_mapping_options(tmp_path, monkeypatch) -> None:
 
     assert called["args"].mapping_batch_size == 12
     assert called["args"].mapping_parallel_types is False
+    assert called["args"].mapping_strict is None
 
 
 def test_generate_evolution_writes_transcripts(tmp_path, monkeypatch) -> None:
@@ -432,6 +441,7 @@ def test_generate_evolution_writes_transcripts(tmp_path, monkeypatch) -> None:
         features_per_role=5,
         mapping_batch_size=30,
         mapping_parallel_types=True,
+        mapping_strict=False,
         models=None,
         web_search=False,
     )
@@ -451,6 +461,7 @@ def test_generate_evolution_writes_transcripts(tmp_path, monkeypatch) -> None:
         roles_file="data/roles.json",
         mapping_batch_size=None,
         mapping_parallel_types=None,
+        mapping_strict=None,
         transcripts_dir=None,
         web_search=None,
     )

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -76,7 +76,7 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
 
     map_calls = {"n": 0}
 
-    def _fake_map_features(session, features):
+    async def _fake_map_features(session, features, **kwargs):
         map_calls["n"] += 1
         results = []
         for feature in features:
@@ -89,7 +89,7 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
             results.append(PlateauFeature(**payload))
         return results
 
-    monkeypatch.setattr("plateau_generator.map_features", _fake_map_features)
+    monkeypatch.setattr("plateau_generator.map_features_async", _fake_map_features)
     template = "{required_count} {service_name} {service_description} {plateau} {roles}"
 
     def fake_loader(name, *_, **__):

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -137,7 +137,7 @@ def test_generate_plateau_returns_results(monkeypatch) -> None:
 
     call = {"n": 0}
 
-    async def dummy_map_features(sess, feats):
+    async def dummy_map_features(sess, feats, **kwargs):
         call["n"] += 1
         for feat in feats:
             feat.mappings["data"] = [Contribution(item="d", contribution=0.5)]
@@ -227,7 +227,7 @@ def test_generate_plateau_repairs_missing_features(monkeypatch) -> None:
     )
     session = DummySession([desc_payload, initial, repair])
 
-    async def dummy_map_features(sess, feats):
+    async def dummy_map_features(sess, feats, **kwargs):
         return feats
 
     monkeypatch.setattr("plateau_generator.map_features_async", dummy_map_features)
@@ -315,7 +315,7 @@ def test_generate_plateau_requests_missing_features_concurrently(
     )
     session = DummySession([desc_payload, initial])
 
-    async def dummy_map_features(sess, feats):
+    async def dummy_map_features(sess, feats, **kwargs):
         return feats
 
     monkeypatch.setattr("plateau_generator.map_features_async", dummy_map_features)
@@ -429,7 +429,7 @@ def test_generate_plateau_repairs_invalid_role(monkeypatch) -> None:
     )
     session = DummySession([desc_payload, initial, repair])
 
-    async def dummy_map_features(sess, feats):
+    async def dummy_map_features(sess, feats, **kwargs):
         return feats
 
     monkeypatch.setattr("plateau_generator.map_features_async", dummy_map_features)


### PR DESCRIPTION
## Summary
- add `strict` parameter to mapping helpers to fail on empty mappings when requested
- plumb `strict` flag through PlateauGenerator and CLI
- document `--mapping-strict` CLI option and add regression tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: interrupted)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a47fd0c1cc832bae333c0c4af6a188