### PR TITLE
feat: allow optional mapping weights

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -94,8 +94,14 @@ class Contribution(StrictModel):
     item: Annotated[
         str, Field(min_length=1, description="Identifier of the mapped element.")
     ]
-    contribution: float = Field(
-        ..., ge=0.1, le=1.0, description="Importance weight from 0.1 to 1.0."
+    contribution: float | None = Field(
+        default=None,
+        ge=0.1,
+        le=1.0,
+        description=(
+            "Importance weight from 0.1 to 1.0. ``None`` implies a default weight"
+            " of 1.0 or indicates the mapping should be ignored."
+        ),
     )
 
 
@@ -542,20 +548,6 @@ class MappingFeature(StrictModel):
         # Normalise nested mapping structures and ensure list values.
         data["mappings"] = _normalize_mapping_values(mapping)
         return data
-
-    @field_validator("mappings")
-    @classmethod
-    def _limit_mapping_items(
-        cls, value: dict[str, list[Contribution]]
-    ) -> dict[str, list[Contribution]]:
-        """Ensure each mapping list contains at most five items."""
-
-        for key, items in value.items():
-            if len(items) > 5:
-                raise ValueError(
-                    f"Too many entries for {key}: {len(items)} (maximum 5)"
-                )
-        return value
 
 
 class MappingResponse(StrictModel):

--- a/tests/test_roundtrip_models.py
+++ b/tests/test_roundtrip_models.py
@@ -23,15 +23,15 @@ TEXT = st.text(min_size=1, max_size=20)
 contributions = st.builds(
     Contribution,
     item=TEXT,
-    contribution=st.floats(min_value=0.1, max_value=1.0),
+    contribution=st.one_of(st.none(), st.floats(min_value=0.1, max_value=1.0)),
 )
 
 
-# Strategy producing mapping dictionaries with up to three types and five items each.
+# Strategy producing mapping dictionaries with up to three types and unbounded items.
 def mapping_dict() -> st.SearchStrategy[Dict[str, List[Contribution]]]:
     return st.dictionaries(
         TEXT,
-        st.lists(contributions, max_size=5),
+        st.lists(contributions),
         max_size=3,
     )
 


### PR DESCRIPTION
## Summary
- allow Contribution weights to be omitted
- drop per-feature mapping list limit to allow arbitrary entries
- adapt tests for new schema

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy src/models.py tests/test_models.py tests/test_roundtrip_models.py`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6b97c6b50832b91346505ba60a34b