### PR TITLE
Add run metadata to service evolution records

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,8 @@ Each JSON line in the output file follows the `ServiceEvolution` schema:
     "models": {
       "descriptions": "openai:o4-mini",
       "features": "openai:gpt-5",
-      "mapping": "openai:o4-mini"
+      "mapping": "openai:o4-mini",
+      "search": "openai:gpt-4o-search-preview"
     },
     "web_search": false,
     "mapping_types": ["data", "applications", "technology"],

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -65,7 +65,8 @@ Each line in the output file is a JSON object with:
     "models": {
       "descriptions": "openai:o4-mini",
       "features": "openai:gpt-5",
-      "mapping": "openai:o4-mini"
+      "mapping": "openai:o4-mini",
+      "search": "openai:gpt-4o-search-preview"
     },
     "web_search": false,
     "mapping_types": ["data", "applications", "technology"],

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -33,6 +33,7 @@ from models import (
     RoleFeaturesResponse,
     ServiceEvolution,
     ServiceInput,
+    ServiceMeta,
 )
 from settings import load_settings
 from token_scheduler import TokenScheduler
@@ -495,6 +496,7 @@ class PlateauGenerator:
         results: Sequence[PlateauResult],
         plateau_names: Sequence[str],
         role_ids: Sequence[str],
+        meta: ServiceMeta,
         transcripts_dir: Path | None,
     ) -> ServiceEvolution:
         """Return ``ServiceEvolution`` from plateau ``results``."""
@@ -527,7 +529,9 @@ class PlateauGenerator:
                 )
             )
 
