### PR TITLE
Log stage totals after mapping

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -460,6 +460,7 @@ async def _cmd_generate_evolution(
 
 async def _cmd_generate_mapping(args: argparse.Namespace, settings) -> None:
     """Augment evolution features with mapping results."""
+    reset_stage_totals()
 
     use_web_search = (
         args.web_search if args.web_search is not None else settings.web_search
@@ -513,9 +514,12 @@ async def _cmd_generate_mapping(args: argparse.Namespace, settings) -> None:
             plateau.features = [mapped_by_id[f.feature_id] for f in plateau.features]
 
     output_path = Path(args.output)
-    with output_path.open("w", encoding="utf-8") as out:
-        for evo in evolutions:
-            out.write(f"{evo.model_dump_json()}\n")
+    try:
+        with output_path.open("w", encoding="utf-8") as out:
+            for evo in evolutions:
+                out.write(f"{evo.model_dump_json()}\n")
+    finally:
+        _log_stage_totals()
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- reset stage metrics when mapping begins
- always log stage totals after writing mapping output
- test that mapping logs include throughput and error rate

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Argument type mismatches and missing annotations in tests)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_cli_generate_mapping.py::test_generate_mapping_updates_features tests/test_cli_generate_mapping.py::test_generate_mapping_logs_stage_totals`


------
https://chatgpt.com/codex/tasks/task_e_68a5b43cd250832bbee4dd5909818ff2