### PR TITLE
docs: nest feature mapping data

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,9 +288,11 @@ Each JSON line in the output file follows the `ServiceEvolution` schema:
             "justification": "string"
           },
           "customer_type": "string",
-          "data": [{ "item": "string", "contribution": 0.5 }],
-          "applications": [{ "item": "string", "contribution": 0.5 }],
-          "technology": [{ "item": "string", "contribution": 0.5 }]
+          "mappings": {
+            "data": [{ "item": "string", "contribution": 0.5 }],
+            "applications": [{ "item": "string", "contribution": 0.5 }],
+            "technology": [{ "item": "string", "contribution": 0.5 }]
+          }
         }
       ]
     }
@@ -310,16 +312,17 @@ Fields in the schema:
   - `created`: ISO-8601 timestamp when the record was produced.
 - `service`: `ServiceInput` with `service_id`, `name`, `description`, optional
   `customer_type`, `jobs_to_be_done`, and existing `features`.
-- `plateaus`: list of `PlateauResult` entries, each containing:
-  - `plateau`: integer plateau level.
-  - `plateau_name`: descriptive plateau label.
-  - `service_description`: narrative for the service at that plateau.
-  - `features`: list of `PlateauFeature` entries with:
-    - `feature_id`, `name`, and `description`.
-    - `score`: object with CMMI maturity `level`, `label` and `justification`.
-    - `customer_type`: audience benefiting from the feature.
-    - `data`, `applications`, `technology`: lists of `Contribution` objects
-      describing why a mapped item supports the feature.
+  - `plateaus`: list of `PlateauResult` entries, each containing:
+    - `plateau`: integer plateau level.
+    - `plateau_name`: descriptive plateau label.
+    - `service_description`: narrative for the service at that plateau.
+    - `features`: list of `PlateauFeature` entries with:
+      - `feature_id`, `name`, and `description`.
+      - `score`: object with CMMI maturity `level`, `label` and `justification`.
+      - `customer_type`: audience benefiting from the feature.
+      - `mappings`: object with `data`, `applications` and `technology` lists of
+        `Contribution` objects describing why a mapped item supports the
+        feature.
 
 ## Reference Data
 
@@ -353,7 +356,6 @@ Generate service features for the {service_name} service at plateau {plateau}.
 - Each key must map to an array containing at least {required_count} feature
   objects.
 - Every feature must provide:
-  - "feature_id": unique string identifier.
   - "name": short feature title.
   - "description": explanation of the feature.
   - "score": object describing CMMI maturity with:
@@ -374,8 +376,8 @@ below.
 ## Instructions
 
 - Return a JSON object with a top-level "features" array.
-- Each element must include "feature_id", "data", "applications" and
-  "technology" arrays.
+- Each element must include "feature_id" and a "mappings" object containing
+  "data", "applications" and "technology" arrays.
 - For each mapping list, return at most 5 items.
 - Items in these arrays must provide "item" and "contribution" fields. The
   "contribution" value is a number in [0.1, 1.0] where 1.0 = critical, 0.5 =

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -94,9 +94,11 @@ Each line in the output file is a JSON object with:
             "justification": "string"
           },
           "customer_type": "string",
-          "data": [{ "item": "string", "contribution": 0.5 }],
-          "applications": [{ "item": "string", "contribution": 0.5 }],
-          "technology": [{ "item": "string", "contribution": 0.5 }]
+          "mappings": {
+            "data": [{ "item": "string", "contribution": 0.5 }],
+            "applications": [{ "item": "string", "contribution": 0.5 }],
+            "technology": [{ "item": "string", "contribution": 0.5 }]
+          }
         }
       ]
     }

--- a/docs/sd01-flow-of-evolution-prompts.md
+++ b/docs/sd01-flow-of-evolution-prompts.md
@@ -121,7 +121,6 @@ Generate service features for the Learning & Teaching service at plateau 1.
 - Return a single JSON object with three keys: "learners", "staff" and "community".
 - Each key must map to an array containing at least 5 feature objects.
 - Every feature must provide:
-    - "feature_id": unique string identifier.
     - "name": short feature title.
     - "description": explanation of the feature.
     - "score": object describing CMMI maturity with "level", "label" and "justification".
