### PR TITLE
Redact prompts and transcripts to remove PII

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -26,6 +26,7 @@ from tqdm import tqdm
 
 from backpressure import AdaptiveSemaphore, RollingMetrics
 from models import ReasoningConfig, ServiceInput
+from redaction import redact_pii
 from token_utils import estimate_tokens
 
 SERVICES_PROCESSED = logfire.metric_counter("services_processed")
@@ -305,10 +306,11 @@ class ServiceAmbitionGenerator:
                     "request": service.model_dump(),
                     "response": json.loads(line),
                 }
+                data = redact_pii(json.dumps(payload, ensure_ascii=False))
                 path = transcripts_dir / f"{service.service_id}.json"
                 await asyncio.to_thread(
                     path.write_text,
-                    json.dumps(payload, ensure_ascii=False),
+                    data,
                     encoding="utf-8",
                 )
             return line, service.service_id, tokens

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -35,6 +35,7 @@ from models import (
     ServiceInput,
     ServiceMeta,
 )
+from redaction import redact_pii
 from settings import load_settings
 from token_scheduler import TokenScheduler
 from token_utils import estimate_tokens
@@ -563,10 +564,11 @@ class PlateauGenerator:
                 "request": service_input.model_dump(),
                 "response": evolution.model_dump(),
             }
+            data = redact_pii(json.dumps(payload, ensure_ascii=False))
             path = transcripts_dir / f"{service_input.service_id}.json"
             await asyncio.to_thread(
                 path.write_text,
-                json.dumps(payload, ensure_ascii=False),
+                data,
                 encoding="utf-8",
             )
         if strict:

--- a/src/redaction.py
+++ b/src/redaction.py
@@ -4,19 +4,38 @@ from __future__ import annotations
 
 import re
 
+# Common PII patterns which should be fully masked before logging or
+# persistence.  Each pattern is substituted with ``<redacted>`` prior to the
+# generic numeric replacement applied at the end of :func:`redact_pii`.
+_PII_PATTERNS: list[re.Pattern[str]] = [
+    # Email addresses such as ``user@example.com``
+    re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"),
+    # UUID strings like ``123e4567-e89b-12d3-a456-426614174000``
+    re.compile(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        re.IGNORECASE,
+    ),
+    # Simple identifiers combining letters and digits e.g. ``AB1234567``
+    re.compile(r"[A-Z]{1,3}\d{3,}", re.IGNORECASE),
+]
+
 
 def redact_pii(text: str) -> str:
     """Return ``text`` with obvious personal identifiers removed.
 
-    This implementation naively replaces all digits with ``*`` characters.
+    The function masks common PII patterns such as email addresses and
+    alphanumeric identifiers before replacing any remaining digits with
+    ``*`` characters.
 
     Args:
         text: Raw string potentially containing PII.
 
     Returns:
-        Redacted string with numeric characters masked.
+        Redacted string with sensitive content masked.
     """
 
+    for pattern in _PII_PATTERNS:
+        text = pattern.sub("<redacted>", text)
     return re.sub(r"\d", "*", text)
 
 

--- a/tests/test_async_processing.py
+++ b/tests/test_async_processing.py
@@ -219,7 +219,10 @@ def test_generate_async_saves_transcripts(tmp_path, monkeypatch):
 
     monkeypatch.setattr(generator, "Agent", DummyAgent)
     service = ServiceInput(
-        service_id="svc", name="alpha", description="d", jobs_to_be_done=[]
+        service_id="svc-123",
+        name="alpha",
+        description="Contact j.doe@example.com",
+        jobs_to_be_done=[],
     )
     gen = generator.ServiceAmbitionGenerator(SimpleNamespace())
     out_file = tmp_path / "out.jsonl"
@@ -231,8 +234,12 @@ def test_generate_async_saves_transcripts(tmp_path, monkeypatch):
         )
 
     asyncio.run(run())
-    transcript_path = transcripts / "svc.json"
+    transcript_path = transcripts / "svc-123.json"
     assert transcript_path.exists()
+    data = transcript_path.read_text(encoding="utf-8")
+    assert "j.doe@example.com" not in data
+    assert "svc-123" not in data
+    assert "<redacted>" in data
 
 
 @pytest.mark.asyncio()

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,10 @@
+"""Tests for the :mod:`redaction` helpers."""
+
+from redaction import redact_pii
+
+
+def test_redact_pii_masks_common_patterns() -> None:
+    """Emails, identifiers and digits should be redacted."""
+
+    text = "Email j.doe@example.com ID AB1234567 number 1234"
+    assert redact_pii(text) == "Email <redacted> ID <redacted> number ****"


### PR DESCRIPTION
## Summary
- Redact service context before adding to conversation history when sanitization is enabled
- Mask emails, UUIDs and alphanumeric IDs in `redact_pii`
- Sanitize per-service transcripts and conversation history

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix tests/test_conversation.py src/conversation.py tests/test_async_processing.py tests/test_redaction.py`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_redaction.py tests/test_conversation.py tests/test_async_processing.py::test_generate_async_saves_transcripts`


------
https://chatgpt.com/codex/tasks/task_e_68a69aadf478832b9ab7af3656cab137