### PR TITLE
feat: add strict validation option

### DIFF
--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -22,6 +22,10 @@ poetry run service-ambitions generate-evolution \
 
 Use `--roles-file` to supply an alternative roles definition file when needed.
 
+Pass `--strict` to abort if any role lacks features or if generated features
+contain empty mapping lists. This turns on a fail-fast mode instead of the
+default best‑effort behaviour.
+
 Services run concurrently using a bounded worker pool configured via the
 `--concurrency` flag or the `concurrency` setting in `config/app.json`. The
 required number of features per role comes from the `features_per_role` setting

--- a/docs/generate-mapping.md
+++ b/docs/generate-mapping.md
@@ -22,6 +22,10 @@ limit pressure.
 concurrently. Disable it with `--no-mapping-parallel-types` to process types
 sequentially when working under tight rate limits.
 
+Enable fail-fast behaviour with `--strict` to raise an error when any requested
+mapping type is missing or produces an empty list. Without this flag the command
+will keep existing mappings and continue.
+
 ## Input format
 
 Provide a JSON Lines file produced by `generate-evolution`. Each line should be a

--- a/src/cli.py
+++ b/src/cli.py
@@ -209,6 +209,7 @@ async def _generate_evolution_for_service(
                 mapping_session=map_session,
                 mapping_batch_size=mapping_batch_size,
                 mapping_parallel_types=mapping_parallel_types,
+                strict=args.strict,
             )
             global _RUN_META
             if _RUN_META is None:
@@ -530,6 +531,7 @@ async def _cmd_generate_mapping(args: argparse.Namespace, settings) -> None:
     mapped = await map_features_async(
         session,
         features,
+        strict=args.strict,
         batch_size=mapping_batch_size,
         parallel_types=mapping_parallel_types,
     )
@@ -673,6 +675,12 @@ def main() -> None:
         "--no-logs",
         action="store_true",
         help="Disable file logging and Logfire telemetry",
+    )
+    common.add_argument(
+        "--strict",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Fail on missing roles or mappings when enabled",
     )
 
     subparsers = parser.add_subparsers(dest="command", required=True)

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -112,6 +112,7 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
         web_search=None,
         no_logs=False,
         search_model=None,
+        strict=False,
     )
 
     monkeypatch.setattr(cli, "_RUN_META", None)
@@ -195,6 +196,7 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
         web_search=None,
         no_logs=False,
         search_model=None,
+        strict=False,
     )
 
     monkeypatch.setattr(cli, "_RUN_META", None)
@@ -282,6 +284,7 @@ def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:
         web_search=None,
         no_logs=False,
         search_model=None,
+        strict=False,
     )
 
     monkeypatch.setattr(cli, "_RUN_META", None)
@@ -359,6 +362,7 @@ def test_generate_evolution_rejects_invalid_concurrency(tmp_path, monkeypatch) -
         web_search=None,
         no_logs=False,
         search_model=None,
+        strict=False,
     )
 
     monkeypatch.setattr(cli, "_RUN_META", None)
@@ -483,6 +487,7 @@ def test_generate_evolution_writes_transcripts(tmp_path, monkeypatch) -> None:
         web_search=None,
         no_logs=False,
         search_model=None,
+        strict=False,
     )
 
     monkeypatch.setattr(cli, "_RUN_META", None)

--- a/tests/test_cli_generate_mapping.py
+++ b/tests/test_cli_generate_mapping.py
@@ -102,6 +102,7 @@ def test_generate_mapping_updates_features(tmp_path, monkeypatch) -> None:
         features,
         mapping_types=None,
         *,
+        strict,
         batch_size,
         parallel_types,
     ):
@@ -138,6 +139,7 @@ def test_generate_mapping_updates_features(tmp_path, monkeypatch) -> None:
         mapping_parallel_types=False,
         seed=None,
         web_search=None,
+        strict=False,
     )
 
     asyncio.run(_cmd_generate_mapping(args, settings))
@@ -201,6 +203,7 @@ def test_generate_mapping_logs_stage_totals(tmp_path, monkeypatch) -> None:
         features,
         mapping_types=None,
         *,
+        strict,
         batch_size,
         parallel_types,
     ):
@@ -247,6 +250,7 @@ def test_generate_mapping_logs_stage_totals(tmp_path, monkeypatch) -> None:
         mapping_parallel_types=False,
         seed=None,
         web_search=None,
+        strict=False,
     )
 
     asyncio.run(_cmd_generate_mapping(args, settings))

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -84,7 +84,7 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
 
     map_calls = {"n": 0}
 
-    def _fake_map_features(session, features):
+    def _fake_map_features(session, features, *, strict=False):
         map_calls["n"] += 1
         results = []
         for feature in features:

--- a/tests/test_mapping_batch_size.py
+++ b/tests/test_mapping_batch_size.py
@@ -49,6 +49,7 @@ async def test_long_description_reduces_batch_size(monkeypatch) -> None:
         features,
         mapping_types=None,
         *,
+        strict=False,
         batch_size,
         parallel_types=True,
         token_cap=0,
@@ -70,7 +71,7 @@ async def test_long_description_reduces_batch_size(monkeypatch) -> None:
             feature_id=f"F{i}",
             name="N",
             description="D",
-            score=MaturityScore(level=1, label="L", justification="J"),
+            score=MaturityScore(level=1, label="Initial", justification="J"),
             customer_type="learners",
         )
         for i in range(5)


### PR DESCRIPTION
## Summary
- add `--strict` CLI flag to enforce complete mappings
- enforce missing role and mapping checks during plateau assembly and mapping
- document strict mode and add tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_mapping.py::test_map_features_async_strict_raises_missing tests/test_mapping.py::test_map_features_async_best_effort tests/test_plateau_generator.py::test_assemble_evolution_strict_checks tests/test_mapping_batch_size.py::test_long_description_reduces_batch_size -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6926a0774832b8e906cce91cd7d04