### PR TITLE
feat: record session metrics

### DIFF
--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -477,7 +477,9 @@ class PlateauGenerator:
                 if level is None:
                     raise ValueError(f"Unknown plateau name: {n}")
                 plateau_session = ConversationSession(
-                    self.session.client, stage=self.session.stage
+                    self.session.client,
+                    stage=self.session.stage,
+                    metrics=self.session.metrics,
                 )
                 plateau_session.add_parent_materials(service_input)
                 return await self.generate_plateau_async(
@@ -651,7 +653,9 @@ class PlateauGenerator:
 
             features = self._collect_features(payload, plateau_name)
             map_session = ConversationSession(
-                self.mapping_session.client, stage=self.mapping_session.stage
+                self.mapping_session.client,
+                stage=self.mapping_session.stage,
+                metrics=self.mapping_session.metrics,
             )
             if self._service is not None:
                 map_session.add_parent_materials(self._service)

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -6,9 +6,11 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 
+import pytest
 from pydantic_ai import Agent, messages
 
 import conversation
+from backpressure import RollingMetrics
 from conversation import ConversationSession
 from models import ServiceFeature, ServiceInput
 from stage_metrics import iter_stage_totals, reset_stage_totals
@@ -147,3 +149,34 @@ def test_ask_redacts_prompt_when_enabled(monkeypatch) -> None:
     session.ask("secret")
 
     assert calls == ["Sending prompt: <redacted>"]
+
+
+def test_metrics_recorded_on_success() -> None:
+    """Metrics should capture request and token usage on success."""
+
+    metrics = RollingMetrics(window=1)
+    session = ConversationSession(cast(Agent[None, str], DummyAgent()), metrics=metrics)
+    session.ask("ping")
+
+    assert len(metrics._requests) == 1
+    assert len(metrics._latencies) == 1
+    assert len(metrics._tokens) == 1
+    assert metrics._in_flight == 0
+
+
+def test_metrics_recorded_on_error() -> None:
+    """Metrics should record errors including 429 hints."""
+
+    class ErrorAgent(DummyAgent):
+        def run_sync(self, prompt: str, message_history: list[str], output_type=None):
+            raise RuntimeError("429 rate limit")
+
+    metrics = RollingMetrics(window=1)
+    session = ConversationSession(cast(Agent[None, str], ErrorAgent()), metrics=metrics)
+    with pytest.raises(RuntimeError):
+        session.ask("ping")
+
+    assert len(metrics._requests) == 1
+    assert len(metrics._errors) == 1
+    assert len(metrics._errors_429) == 1
+    assert len(metrics._latencies) == 1


### PR DESCRIPTION
## Summary
- inject optional RollingMetrics into ConversationSession
- propagate metrics through plateau and CLI sessions for telemetry
- track ConversationSession request/error/timing metrics and add unit tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy src`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6635e95f4832b9b017c6535f51e3e