### PR TITLE
Redact PII in conversation history

### DIFF
--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 
-import pytest
 from pydantic_ai import (
     Agent,
     messages,
@@ -14,6 +13,7 @@ from pydantic_ai import (
 
 from conversation import (
     ConversationSession,
+    redact_pii,
 )
 from models import (
     ServiceFeature,
@@ -29,9 +29,21 @@ class DummyAgent:
     def __init__(self) -> None:
         self.called_with: list[str] = []
 
+    def run_sync(self, prompt: str, message_history: list[str], output_type=None):
+        self.called_with.append(prompt)
+        return SimpleNamespace(
+            output="pong",
+            new_messages=lambda: ["msg"],
+            usage=lambda: SimpleNamespace(total_tokens=0),
+        )
+
     async def run(self, prompt: str, message_history: list[str], output_type=None):
         self.called_with.append(prompt)
-        return SimpleNamespace(output="pong", new_messages=lambda: ["msg"])
+        return SimpleNamespace(
+            output="pong",
+            new_messages=lambda: ["msg"],
+            usage=lambda: SimpleNamespace(total_tokens=0),
+        )
 
 
 def test_add_parent_materials_records_history() -> None:
@@ -93,21 +105,51 @@ def test_add_parent_materials_includes_features() -> None:
     ]
 
 
-@pytest.mark.asyncio
-async def test_ask_adds_responses_to_history() -> None:
+def test_redact_pii_masks_common_identifiers() -> None:
+    """``redact_pii`` should replace emails, phone numbers and IDs."""
+
+    text = "Reach me at jane.doe@example.com or 555-123-4567 with ID 123456789."
+    redacted = redact_pii(text)
+    assert "jane.doe@example.com" not in redacted
+    assert "555-123-4567" not in redacted
+    assert "123456789" not in redacted
+    assert redacted.count("[REDACTED]") == 3
+
+
+def test_add_parent_materials_redacts_pii() -> None:
+    """Service materials stored in history should have PII redacted."""
+
+    session = ConversationSession(cast(Agent[None, str], DummyAgent()))
+    service = ServiceInput(
+        service_id="123456789",
+        name="svc",
+        customer_type=None,
+        description="Contact jane.doe@example.com or 555-123-4567 for details.",
+        jobs_to_be_done=[],
+    )
+    session.add_parent_materials(service)
+
+    part = cast(messages.UserPromptPart, session._history[0].parts[0])
+    material = cast(str, part.content)
+    assert "jane.doe@example.com" not in material
+    assert "555-123-4567" not in material
+    assert "123456789" not in material
+    assert material.count("[REDACTED]") == 3
+
+
+def test_ask_adds_responses_to_history() -> None:
     """``ask`` should forward prompts and store new messages."""
 
     session = ConversationSession(cast(Agent[None, str], DummyAgent()))
-    reply = await session.ask("ping")
+    reply = session.ask("ping")
 
     assert reply == "pong"
     assert session._history[-1] == "msg"
 
 
-@pytest.mark.asyncio
-async def test_ask_forwards_prompt_to_agent() -> None:
+def test_ask_forwards_prompt_to_agent() -> None:
     """``ask`` should delegate to the underlying agent."""
     agent = DummyAgent()
     session = ConversationSession(cast(Agent[None, str], agent))
-    await session.ask("hello")
+    session.ask("hello")
     assert agent.called_with == ["hello"]


### PR DESCRIPTION
## Summary
- add `redact_pii` helper to mask emails, phone numbers and long numeric IDs
- sanitize service materials before logging or storing in conversation history
- cover PII redaction with unit tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: existing errors in unrelated modules)*
- `poetry run mypy src/conversation.py tests/test_conversation.py`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_conversation.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4800820cc832b98d537936788eab2