@@ -135,15 +134,15 @@ Generate service features for the Learning & Teaching service at plateau 1.
   "properties": {
     "learners": {
       "type": "array",
-      "items": {"type": "object","properties": {"feature_id": {"type": "string"},"name": {"type": "string"},"description": {"type": "string"},"score": {"type": "object","properties": {"level": {"type": "integer"},"label": {"type": "string"},"justification": {"type": "string"}},"required": ["level","label","justification"]}},"required": ["feature_id","name","description","score"]}
+      "items": {"type": "object","properties": {"name": {"type": "string"},"description": {"type": "string"},"score": {"type": "object","properties": {"level": {"type": "integer"},"label": {"type": "string"},"justification": {"type": "string"}},"required": ["level","label","justification"]}},"required": ["name","description","score"]}
     },
     "staff": {
       "type": "array",
-      "items": {"type": "object","properties": {"feature_id": {"type": "string"},"name": {"type": "string"},"description": {"type": "string"},"score": {"type": "object","properties": {"level": {"type": "integer"},"label": {"type": "string"},"justification": {"type": "string"}},"required": ["level","label","justification"]}},"required": ["feature_id","name","description","score"]}
+      "items": {"type": "object","properties": {"name": {"type": "string"},"description": {"type": "string"},"score": {"type": "object","properties": {"level": {"type": "integer"},"label": {"type": "string"},"justification": {"type": "string"}},"required": ["level","label","justification"]}},"required": ["name","description","score"]}
     },
     "community": {
       "type": "array",
-      "items": {"type": "object","properties": {"feature_id": {"type": "string"},"name": {"type": "string"},"description": {"type": "string"},"score": {"type": "object","properties": {"level": {"type": "integer"},"label": {"type": "string"},"justification": {"type": "string"}},"required": ["level","label","justification"]}},"required": ["feature_id","name","description","score"]}
+      "items": {"type": "object","properties": {"name": {"type": "string"},"description": {"type": "string"},"score": {"type": "object","properties": {"level": {"type": "integer"},"label": {"type": "string"},"justification": {"type": "string"}},"required": ["level","label","justification"]}},"required": ["name","description","score"]}
     }
   },
   "required": ["learners","staff","community"]
@@ -170,7 +169,7 @@ Map each feature to relevant Data, Applications, Technologies from the lists bel
 
 #### Instructions
 - Return a JSON object with a top-level "features" array.
-- Each element must include "feature_id" and the following arrays: data, applications, technology.
+- Each element must include "feature_id" and a "mappings" object containing "data", "applications" and "technology" arrays.
 - For each mapping list, return at most 5 items.
 - Items in these arrays must provide "item" and "contribution" fields. The
   "contribution" value is a number in [0.1, 1.0] where 1.0 = critical, 0.5 =
@@ -191,11 +190,13 @@ Map each feature to relevant Data, Applications, Technologies from the lists bel
         "type": "object",
         "properties": {
           "feature_id": {"type": "string"},
-          "data": {"type": "array", "maxItems": 5, "items": {"type": "object", "properties": {"item": {"type": "string"}, "contribution": {"type": "number", "minimum": 0.1, "maximum": 1.0}}, "required": ["item", "contribution"]}},
-          "applications": {"type": "array", "maxItems": 5, "items": {"type": "object", "properties": {"item": {"type": "string"}, "contribution": {"type": "number", "minimum": 0.1, "maximum": 1.0}}, "required": ["item", "contribution"]}},
-          "technology": {"type": "array", "maxItems": 5, "items": {"type": "object", "properties": {"item": {"type": "string"}, "contribution": {"type": "number", "minimum": 0.1, "maximum": 1.0}}, "required": ["item", "contribution"]}}
+          "mappings": {"type": "object", "properties": {
+            "data": {"type": "array", "maxItems": 5, "items": {"type": "object", "properties": {"item": {"type": "string"}, "contribution": {"type": "number", "minimum": 0.1, "maximum": 1.0}}, "required": ["item", "contribution"]}},
+            "applications": {"type": "array", "maxItems": 5, "items": {"type": "object", "properties": {"item": {"type": "string"}, "contribution": {"type": "number", "minimum": 0.1, "maximum": 1.0}}, "required": ["item", "contribution"]}},
+            "technology": {"type": "array", "maxItems": 5, "items": {"type": "object", "properties": {"item": {"type": "string"}, "contribution": {"type": "number", "minimum": 0.1, "maximum": 1.0}}, "required": ["item", "contribution"]}}
+          }, "required": ["data", "applications", "technology"]}
         },
-        "required": ["feature_id", "data", "applications", "technology"]
+        "required": ["feature_id", "mappings"]
       }
     }
   },


### PR DESCRIPTION
## Summary
- document feature mappings under a consolidated `mappings` object in examples
- drop `feature_id` requirement from plateau prompts and schemas
- align mapping prompts with new nested mapping structure

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Argument 1 to "map_features_async" has incompatible type "DummySession")*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`


------
https://chatgpt.com/codex/tasks/task_e_68a5ad4791b8832b8318ce81847c125d