### PR TITLE
feat: add strict validation mode

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -179,6 +179,7 @@ async def _generate_evolution_for_service(
                 mapping_session=map_session,
                 mapping_batch_size=mapping_batch_size,
                 mapping_parallel_types=mapping_parallel_types,
+                strict=args.strict,
             )
             evolution = await generator.generate_service_evolution_async(
                 service, transcripts_dir=transcripts_dir
@@ -577,6 +578,12 @@ def main() -> None:
         "--roles-file",
         default="data/roles.json",
         help="Path to the roles definition JSON file",
+    )
+    evo.add_argument(
+        "--strict",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Fail immediately on invalid or missing role outputs",
     )
     evo.set_defaults(func=_cmd_generate_evolution)
 

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -18,7 +18,7 @@ import logfire
 import numpy as np
 from openai import AsyncOpenAI
 from scipy.sparse import csr_matrix
-from sklearn.feature_extraction.text import (
+from sklearn.feature_extraction.text import (  # type: ignore[import-untyped]
     TfidfVectorizer,
 )
 

--- a/tests/test_plateau_generator_strict.py
+++ b/tests/test_plateau_generator_strict.py
@@ -1,0 +1,48 @@
+"""Tests for strict mode in PlateauGenerator."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from conversation import ConversationSession
+from plateau_generator import PlateauGenerator
+from test_plateau_generator import DummySession
+
+
+def test_validate_roles_strict_raises() -> None:
+    """Invalid role payloads should raise when strict mode is enabled."""
+
+    session = DummySession([])
+    generator = PlateauGenerator(
+        cast(ConversationSession, session), required_count=2, strict=True
+    )
+    role_data = {"learners": []}
+    with pytest.raises(ValueError):
+        generator._validate_roles(role_data)
+
+
+def test_enforce_min_features_respects_strict(monkeypatch) -> None:
+    """_enforce_min_features emits warnings or raises based on strict mode."""
+
+    session = DummySession([])
+    generator = PlateauGenerator(
+        cast(ConversationSession, session), required_count=2, strict=False
+    )
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        "plateau_generator.logfire.warning", lambda msg, **_: warnings.append(msg)
+    )
+    generator._enforce_min_features(
+        {"learners": [], "academics": [], "professional_staff": []}
+    )
+    assert warnings  # warning emitted in non-strict mode
+
+    strict_gen = PlateauGenerator(
+        cast(ConversationSession, session), required_count=2, strict=True
+    )
+    with pytest.raises(ValueError):
+        strict_gen._enforce_min_features(
+            {"learners": [], "academics": [], "professional_staff": []}
+        )


### PR DESCRIPTION
## Summary
- add strict flag to PlateauGenerator to control error handling for role output
- warn and recover by default or raise in strict mode
- expose strict option in CLI and cover new behavior with tests

## Testing
- `poetry run ruff check --fix src/plateau_generator.py src/cli.py src/mapping.py tests/test_plateau_generator_strict.py`
- `poetry run black --preview --enable-unstable-feature string_processing src/plateau_generator.py src/cli.py src/mapping.py tests/test_plateau_generator_strict.py`
- `poetry run mypy`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_plateau_generator_strict.py`


------
https://chatgpt.com/codex/tasks/task_e_68a47fd54e10832bac812a902b3d17aa