### PR TITLE
Enable structured JSON file logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,9 @@ file.
 Use the `generate-evolution` subcommand to score each service against all
 configured plateau features and customer segments. It reads services from an
 input JSON Lines file and writes a `ServiceEvolution` record for each line in
-the output file. Logs are written to `service.log` in the current working
-directory. Enable verbose logs with `-v` or `-vv`.
+the output file. A `service.log` file in the current working directory captures
+structured JSON log records, one object per line, making downstream parsing
+trivial. Enable verbose logs with `-v` or `-vv`.
 
 Basic invocation:
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,6 +160,24 @@ def test_cli_requires_api_key(monkeypatch):
     assert "openai_api_key" in str(excinfo.value)
 
 
+def test_configure_logging_emits_json(tmp_path, monkeypatch):
+    """Structured logging writes JSON records to the default file."""
+
+    monkeypatch.chdir(tmp_path)
+    args = SimpleNamespace(verbose=0)
+    settings = SimpleNamespace(log_level="INFO", logfire_token=None)
+
+    cli._configure_logging(args, settings)
+    logging.getLogger().info("hello")
+    logging.getLogger().handlers[0].flush()
+
+    log_path = Path(LOG_FILE_NAME)
+    payload = json.loads(log_path.read_text(encoding="utf-8"))
+    assert payload["message"] == "hello"
+
+    logging.getLogger().handlers.clear()
+
+
 def test_cli_switches_context(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     base = tmp_path / "prompts"


### PR DESCRIPTION
## Summary
- log CLI output through a JsonFormatter-backed FileHandler
- document structured logging in `README`
- test JSON log emission

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy` *(fails: Skipping analyzing "sklearn.feature_extraction.text": module is installed, but missing library stubs or py.typed marker)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_cli.py::test_configure_logging_emits_json -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4800a4af8832b9ef35867ca855e69