### PR TITLE
refactor: generate feature ids in code

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -424,13 +424,6 @@ class PlateauDescriptionsResponse(StrictModel):
 
 class FeatureItem(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    feature_id: Annotated[
-        str | None,
-        Field(
-            min_length=1,
-            description="Unique feature identifier assigned post-processing.",
-        ),
-    ] = None
     name: Annotated[str, Field(min_length=1)]
     description: Annotated[str, Field(min_length=1)]
     score: MaturityScore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,13 +5,9 @@ Ensures OpenAI calls are stubbed and a deterministic API key is present.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Callable
 from unittest.mock import AsyncMock
 
 import pytest
-
-from models import SCHEMA_VERSION, EvolutionMeta
 
 
 @pytest.fixture(autouse=True)
@@ -35,19 +31,3 @@ def _mock_openai(monkeypatch):
             )
     except Exception:
         pass
-
-
-@pytest.fixture
-def meta_factory() -> Callable[..., EvolutionMeta]:
-    """Return a factory that builds ``EvolutionMeta`` instances for tests."""
-
-    def _factory(**overrides: Any) -> EvolutionMeta:
-        data: dict[str, Any] = {
-            "schema_version": SCHEMA_VERSION,
-            "generated_at": datetime(2000, 1, 1, tzinfo=timezone.utc),
-            "generator": "tests",
-        }
-        data.update(overrides)
-        return EvolutionMeta(**data)
-
-    return _factory

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -34,7 +34,7 @@ async def _noop_init_embeddings() -> None:
 cli.init_embeddings = _noop_init_embeddings
 
 
-def test_generate_evolution_writes_results(tmp_path, monkeypatch, meta_factory) -> None:
+def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
     """_cmd_generate_evolution should write evolution results to disk."""
     input_path = tmp_path / "services.jsonl"
     output_path = tmp_path / "out.jsonl"
@@ -64,7 +64,7 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch, meta_factory) 
         role_ids=None,
         transcripts_dir=None,
     ) -> ServiceEvolution:
-        return ServiceEvolution(meta=meta_factory(), service=service, plateaus=[])
+        return ServiceEvolution(service=service, plateaus=[])
 
     monkeypatch.setattr("cli.Agent", DummyAgent)
     monkeypatch.setattr(
@@ -116,11 +116,10 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch, meta_factory) 
     payload = json.loads(output_path.read_text(encoding="utf-8").strip())
     assert payload["service"]["name"] == "svc"
     assert payload["service"]["service_id"] == "svc-1"
-    assert payload["meta"]["schema_version"] == SCHEMA_VERSION
-    assert "generated_at" in payload["meta"]
+    assert payload["schema_version"] == SCHEMA_VERSION
 
 
-def test_generate_evolution_dry_run(tmp_path, monkeypatch, meta_factory) -> None:
+def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
     """Dry run should skip processing and not write output."""
     input_path = tmp_path / "services.jsonl"
     output_path = tmp_path / "out.jsonl"
@@ -140,7 +139,7 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch, meta_factory) -> None
         transcripts_dir=None,
     ) -> ServiceEvolution:
         called["ran"] = True
-        return ServiceEvolution(meta=meta_factory(), service=service, plateaus=[])
+        return ServiceEvolution(service=service, plateaus=[])
 
     monkeypatch.setattr("cli.Agent", DummyAgent)
     monkeypatch.setattr(
@@ -193,7 +192,7 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch, meta_factory) -> None
     assert not called["ran"]
 
 
-def test_generate_evolution_resume(tmp_path, monkeypatch, meta_factory) -> None:
+def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:
     """Resume should append new results and track processed IDs."""
     input_path = tmp_path / "services.jsonl"
     output_path = tmp_path / "out.jsonl"
@@ -222,7 +221,7 @@ def test_generate_evolution_resume(tmp_path, monkeypatch, meta_factory) -> None:
         transcripts_dir=None,
     ) -> ServiceEvolution:
         processed.append(service.service_id)
