### PR TITLE
Add JSONL migration CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ subcommands to select the desired operation:
 poetry run service-ambitions generate-ambitions --input-file sample-services.jsonl --output-file ambitions.jsonl
 poetry run service-ambitions generate-evolution --input-file sample-services.jsonl --output-file evolution.jsonl
 poetry run service-ambitions generate-mapping --input evolution.jsonl --output remapped.jsonl
+poetry run service-ambitions migrate-jsonl --input ambitions.jsonl --output upgraded.jsonl --from 1.0 --to 1.1
 ```
 
 Alternatively, use the provided shell script which forwards all arguments to the CLI:
@@ -105,6 +106,7 @@ Alternatively, use the provided shell script which forwards all arguments to the
 ./run.sh generate-ambitions --input-file sample-services.jsonl --output-file ambitions.jsonl
 ./run.sh generate-evolution --input-file sample-services.jsonl --output-file evolution.jsonl
 ./run.sh generate-mapping --input evolution.jsonl --output remapped.jsonl
+./run.sh migrate-jsonl --input ambitions.jsonl --output upgraded.jsonl --from 1.0 --to 1.1
 ```
 
 ## Usage
@@ -141,6 +143,18 @@ Example invocation:
 
 See [generate-mapping](docs/generate-mapping.md) for detailed behaviour and
 troubleshooting.
+
+### Schema migration
+
+Use `migrate-jsonl` to upgrade records between supported schema versions. Each
+line of the input JSON Lines file is parsed, migrated and written to the
+output file.
+
+Example:
+
+```bash
+./run.sh migrate-jsonl --input ambitions.jsonl --output upgraded.jsonl --from 1.0 --to 1.1
+```
 
 ## Adaptive backpressure
 

--- a/tests/test_cli_migrate_jsonl.py
+++ b/tests/test_cli_migrate_jsonl.py
@@ -1,0 +1,53 @@
+"""Tests for the migrate-jsonl CLI subcommand."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from cli import _cmd_migrate_jsonl
+
+
+def test_migrate_jsonl_migrates_records(tmp_path: Path) -> None:
+    """Records should be rewritten with the target schema version."""
+
+    input_path = tmp_path / "in.jsonl"
+    output_path = tmp_path / "out.jsonl"
+    input_path.write_text(
+        '{"schema_version": "1.0", "service": {}, "plateaus": []}\n',
+        encoding="utf-8",
+    )
+
+    args = argparse.Namespace(
+        input=str(input_path),
+        output=str(output_path),
+        from_version="1.0",
+        to_version="1.1",
+    )
+
+    _cmd_migrate_jsonl(args, None)
+
+    lines = output_path.read_text(encoding="utf-8").splitlines()
+    payload = json.loads(lines[0])
+    assert payload["meta"]["schema_version"] == "1.1"
+
+
+def test_migrate_jsonl_rejects_unknown_versions(tmp_path: Path) -> None:
+    """Unsupported version pairs should raise ``ValueError``."""
+
+    input_path = tmp_path / "in.jsonl"
+    output_path = tmp_path / "out.jsonl"
+    input_path.write_text("{}\n", encoding="utf-8")
+
+    args = argparse.Namespace(
+        input=str(input_path),
+        output=str(output_path),
+        from_version="0.9",
+        to_version="1.0",
+    )
+
+    with pytest.raises(ValueError):
+        _cmd_migrate_jsonl(args, None)


### PR DESCRIPTION
## Summary
- add `migrate-jsonl` CLI command for schema upgrades
- document JSONL migration workflow
- test CLI migration between schema versions and error cases

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_cli_migrate_jsonl.py tests/test_schema_migration.py`
- `poetry run pytest` *(interrupted: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a68f78be98832b8a4fcc688ca28572