-        evolution = ServiceEvolution(service=service_input, plateaus=plateaus)
+        evolution = ServiceEvolution(
+            meta=meta, service=service_input, plateaus=plateaus
+        )
         if transcripts_dir is not None:
             payload = {
                 "request": service_input.model_dump(),
@@ -700,6 +704,7 @@ class PlateauGenerator:
         role_ids: Sequence[str] | None = None,
         *,
         transcripts_dir: Path | None = None,
+        meta: ServiceMeta,
     ) -> ServiceEvolution:
         """Asynchronously return service evolution for selected plateaus.
 
@@ -731,7 +736,7 @@ class PlateauGenerator:
             )
 
             evolution = await self._assemble_evolution(
-                service_input, results, plateau_names, role_ids, transcripts_dir
+                service_input, results, plateau_names, role_ids, meta, transcripts_dir
             )
 
             if self.quarantined_descriptions:
@@ -750,6 +755,7 @@ class PlateauGenerator:
         role_ids: Sequence[str] | None = None,
         *,
         transcripts_dir: Path | None = None,
+        meta: ServiceMeta,
     ) -> ServiceEvolution:
         """Return service evolution for selected plateaus and roles."""
 
@@ -759,5 +765,6 @@ class PlateauGenerator:
                 plateau_names,
                 role_ids,
                 transcripts_dir=transcripts_dir,
+                meta=meta,
             )
         )

--- a/src/schema_migration.py
+++ b/src/schema_migration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from datetime import datetime, timezone
 from typing import Any, Dict
 
 
@@ -31,15 +32,23 @@ def migrate_record(
         ...         "service": {},
         ...         "plateaus": [
         ...             {
-        ...                 "plateau": 1,
-        ...                 "plateau_name": "p1",
-        ...                 "service_description": "d",
-        ...             }
-        ...         ],
+                "plateau": 1,
+                "plateau_name": "p1",
+                "service_description": "d",
+            }
+        ],
         ...     },
         ... )
         {
-            'schema_version': '1.1',
+            'meta': {
+                'schema_version': '1.1',
+                'run_id': '',
+                'seed': None,
+                'models': {},
+                'web_search': False,
+                'mapping_types': [],
+                'created': '2024-01-01T00:00:00+00:00',
+            },
             'service': {},
             'plateaus': [
                 {
@@ -59,7 +68,16 @@ def migrate_record(
     if from_version == "1.0" and to_version.startswith("1."):
         # Perform the 1.0 → 1.x migration.
         migrated = deepcopy(data)
-        migrated["schema_version"] = to_version
+        migrated.pop("schema_version", None)
+        migrated["meta"] = {
+            "schema_version": to_version,
+            "run_id": "",
+            "seed": None,
+            "models": {},
+            "web_search": False,
+            "mapping_types": [],
+            "created": datetime.now(timezone.utc).isoformat(),
+        }
         for plateau in migrated.get("plateaus", []):
             if "service_description" in plateau:
                 plateau["description"] = plateau.pop("service_description")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,7 @@ class DummyFactory:
         return object()
 
 
-cli.ModelFactory = DummyFactory
+cli.ModelFactory = DummyFactory  # type: ignore[assignment,misc]
 
 
 def test_cli_generates_output(tmp_path, monkeypatch):

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -2,6 +2,7 @@
 
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -15,6 +16,7 @@ from models import (
     PlateauFeature,
     ServiceEvolution,
     ServiceInput,
+    ServiceMeta,
 )
 from plateau_generator import PlateauGenerator
 
@@ -114,10 +116,19 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
         description="desc",
         jobs_to_be_done=[{"name": "job"}],
     )
+    meta = ServiceMeta(
+        run_id="run",
+        seed=None,
+        models={},
+        web_search=False,
+        mapping_types=[],
+        created=datetime.now(timezone.utc),
+    )
     evolution = generator.generate_service_evolution(
         service,
         ["Foundational", "Enhanced", "Experimental", "Disruptive"],
         ["learners", "academics", "professional_staff"],
+        meta=meta,
     )
     assert isinstance(evolution, ServiceEvolution)
     assert evolution.meta.schema_version == SCHEMA_VERSION

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -4,11 +4,13 @@ import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 
 import numpy as np
 import pytest
 
 import mapping
+from conversation import ConversationSession
 from mapping import map_feature, map_feature_async, map_features_async
 from models import MappingItem, MappingTypeConfig, MaturityScore, PlateauFeature
 
@@ -98,7 +100,7 @@ async def test_map_feature_returns_mappings(monkeypatch) -> None:
         customer_type="learners",
     )
 
-    result = await map_feature_async(session, feature)
+    result = await map_feature_async(cast(ConversationSession, session), feature)
 
     assert isinstance(result, PlateauFeature)
     assert result.mappings["data"][0].item == "INF-1"
@@ -167,7 +169,7 @@ async def test_map_feature_injects_reference_data(monkeypatch) -> None:
         score=MaturityScore(level=3, label="Defined", justification="j"),
         customer_type="learners",
     )
-    await map_feature_async(session, feature)
+    await map_feature_async(cast(ConversationSession, session), feature)
 
     assert len(session.prompts) == 3
     assert "User Data" in session.prompts[0]
@@ -200,7 +202,7 @@ async def test_map_feature_rejects_invalid_json(monkeypatch) -> None:
         customer_type="learners",
     )
     with pytest.raises(ValueError):
-        await map_feature_async(session, feature)
+        await map_feature_async(cast(ConversationSession, session), feature)
 
 
 def test_map_feature_ignores_unknown_ids(monkeypatch) -> None:
@@ -252,7 +254,7 @@ def test_map_feature_ignores_unknown_ids(monkeypatch) -> None:
         score=MaturityScore(level=3, label="Defined", justification="j"),
         customer_type="learners",
     )
-    result = map_feature(session, feature)
+    result = map_feature(cast(ConversationSession, session), feature)
 
     assert result.mappings["data"] == []
 
@@ -305,7 +307,7 @@ async def test_map_feature_flattens_nested_mappings(monkeypatch) -> None:
         customer_type="learners",
     )
 
-    result = await map_feature_async(session, feature)
+    result = await map_feature_async(cast(ConversationSession, session), feature)
 
     assert result.mappings["data"][0].item == "INF-1"
     assert result.mappings["applications"][0].item == "APP-1"
@@ -366,7 +368,7 @@ async def test_map_feature_flattens_repeated_mapping_keys(monkeypatch) -> None:
         customer_type="learners",
     )
 
-    result = await map_feature_async(session, feature)
+    result = await map_feature_async(cast(ConversationSession, session), feature)
 
     assert result.mappings["data"][0].item == "INF-1"
     assert result.mappings["applications"][0].item == "APP-1"
@@ -432,7 +434,7 @@ async def test_map_features_returns_mappings(monkeypatch) -> None:
         customer_type="learners",
     )
 
-    result = await map_features_async(session, [feature])
+    result = await map_features_async(cast(ConversationSession, session), [feature])
 
     assert result[0].mappings["data"][0].item == "INF-1"
     assert "User Data" in session.prompts[0]
@@ -481,7 +483,7 @@ async def test_map_features_allows_empty_lists(monkeypatch) -> None:
         customer_type="learners",
     )
 
-    result = await map_features_async(session, [feature])
+    result = await map_features_async(cast(ConversationSession, session), [feature])
 
     assert result[0].mappings["data"] == []
     assert result[0].mappings["applications"] == []
@@ -525,7 +527,7 @@ async def test_map_features_retries_on_empty(monkeypatch) -> None:
     )
 
     result = await map_features_async(
-        session,
+        cast(ConversationSession, session),
         [feature],
         {"data": MappingTypeConfig(dataset="information", label="Info")},
     )
@@ -602,7 +604,7 @@ async def test_map_features_reprompts_per_feature(monkeypatch, parallel) -> None
     ]
 
     result = await map_features_async(
-        session,
+        cast(ConversationSession, session),
         features,
         {"data": MappingTypeConfig(dataset="information", label="Info")},
         batch_size=2,
@@ -717,7 +719,7 @@ async def test_map_features_reprompts_missing_app_and_tech(monkeypatch) -> None:
     ]
 
     result = await map_features_async(
-        session,
+        cast(ConversationSession, session),
         features,
         {
             "applications": MappingTypeConfig(dataset="applications", label="Apps"),

--- a/tests/test_mapping_dynamic_batching.py
+++ b/tests/test_mapping_dynamic_batching.py
@@ -1,5 +1,8 @@
+from typing import cast
+
 import pytest
 
+from conversation import ConversationSession
 from mapping import map_features_async
 from models import MappingTypeConfig, MaturityScore, PlateauFeature
 
@@ -46,7 +49,7 @@ async def test_map_features_downsizes_batches(monkeypatch) -> None:
     ]
     mapping_types = {"apps": MappingTypeConfig(dataset="applications", label="Apps")}
     await map_features_async(
-        DummySession(),
+        cast(ConversationSession, DummySession()),
         features,
         mapping_types=mapping_types,
         batch_size=5,

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -8,7 +8,9 @@ def test_model_factory_resolves_models(monkeypatch) -> None:
 
     monkeypatch.setattr("model_factory.build_model", fake_build_model)
 
-    stage = StageModels(features="cfg-feat")
+    stage = StageModels(
+        descriptions=None, features="cfg-feat", mapping=None, search=None
+    )
     factory = ModelFactory("default", "key", stage_models=stage)
 
     assert factory.model_name("features") == "cfg-feat"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,7 @@
 """Unit tests for Pydantic models."""
 
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -14,6 +15,7 @@ from models import (
     PlateauResult,
     ServiceEvolution,
     ServiceInput,
+    ServiceMeta,
 )
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
@@ -43,7 +45,15 @@ def test_service_evolution_contains_plateaus() -> None:
         features=[feature],
     )
 
-    evolution = ServiceEvolution(service=service, plateaus=[plateau])
+    meta = ServiceMeta(
+        run_id="run",
+        seed=None,
+        models={},
+        web_search=False,
+        mapping_types=[],
+        created=datetime.now(timezone.utc),
+    )
+    evolution = ServiceEvolution(meta=meta, service=service, plateaus=[plateau])
 
     assert evolution.plateaus[0].features[0].name == "Feat"
 
@@ -64,7 +74,7 @@ def test_plateau_feature_validates_score() -> None:
 def test_contribution_requires_fields() -> None:
     """Missing fields should trigger a ``ValidationError``."""
     with pytest.raises(ValidationError):
-        Contribution()
+        Contribution()  # type: ignore[call-arg]
 
 
 def test_contribution_enforces_range() -> None:

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -21,7 +21,7 @@ def test_migrate_from_1_0_to_1_1() -> None:
 
     migrated = migrate_record("1.0", "1.1", source)
 
-    assert migrated["schema_version"] == "1.1"
+    assert migrated["meta"]["schema_version"] == "1.1"
     plateau = migrated["plateaus"][0]
     assert "service_description" not in plateau
     assert plateau["description"] == "desc"

--- a/tests/test_token_utils.py
+++ b/tests/test_token_utils.py
@@ -13,7 +13,7 @@ import token_utils
 def test_estimate_tokens_with_tiktoken(monkeypatch) -> None:
     """Ensure ``estimate_tokens`` uses ``tiktoken`` when available."""
     dummy_module = types.ModuleType("tiktoken")
-    dummy_module.get_encoding = lambda name: SimpleNamespace(
+    dummy_module.get_encoding = lambda name: SimpleNamespace(  # type: ignore[attr-defined]
         encode=lambda text: list(text)
     )
     monkeypatch.setitem(sys.modules, "tiktoken", dummy_module)
@@ -36,7 +36,7 @@ def test_estimate_tokens_empty_prompt_with_tiktoken(monkeypatch) -> None:
     """Empty prompts still account for expected output when using tiktoken."""
 
     dummy_module = types.ModuleType("tiktoken")
-    dummy_module.get_encoding = lambda name: SimpleNamespace(
+    dummy_module.get_encoding = lambda name: SimpleNamespace(  # type: ignore[attr-defined]
         encode=lambda text: list(text)
     )
     monkeypatch.setitem(sys.modules, "tiktoken", dummy_module)


### PR DESCRIPTION
## Summary
- track generation run details in new `ServiceMeta` model
- embed `meta` in `ServiceEvolution` and propagate through CLI/generator
- update docs, examples, and tests for the new metadata

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`


------
https://chatgpt.com/codex/tasks/task_e_68a6892906e8832b8b2ec89d5a7a97d8