### PR TITLE
refactor: centralize mapping batch sizing

### DIFF
--- a/src/mapping_utils.py
+++ b/src/mapping_utils.py
@@ -1,0 +1,54 @@
+"""Shared utilities for mapping operations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import TypeVar
+
+import logfire
+
+T = TypeVar("T")
+
+
+def fit_batch_to_token_cap(
+    items: Sequence[T],
+    target_size: int,
+    token_cap: int,
+    token_counter: Callable[[Sequence[T]], int],
+    *,
+    label: str,
+) -> int:
+    """Return the largest batch size within ``token_cap``.
+
+    The ``token_counter`` callable is invoked on progressively smaller slices of
+    ``items`` until the resulting token count is within ``token_cap`` or the
+    batch is reduced to a single item. A reduction is logged when the final
+    size is smaller than ``target_size``.
+
+    Args:
+        items: Complete sequence of items under consideration.
+        target_size: Initial batch size to attempt.
+        token_cap: Maximum permitted token count.
+        token_counter: Function returning the token usage for a given slice of
+            ``items``.
+        label: Descriptor used in log messages to identify the batch type.
+
+    Returns:
+        The adjusted batch size, guaranteed to be at least ``1``.
+    """
+
+    size = min(target_size, len(items))
+    initial = size
+    tokens = token_counter(items[:size])
+    # Reduce the batch until it fits within ``token_cap`` or only one item
+    # remains. The loop handles the edge case where even a single item exceeds
+    # the cap by returning a size of 1.
+    while tokens > token_cap and size > 1:
+        size -= 1
+        tokens = token_counter(items[:size])
+    if size < initial:
+        logfire.info(
+            f"Reduced {label} batch size from {initial} to {size} "
+            f"({tokens} tokens > cap {token_cap})"
+        )
+    return max(1, size)

--- a/tests/test_mapping_batch_size.py
+++ b/tests/test_mapping_batch_size.py
@@ -39,7 +39,7 @@ async def test_long_description_reduces_batch_size(monkeypatch) -> None:
     def fake_info(msg: str, *args) -> None:
         logged["msg"] = msg % args if args else msg
 
-    monkeypatch.setattr("plateau_generator.logfire.info", fake_info)
+    monkeypatch.setattr("mapping_utils.logfire.info", fake_info)
 
     async def dummy_map_features(
         session,

--- a/tests/test_mapping_dynamic_batching.py
+++ b/tests/test_mapping_dynamic_batching.py
@@ -30,7 +30,8 @@ async def test_map_features_downsizes_batches(monkeypatch) -> None:
     monkeypatch.setattr("mapping._map_parallel", fake_map_parallel)
     logs: list[str] = []
     monkeypatch.setattr(
-        "mapping.logfire.info", lambda msg, *a, **k: logs.append(msg % a if a else msg)
+        "mapping_utils.logfire.info",
+        lambda msg, *a, **k: logs.append(msg % a if a else msg),
     )
 
     features = [

--- a/tests/test_mapping_utils.py
+++ b/tests/test_mapping_utils.py
@@ -1,0 +1,29 @@
+from mapping_utils import fit_batch_to_token_cap
+
+
+def test_fit_batch_to_token_cap_reduces(monkeypatch) -> None:
+    """Batch size should shrink until under token cap."""
+
+    logged = {}
+
+    def fake_info(msg: str, *args) -> None:
+        logged["msg"] = msg % args if args else msg
+
+    monkeypatch.setattr("mapping_utils.logfire.info", fake_info)
+
+    items = list(range(5))
+
+    def token_counter(seq):
+        return len(seq) * 5
+
+    size = fit_batch_to_token_cap(items, 5, 10, token_counter, label="test")
+
+    assert size == 2
+    assert "Reduced" in logged["msg"]
+
+
+def test_fit_batch_to_token_cap_never_below_one() -> None:
+    """Helper should always return at least one item."""
+
+    size = fit_batch_to_token_cap([1, 2, 3], 3, 0, lambda s: len(s) * 10, label="test")
+    assert size == 1


### PR DESCRIPTION
## Summary
- extract shared batch-sizing logic into mapping_utils.fit_batch_to_token_cap
- reuse batch-sizing helper in mapping._split_batches and PlateauGenerator._compute_mapping_batch_size
- exercise new utility with dedicated tests and adjust existing mappings tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy src`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a65fe16f28832bbf433253a9ff900d