### PR TITLE
feat: dynamically downsize mapping batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ subcommands to select the desired operation:
 ```bash
 poetry run service-ambitions generate-ambitions --input-file sample-services.jsonl --output-file ambitions.jsonl
 poetry run service-ambitions generate-evolution --input-file sample-services.jsonl --output-file evolution.jsonl
-poetry run service-ambitions generate-mapping --input-file evolution.jsonl --output-file remapped.jsonl
+poetry run service-ambitions generate-mapping --input evolution.jsonl --output remapped.jsonl
 ```
 
 Alternatively, use the provided shell script which forwards all arguments to the CLI:
@@ -104,7 +104,7 @@ Alternatively, use the provided shell script which forwards all arguments to the
 ```bash
 ./run.sh generate-ambitions --input-file sample-services.jsonl --output-file ambitions.jsonl
 ./run.sh generate-evolution --input-file sample-services.jsonl --output-file evolution.jsonl
-./run.sh generate-mapping --input-file evolution.jsonl --output-file remapped.jsonl
+./run.sh generate-mapping --input evolution.jsonl --output remapped.jsonl
 ```
 
 ## Usage
@@ -135,7 +135,7 @@ new mapping data. Adjust mapping behaviour with:
 Example invocation:
 
 ```bash
-./run.sh generate-mapping --input-file evolution.jsonl --output-file remapped.jsonl \
+./run.sh generate-mapping --input evolution.jsonl --output remapped.jsonl \
   --mapping-batch-size 20 --no-mapping-parallel-types
 ```
 

--- a/docs/generate-mapping.md
+++ b/docs/generate-mapping.md
@@ -8,8 +8,8 @@ Example command:
 
 ```bash
 poetry run service-ambitions generate-mapping \
-  --input-file evolution.jsonl \
-  --output-file remapped.jsonl \
+  --input evolution.jsonl \
+  --output remapped.jsonl \
   --mapping-batch-size 20 --mapping-parallel-types
 ```
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -483,7 +483,7 @@ async def _cmd_generate_mapping(args: argparse.Namespace, settings) -> None:
         else settings.mapping_parallel_types
     )
 
-    input_path = Path(args.input_file)
+    input_path = Path(args.input)
     evolutions = [
         ServiceEvolution.model_validate_json(line)
         for line in input_path.read_text(encoding="utf-8").splitlines()
@@ -507,7 +507,7 @@ async def _cmd_generate_mapping(args: argparse.Namespace, settings) -> None:
         for plateau in evo.plateaus:
             plateau.features = [mapped_by_id[f.feature_id] for f in plateau.features]
 
-    output_path = Path(args.output_file)
+    output_path = Path(args.output)
     with output_path.open("w", encoding="utf-8") as out:
         for evo in evolutions:
             out.write(f"{evo.model_dump_json()}\n")
@@ -692,12 +692,12 @@ def main() -> None:
         help="Generate feature mappings",
     )
     map_p.add_argument(
-        "--input-file",
+        "--input",
         default="evolution.jsonl",
         help="Path to the evolution JSONL file",
     )
     map_p.add_argument(
-        "--output-file",
+        "--output",
         default="mapped.jsonl",
         help="File to write the results",
     )

--- a/tests/test_cli_generate_mapping.py
+++ b/tests/test_cli_generate_mapping.py
@@ -34,8 +34,8 @@ class DummyAgent:
         self.instructions = instructions
 
 
-cli.ModelFactory = DummyFactory
-cli.Agent = DummyAgent
+cli.ModelFactory = DummyFactory  # type: ignore[assignment, misc]
+cli.Agent = DummyAgent  # type: ignore[assignment, misc]
 
 
 def test_generate_mapping_updates_features(tmp_path, monkeypatch) -> None:
@@ -102,8 +102,8 @@ def test_generate_mapping_updates_features(tmp_path, monkeypatch) -> None:
         web_search=False,
     )
     args = argparse.Namespace(
-        input_file=str(input_path),
-        output_file=str(output_path),
+        input=str(input_path),
+        output=str(output_path),
         model=None,
         mapping_model=None,
         mapping_batch_size=5,

--- a/tests/test_mapping_batch_size.py
+++ b/tests/test_mapping_batch_size.py
@@ -42,7 +42,13 @@ async def test_long_description_reduces_batch_size(monkeypatch) -> None:
     monkeypatch.setattr("plateau_generator.logfire.info", fake_info)
 
     async def dummy_map_features(
-        session, features, mapping_types=None, *, batch_size, parallel_types=True
+        session,
+        features,
+        mapping_types=None,
+        *,
+        batch_size,
+        parallel_types=True,
+        token_cap=0,
     ):
         captured["batch_size"] = batch_size
         captured["order"] = [f.feature_id for f in features]

--- a/tests/test_mapping_dynamic_batching.py
+++ b/tests/test_mapping_dynamic_batching.py
@@ -1,0 +1,56 @@
+import pytest
+
+from mapping import map_features_async
+from models import MappingTypeConfig, MaturityScore, PlateauFeature
+
+
+class DummySession:
+    """Minimal session used for mapping tests."""
+
+
+@pytest.mark.asyncio
+async def test_map_features_downsizes_batches(monkeypatch) -> None:
+    """Mapping should split batches when the prompt exceeds ``token_cap``."""
+
+    # Prompt length scales with number of features to trigger downsizing.
+    monkeypatch.setattr(
+        "mapping._build_mapping_prompt",
+        lambda feats, *_, **__: "x" * (len(feats) * 10),
+    )
+    monkeypatch.setattr(
+        "mapping.estimate_tokens", lambda prompt, expected_output: len(prompt)
+    )
+
+    captured: list[list[str]] = []
+
+    async def fake_map_parallel(session, batches, mapping_types, **kwargs):
+        captured.extend([[f.feature_id for f in batch] for batch in batches])
+        return {f.feature_id: f for batch in batches for f in batch}
+
+    monkeypatch.setattr("mapping._map_parallel", fake_map_parallel)
+    logs: list[str] = []
+    monkeypatch.setattr(
+        "mapping.logfire.info", lambda msg, *a, **k: logs.append(msg % a if a else msg)
+    )
+
+    features = [
+        PlateauFeature(
+            feature_id=f"F{i}",
+            name="N",
+            description="D",
+            score=MaturityScore(level=1, label="L", justification="J"),
+            customer_type="learners",
+        )
+        for i in range(5)
+    ]
+    mapping_types = {"apps": MappingTypeConfig(dataset="applications", label="Apps")}
+    await map_features_async(
+        DummySession(),
+        features,
+        mapping_types=mapping_types,
+        batch_size=5,
+        token_cap=15,
+    )
+
+    assert captured == [[f"F{i}"] for i in range(5)]
+    assert any("Reduced mapping batch size" in msg for msg in logs)

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -106,8 +106,8 @@ def test_build_plateau_prompt_excludes_feature_id() -> None:
     assert "FEAT-" not in prompt
 
 
-def test_to_feature_hashes_name_and_role() -> None:
-    """_to_feature should hash the feature name and role."""
+def test_to_feature_hashes_name_role_and_plateau() -> None:
+    """_to_feature should hash name, role and plateau."""
 
     session = DummySession([])
     generator = PlateauGenerator(cast(ConversationSession, session))
@@ -116,8 +116,8 @@ def test_to_feature_hashes_name_and_role() -> None:
         description="d",
         score=MaturityScore(level=3, label="Defined", justification="j"),
     )
-    feature = generator._to_feature(item, "learners")
-    expected = hashlib.sha1("Example|learners".encode()).hexdigest()
+    feature = generator._to_feature(item, "learners", "Foundational")
+    expected = hashlib.sha1("Example|learners|Foundational".encode()).hexdigest()
     assert feature.feature_id == expected
 
 


### PR DESCRIPTION
## Summary
- split mapping batches when prompts would exceed a configurable token cap
- pass token cap through PlateauGenerator and cover with a unit test
- simplify `generate-mapping` CLI flags to `--input`/`--output`

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: attr-defined and call-arg issues in tests)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(7 passed, 23 warnings, interrupted by KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a517b9b2d4832baea37babbd5dfae3