### PR TITLE
refactor: simplify service loading and retry helpers

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -454,20 +454,21 @@ class RoleFeaturesResponse(BaseModel):
 
 def _extract_mapping_list(value: object, key: str) -> list[Contribution]:
     """Return mapping list from ``value`` or an empty list."""
-
     if isinstance(value, list):
         return value
-    if isinstance(value, dict):
-        direct = value.get(key)
-        if isinstance(direct, list):
-            return direct
-        nested = value.get("mappings")
-        if isinstance(nested, dict):
-            inner = nested.get(key)
-            if isinstance(inner, list):
-                return inner
-        elif isinstance(nested, list):
-            return nested
+    if not isinstance(value, dict):
+        return []
+
+    direct = value.get(key)
+    if isinstance(direct, list):
+        return direct
+
+    nested = value.get("mappings")
+    if isinstance(nested, dict):  # Prefer nested dict over list for precision
+        inner = nested.get(key)
+        return inner if isinstance(inner, list) else []
+    if isinstance(nested, list):  # Fallback when nested is already a list
+        return nested
     return []
 
 


### PR DESCRIPTION
## Summary
- reduce service loader complexity and centralize service id attribute
- add retry-after parsing helper and split service execution in generator
- streamline mapping list extraction

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy src`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `pytest` *(fails: Interrupted: 25 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a67b3615f8832b9e0a3777d9ea9fa3