### PR TITLE
Skip embedding warmup during evolution dry run

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -389,10 +389,6 @@ async def _cmd_generate_evolution(
         web_search=use_web_search,
     )
 
-    # Warm mapping embeddings upfront so subsequent requests reuse cached vectors.
-    # Failures are logged by ``init_embeddings`` and do not interrupt startup.
-    await init_embeddings()
-
     configure_prompt_dir(settings.prompt_dir)
     system_prompt = load_evolution_prompt(settings.context_id, settings.inspiration)
 
@@ -416,6 +412,10 @@ async def _cmd_generate_evolution(
     if args.dry_run:
         logfire.info(f"Validated {len(services)} services")
         return
+
+    # Warm mapping embeddings upfront so subsequent requests reuse cached vectors.
+    # Failures are logged by ``init_embeddings`` and do not interrupt startup.
+    await init_embeddings()
 
     concurrency = args.concurrency or settings.concurrency
     if concurrency < 1:

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -129,7 +129,10 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
         def __init__(self, model, instructions):
             pass
 
-    called = {"ran": False}
+    called = {"ran": False, "embed": False}
+
+    async def fake_init_embeddings() -> None:
+        called["embed"] = True
 
     async def fake_generate(
         self,
@@ -145,6 +148,7 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(
         "cli.PlateauGenerator.generate_service_evolution_async", fake_generate
     )
+    monkeypatch.setattr("cli.init_embeddings", fake_init_embeddings)
     monkeypatch.setattr("cli.configure_prompt_dir", lambda _path: None)
     monkeypatch.setattr("cli.load_evolution_prompt", lambda _ctx, _insp: "prompt")
     monkeypatch.setattr("cli.logfire.force_flush", lambda: None)
@@ -190,6 +194,7 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
 
     assert not output_path.exists()
     assert not called["ran"]
+    assert not called["embed"]
 
 
 def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- avoid calling `init_embeddings` when running `generate-evolution` with `--dry-run`
- ensure dry-run test verifies embeddings aren't warmed

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Argument 1 to "PlateauGenerator" has incompatible type "DummySession"; expected "ConversationSession" ...)*
- `poetry run mypy src`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest`
- `./run.sh generate-evolution --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68a6671a6798832b9326814941f19fb5