### PR TITLE
docs: document model presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,22 @@ Stage-specific model overrides live under the `models` block in
 }
 ```
 
-| Stage        | Default model                  | Fast/cheap alternative |
-|--------------|--------------------------------|------------------------|
-| Descriptions | `openai:o4-mini`               | Already cost optimised |
-| Features     | `openai:gpt-5`                 | `openai:o4-mini`       |
-| Mapping      | `openai:o4-mini`               | Already cost optimised |
-| Search       | `openai:gpt-4o-search-preview` | n/a                    |
+The CLI ships with three presets that balance cost and quality across stages:
+
+| Preset       | Descriptions           | Features           | Mapping           | Search                         |
+|--------------|-----------------------|--------------------|-------------------|-------------------------------|
+| cheap & fast | `openai:o4-mini`       | `openai:o4-mini`   | `openai:o4-mini`  | `openai:gpt-4o-search-preview` |
+| balanced     | `openai:o4-mini`       | `openai:gpt-5`     | `openai:o4-mini`  | `openai:gpt-4o-search-preview` |
+| max quality  | `openai:gpt-5`         | `openai:gpt-5`     | `openai:gpt-5`    | `openai:gpt-4o-search-preview` |
+
+Use the **cheap & fast** preset for quick prototypes and tight budgets. The
+**balanced** preset (default) mixes high‑quality feature generation with
+lower‑cost stages for everyday workloads. Choose **max quality** when accuracy
+matters more than latency or price.
+
+Select a preset by setting `model_preset` in your configuration file or by
+passing `--preset` on the command line. `config/app.example.json` lists the
+exact model mappings and shows how to set `model_preset` explicitly.
 
 OpenAI recommends using cost‑optimised models like `o4-mini` when latency or
 price is a concern and higher‑capacity models such as `gpt-5` for best quality

--- a/config/app.example.json
+++ b/config/app.example.json
@@ -1,0 +1,23 @@
+{
+    "model_preset": "balanced",
+    "model_presets": {
+        "cheap_fast": {
+            "descriptions": "openai:o4-mini",
+            "features": "openai:o4-mini",
+            "mapping": "openai:o4-mini",
+            "search": "openai:gpt-4o-search-preview"
+        },
+        "balanced": {
+            "descriptions": "openai:o4-mini",
+            "features": "openai:gpt-5",
+            "mapping": "openai:o4-mini",
+            "search": "openai:gpt-4o-search-preview"
+        },
+        "max_quality": {
+            "descriptions": "openai:gpt-5",
+            "features": "openai:gpt-5",
+            "mapping": "openai:gpt-5",
+            "search": "openai:gpt-4o-search-preview"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- explain preset-based model selection in configuration docs
- add example config showing preset mappings

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Module has no attribute "get_encoding"; see logs for details)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`


------
https://chatgpt.com/codex/tasks/task_e_68a47ff0b8cc832b82248861efcf20a2