### PR TITLE
docs: remove score limits from mapping prompt

### DIFF
--- a/prompts/mapping_prompt.md
+++ b/prompts/mapping_prompt.md
@@ -12,12 +12,10 @@ Map each feature to relevant {mapping_labels} from the lists below.
 
 - Return a JSON object with a top-level "features" array.
 - Each element must include "feature_id" and the following arrays: {mapping_fields}.
-- For each mapping list, return at most 5 items.
-- Items in these arrays must provide "item" and "contribution" fields. The
-  "contribution" value describes how strongly the mapped item supports the
-  feature; higher numbers indicate greater importance.
-- contribution is a number in [0.1, 1.0] where 1.0 = critical, 0.5 = helpful, 0.1 = weak.
-- Do not invent IDs; only use those provided.
+- Select all relevant IDs from the lists provided.
+- Each entry in these arrays must include an "item" field for the selected ID.
+- Do not invent IDs.
+- No limit on the number of items you can return.
 - Maintain terminology consistent with the situational context, definitions and inspirations.
 - Do not include any text outside the JSON object.
 - The response must adhere to the JSON schema provided below.


### PR DESCRIPTION
## Summary
- update mapping prompt to allow selecting all relevant IDs and remove scoring language

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`


------
https://chatgpt.com/codex/tasks/task_e_68a6b9b272d4832b8200516ccc880df5