### PR TITLE
feat: add diagnostics flag for conversation spans

### DIFF
--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -123,10 +123,12 @@ def test_stage_metrics_accumulate() -> None:
 
 
 def test_ask_omits_prompt_logging_when_disabled(monkeypatch) -> None:
-    """Prompts should not be logged when ``log_prompts`` is ``False``."""
+    """Prompts should not be logged when logging is disabled."""
 
     agent = DummyAgent()
-    session = ConversationSession(cast(Agent[None, str], agent), log_prompts=False)
+    session = ConversationSession(
+        cast(Agent[None, str], agent), diagnostics=True, log_prompts=False
+    )
     calls: list[str] = []
     monkeypatch.setattr(conversation.logfire, "debug", lambda msg: calls.append(msg))
 
@@ -140,7 +142,10 @@ def test_ask_redacts_prompt_when_enabled(monkeypatch) -> None:
 
     agent = DummyAgent()
     session = ConversationSession(
-        cast(Agent[None, str], agent), log_prompts=True, redact_prompts=True
+        cast(Agent[None, str], agent),
+        diagnostics=True,
+        log_prompts=True,
+        redact_prompts=True,
     )
     monkeypatch.setattr(conversation, "redact_pii", lambda s: "<redacted>")
     calls: list[str] = []
@@ -155,7 +160,10 @@ def test_add_parent_materials_redacts_when_enabled(monkeypatch) -> None:
     """Service material logging should redact PII when enabled."""
 
     session = ConversationSession(
-        cast(Agent[None, str], DummyAgent()), redact_prompts=True
+        cast(Agent[None, str], DummyAgent()),
+        diagnostics=True,
+        log_prompts=True,
+        redact_prompts=True,
     )
     monkeypatch.setattr(conversation, "redact_pii", lambda s: "<redacted>")
     calls: list[str] = []


### PR DESCRIPTION
## Summary
- add diagnostics flag to `ConversationSession` to control prompt logging and span creation
- log prompts and create spans only when diagnostics are enabled
- update conversation tests for new diagnostics behaviour

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: async functions not supported; missing modules; multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fc13fba4832b9ad384891fb4d2b6