### PR TITLE
Add token metrics and stage summaries

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -55,6 +55,7 @@ def _log_stage_totals() -> None:
             "Stage totals",
             stage=stage,
             total_tokens=totals.total_tokens,
+            prompt_tokens_estimate=totals.prompt_tokens_estimate,
             estimated_cost=totals.estimated_cost,
             tokens_per_sec=tokens_sec,
             avg_latency=avg_latency,

--- a/src/stage_metrics.py
+++ b/src/stage_metrics.py
@@ -10,6 +10,7 @@ class StageTotals:
     """Aggregate metrics for a conversation stage."""
 
     total_tokens: int = 0
+    prompt_tokens_estimate: int = 0
     estimated_cost: float = 0.0
     total_duration: float = 0.0
     prompts: int = 0
@@ -20,12 +21,27 @@ _stage_totals: dict[str, StageTotals] = defaultdict(StageTotals)
 
 
 def record_stage_metrics(
-    stage: str, tokens: int, cost: float, duration: float, is_429: bool
+    stage: str,
+    tokens: int,
+    cost: float,
+    duration: float,
+    is_429: bool,
+    prompt_tokens: int,
 ) -> None:
-    """Update aggregated metrics for ``stage``."""
+    """Update aggregated metrics for ``stage``.
+
+    Args:
+        stage: Name of the conversation stage.
+        tokens: Actual tokens consumed by the request.
+        cost: Estimated USD cost for the request.
+        duration: Request latency in seconds.
+        is_429: Whether the request resulted in a rate limit error.
+        prompt_tokens: Estimated prompt tokens before the request was sent.
+    """
 
     totals = _stage_totals[stage]
     totals.total_tokens += tokens
+    totals.prompt_tokens_estimate += prompt_tokens
     totals.estimated_cost += cost
     totals.total_duration += duration
     totals.prompts += 1

--- a/tests/test_stage_metrics.py
+++ b/tests/test_stage_metrics.py
@@ -1,0 +1,20 @@
+from stage_metrics import (
+    iter_stage_totals,
+    record_stage_metrics,
+    reset_stage_totals,
+)
+
+
+def test_record_stage_metrics_tracks_prompt_tokens() -> None:
+    """Prompt token estimates should accumulate per stage."""
+
+    reset_stage_totals()
+    record_stage_metrics("alpha", 10, 1.0, 2.0, False, 4)
+    stage, totals = next(iter_stage_totals())
+    assert stage == "alpha"
+    assert totals.total_tokens == 10
+    assert totals.prompt_tokens_estimate == 4
+    assert totals.estimated_cost == 1.0
+    assert totals.total_duration == 2.0
+    assert totals.prompts == 1
+    assert totals.errors_429 == 0


### PR DESCRIPTION
## Summary
- record prompt token estimates per stage and expose stage totals in CLI output
- expand RollingMetrics with latency tracking and 429-rate logging
- track request latency and rate limit errors in retry helper

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy src`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a578ee9340832b9c11acd91efcd499