-        return ServiceEvolution(meta=meta_factory(), service=service, plateaus=[])
+        return ServiceEvolution(service=service, plateaus=[])
 
     monkeypatch.setattr("cli.Agent", DummyAgent)
     monkeypatch.setattr(
@@ -277,9 +276,7 @@ def test_generate_evolution_resume(tmp_path, monkeypatch, meta_factory) -> None:
     assert processed_path.read_text(encoding="utf-8").splitlines() == ["s1", "s2"]
 
 
-def test_generate_evolution_rejects_invalid_concurrency(
-    tmp_path, monkeypatch, meta_factory
-) -> None:
+def test_generate_evolution_rejects_invalid_concurrency(tmp_path, monkeypatch) -> None:
     """Invalid concurrency should raise an error rather than deadlock."""
 
     input_path = tmp_path / "services.jsonl"
@@ -297,7 +294,7 @@ def test_generate_evolution_rejects_invalid_concurrency(
         role_ids=None,
         transcripts_dir=None,
     ) -> ServiceEvolution:
-        return ServiceEvolution(meta=meta_factory(), service=service, plateaus=[])
+        return ServiceEvolution(service=service, plateaus=[])
 
     monkeypatch.setattr("cli.Agent", DummyAgent)
     monkeypatch.setattr(
@@ -384,9 +381,7 @@ def test_cli_parses_mapping_options(tmp_path, monkeypatch) -> None:
     assert called["args"].mapping_parallel_types is False
 
 
-def test_generate_evolution_writes_transcripts(
-    tmp_path, monkeypatch, meta_factory
-) -> None:
+def test_generate_evolution_writes_transcripts(tmp_path, monkeypatch) -> None:
     """_cmd_generate_evolution writes per-service transcripts to disk."""
 
     input_path = tmp_path / "services.jsonl"
@@ -419,7 +414,7 @@ def test_generate_evolution_writes_transcripts(
         assert transcripts_dir is not None
         path = transcripts_dir / f"{service.service_id}.json"
         path.write_text("{}", encoding="utf-8")
-        return ServiceEvolution(meta=meta_factory(), service=service, plateaus=[])
+        return ServiceEvolution(service=service, plateaus=[])
 
     monkeypatch.setattr("cli.Agent", DummyAgent)
     monkeypatch.setattr(

--- a/tests/test_mapping_batch_size.py
+++ b/tests/test_mapping_batch_size.py
@@ -34,6 +34,12 @@ async def test_long_description_reduces_batch_size(monkeypatch) -> None:
     )
 
     captured: dict[str, object] = {}
+    logged: dict[str, str] = {}
+
+    def fake_info(msg: str, *args) -> None:
+        logged["msg"] = msg % args if args else msg
+
+    monkeypatch.setattr("plateau_generator.logfire.info", fake_info)
 
     async def dummy_map_features(
         session, features, mapping_types=None, *, batch_size, parallel_types=True
@@ -60,6 +66,7 @@ async def test_long_description_reduces_batch_size(monkeypatch) -> None:
 
     assert captured["batch_size"] == 2
     assert captured["order"] == [f"F{i}" for i in range(5)]
+    assert "Reduced mapping batch size" in logged["msg"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,7 +8,6 @@ from pydantic import ValidationError
 
 from models import (
     Contribution,
-    FeatureItem,
     MappingResponse,
     MaturityScore,
     PlateauFeature,
@@ -20,7 +19,7 @@ from models import (
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 
-def test_service_evolution_contains_plateaus(meta_factory) -> None:
+def test_service_evolution_contains_plateaus() -> None:
     """Constructing a ServiceEvolution should retain nested models."""
 
     service = ServiceInput(
@@ -44,9 +43,7 @@ def test_service_evolution_contains_plateaus(meta_factory) -> None:
         features=[feature],
     )
 
-    evolution = ServiceEvolution(
-        meta=meta_factory(), service=service, plateaus=[plateau]
-    )
+    evolution = ServiceEvolution(service=service, plateaus=[plateau])
 
     assert evolution.plateaus[0].features[0].name == "Feat"
 
@@ -62,31 +59,6 @@ def test_plateau_feature_validates_score() -> None:
             score=MaturityScore(level=6, label="Invalid", justification="bad"),
             customer_type="learners",
         )
-
-
-def test_feature_item_allows_missing_id() -> None:
-    """feature_id should be optional."""
-
-    item = FeatureItem(
-        name="n",
-        description="d",
-        score=MaturityScore(level=1, label="Initial", justification="j"),
-    )
-
-    assert item.feature_id is None
-
-
-def test_feature_item_accepts_arbitrary_id() -> None:
-    """Any non-empty string should be accepted as feature_id."""
-
-    item = FeatureItem(
-        feature_id="custom-id",
-        name="n",
-        description="d",
-        score=MaturityScore(level=1, label="Initial", justification="j"),
-    )
-
-    assert item.feature_id == "custom-id"
 
 
 def test_contribution_requires_fields() -> None:

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -106,8 +106,8 @@ def test_build_plateau_prompt_excludes_feature_id() -> None:
     assert "FEAT-" not in prompt
 
 
-def test_to_feature_hashes_missing_id() -> None:
-    """_to_feature should hash name and role when feature_id is absent."""
+def test_to_feature_hashes_name_and_role() -> None:
+    """_to_feature should hash the feature name and role."""
 
     session = DummySession([])
     generator = PlateauGenerator(cast(ConversationSession, session))
@@ -196,7 +196,6 @@ def test_generate_plateau_repairs_missing_features(monkeypatch) -> None:
                 "learners": [],
                 "academics": [
                     {
-                        "feature_id": "FEAT-1-academics-a",
                         "name": "A",
                         "description": "da",
                         "score": {"level": 3, "label": "Defined", "justification": "j"},
@@ -204,7 +203,6 @@ def test_generate_plateau_repairs_missing_features(monkeypatch) -> None:
                 ],
                 "professional_staff": [
                     {
-                        "feature_id": "FEAT-1-professional_staff-p",
                         "name": "P",
                         "description": "dp",
                         "score": {"level": 3, "label": "Defined", "justification": "j"},
@@ -217,7 +215,6 @@ def test_generate_plateau_repairs_missing_features(monkeypatch) -> None:
         {
             "features": [
                 {
-                    "feature_id": "FEAT-1-learners-l",
                     "name": "L",
                     "description": "dl",
                     "score": {"level": 3, "label": "Defined", "justification": "j"},
@@ -282,13 +279,11 @@ def test_generate_plateau_requests_missing_features_concurrently(
             "features": {
                 "learners": [
                     {
-                        "feature_id": "FEAT-1-learners-a",
                         "name": "A",
                         "description": "da",
                         "score": {"level": 3, "label": "Defined", "justification": "j"},
                     },
                     {
-                        "feature_id": "FEAT-1-learners-b",
                         "name": "B",
                         "description": "db",
                         "score": {"level": 3, "label": "Defined", "justification": "j"},
@@ -296,7 +291,6 @@ def test_generate_plateau_requests_missing_features_concurrently(
                 ],
                 "academics": [
                     {
-                        "feature_id": "FEAT-1-academics-a",
                         "name": "A",
                         "description": "da",
                         "score": {"level": 3, "label": "Defined", "justification": "j"},
@@ -304,7 +298,6 @@ def test_generate_plateau_requests_missing_features_concurrently(
                 ],
                 "professional_staff": [
                     {
-                        "feature_id": "FEAT-1-professional_staff-a",
                         "name": "A",
                         "description": "da",
                         "score": {"level": 3, "label": "Defined", "justification": "j"},
@@ -345,7 +338,6 @@ def test_generate_plateau_requests_missing_features_concurrently(
         await asyncio.sleep(0.1)  # Simulate network delay per role request.
         return [
             FeatureItem(
-                feature_id=f"FEAT-1-{role}-extra",
                 name=f"Extra {role}",
                 description="d",
                 score=MaturityScore(level=3, label="Defined", justification="j"),
@@ -395,10 +387,9 @@ def test_generate_plateau_repairs_invalid_role(monkeypatch) -> None:
     initial = json.dumps(
         {
             "features": {
-                "learners": [{"feature_id": "FEAT-1-learners-bad"}],
+                "learners": [{}],
                 "academics": [
                     {
-                        "feature_id": "FEAT-1-academics-a",
                         "name": "A",
                         "description": "da",
                         "score": {"level": 3, "label": "Defined", "justification": "j"},
@@ -406,7 +397,6 @@ def test_generate_plateau_repairs_invalid_role(monkeypatch) -> None:
                 ],
                 "professional_staff": [
                     {
-                        "feature_id": "FEAT-1-professional_staff-p",
                         "name": "P",
                         "description": "dp",
                         "score": {"level": 3, "label": "Defined", "justification": "j"},
@@ -419,7 +409,6 @@ def test_generate_plateau_repairs_invalid_role(monkeypatch) -> None:
         {
             "features": [
                 {
-                    "feature_id": "FEAT-1-learners-l",
                     "name": "L",
                     "description": "dl",
                     "score": {"level": 3, "label": "Defined", "justification": "j"},


### PR DESCRIPTION
## Summary
- generate stable feature identifiers from feature name and role
- drop unused EvolutionMeta test fixture and update CLI tests
- log mapping batch size reduction when token estimate exceeds cap

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing src/plateau_generator.py tests/test_mapping_batch_size.py`
- `poetry run ruff check --fix src/plateau_generator.py tests/test_mapping_batch_size.py`
- `poetry run mypy`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a504ec58b0832bb5a456afa4d3fae2