### PR TITLE
Warm mapping embeddings before feature mapping

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -484,6 +484,10 @@ async def _cmd_generate_mapping(args: argparse.Namespace, settings) -> None:
         else settings.mapping_parallel_types
     )
 
+    # Warm mapping embeddings upfront so subsequent requests reuse cached vectors.
+    # Failures are logged by ``init_embeddings`` and do not interrupt startup.
+    await init_embeddings()
+
     input_path = Path(args.input)
     evolutions = [
         ServiceEvolution.model_validate_json(line)

--- a/tests/test_cli_generate_mapping.py
+++ b/tests/test_cli_generate_mapping.py
@@ -97,6 +97,13 @@ def test_generate_mapping_updates_features(tmp_path, monkeypatch) -> None:
 
     monkeypatch.setattr(cli, "map_features_async", fake_map_features_async)
 
+    init_called = {"ran": False}
+
+    async def fake_init_embeddings() -> None:
+        init_called["ran"] = True
+
+    monkeypatch.setattr(cli, "init_embeddings", fake_init_embeddings)
+
     settings = SimpleNamespace(
         model="cfg",
         openai_api_key="key",
@@ -125,6 +132,7 @@ def test_generate_mapping_updates_features(tmp_path, monkeypatch) -> None:
     }
     assert called["batch_size"] == 5
     assert called["parallel_types"] is False
+    assert init_called["ran"] is True
 
 
 def test_request_mapping_retries(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- warm feature-mapping embeddings before reading evolutions so cached vectors are ready
- assert mapping CLI warms embeddings in tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `pytest` *(fails: 23 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68a5b21fc0bc832baaf20b0e7e4c0ad7