### PR TITLE
feat: add diagnostics and strict mapping flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,9 @@ Use `generate-mapping` to refresh mapping contributions for existing evolution
 results. It reads an evolution JSON Lines file and writes an updated file with
 new mapping data. Adjust mapping behaviour with:
 
-- `--mapping-batch-size` – number of features per mapping request batch. Smaller
-  batches shorten prompts but increase API calls.
-- `--mapping-parallel-types` – dispatch mapping types concurrently. Disable with
-  `--no-mapping-parallel-types` to process them sequentially when rate limits are
-  tight.
+- `--mapping-data-dir` – directory containing mapping reference data.
+- `--strict-mapping/--no-strict-mapping` – fail when mappings are missing.
+- `--diagnostics/--no-diagnostics` – enable verbose diagnostics output.
 - `--exhaustive-mapping` – retry mapping prompts until the minimum number of
   items are returned (disable with `--no-exhaustive-mapping`).
 
@@ -157,7 +155,7 @@ Example invocation:
 
 ```bash
 ./run.sh generate-mapping --input evolution.jsonl --output remapped.jsonl \
-  --mapping-batch-size 20 --no-mapping-parallel-types
+  --strict-mapping
 ```
 
 See [generate-mapping](docs/generate-mapping.md) for detailed behaviour and
@@ -245,22 +243,17 @@ Basic invocation:
 Processing happens concurrently; control parallel workers with `--concurrency`
 which defaults to the `concurrency` value in your settings.
 
-Mapping requests are batched. Adjust `--mapping-batch-size` to control how many
-features are sent per mapping request; the default is 30. Smaller batches create
-shorter prompts and quicker responses but increase API calls. Larger batches
-reduce round trips at the cost of bigger prompts, higher latency and a greater
-risk of hitting model context limits.
-
-For each batch the CLI maps Data, Applications and Technologies in parallel.
-This behaviour is enabled by default via `--mapping-parallel-types`. Disable it
-with `--no-mapping-parallel-types` to process mapping types sequentially when
-rate limits are tight.
+Mapping requests default to a per-set strategy. Use `--mapping-data-dir` to
+point to alternative reference datasets. Enable `--strict-mapping` to fail when
+features return no mappings or `--diagnostics` for verbose request logging.
+`--exhaustive-mapping` retries prompts until the minimum number of items are
+found.
 
 Example invocation tuning mapping behaviour:
 
 ```bash
 ./run.sh generate-evolution --input-file sample-services.jsonl \
-  --output-file evolution.jsonl --mapping-batch-size 20 --no-mapping-parallel-types
+  --output-file evolution.jsonl --strict-mapping
 ```
 
 ### Conversation seed

--- a/docs/generate-mapping.md
+++ b/docs/generate-mapping.md
@@ -10,21 +10,17 @@ Example command:
 poetry run service-ambitions generate-mapping \
   --input evolution.jsonl \
   --output remapped.jsonl \
-  --mapping-batch-size 20 --mapping-parallel-types
+  --strict-mapping --diagnostics
 ```
 
-`--mapping-batch-size` controls how many features are sent in each mapping
-request. Smaller batches shorten prompts but require more API calls; larger
-batches reduce round trips at the cost of bigger prompts and potential context
-limit pressure.
+`--mapping-data-dir` points to the directory containing mapping reference data
+files.
 
-`--mapping-parallel-types` dispatches mapping requests for each mapping type
-concurrently. Disable it with `--no-mapping-parallel-types` to process types
-sequentially when working under tight rate limits.
+`--strict-mapping` raises an error when any requested mapping type is missing or
+produces an empty list. Disable with `--no-strict-mapping` to keep existing
+mappings and continue.
 
-Enable fail-fast behaviour with `--strict` to raise an error when any requested
-mapping type is missing or produces an empty list. Without this flag the command
-will keep existing mappings and continue.
+`--diagnostics` enables verbose logging and spans useful for troubleshooting.
 
 ## Input format
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -83,6 +83,17 @@ class Settings(BaseSettings):
         False, description="Enable OpenAI web search tooling for model browsing."
     )
 
+    mapping_data_dir: Path = Field(
+        Path("data"), description="Directory containing mapping reference data."
+    )
+    diagnostics: bool = Field(
+        False, description="Enable verbose diagnostics and tracing."
+    )
+    strict_mapping: bool = Field(
+        False, description="Fail when feature mappings are missing."
+    )
+    mapping_mode: str = Field("per_set", description="Mapping execution mode.")
+
     model_config = SettingsConfigDict(extra="ignore")
 
 
@@ -128,6 +139,10 @@ def load_settings() -> Settings:
             max_items_per_mapping=config.max_items_per_mapping,
             mapping_feature_batch_cap_tokens=config.mapping_feature_batch_cap_tokens,
             web_search=config.web_search,
+            mapping_data_dir=getattr(config, "mapping_data_dir", Path("data")),
+            diagnostics=getattr(config, "diagnostics", False),
+            strict_mapping=getattr(config, "strict_mapping", False),
+            mapping_mode=getattr(config, "mapping_mode", "per_set"),
             _env_file=env_file,
         )
     except ValidationError as exc:

--- a/tests/test_cli_generate_mapping.py
+++ b/tests/test_cli_generate_mapping.py
@@ -103,13 +103,10 @@ def test_generate_mapping_updates_features(tmp_path, monkeypatch) -> None:
         mapping_types=None,
         *,
         strict,
-        batch_size,
-        parallel_types,
         exhaustive,
         max_items_per_mapping,
     ):
-        called["batch_size"] = batch_size
-        called["parallel_types"] = parallel_types
+        called["strict"] = strict
         for feat in features:
             feat.mappings = {"cat": [Contribution(item="X", contribution=1.0)]}
         return list(features)
@@ -126,26 +123,29 @@ def test_generate_mapping_updates_features(tmp_path, monkeypatch) -> None:
     settings = SimpleNamespace(
         model="cfg",
         openai_api_key="key",
-        mapping_batch_size=30,
-        mapping_parallel_types=True,
         exhaustive_mapping=True,
         max_items_per_mapping=None,
         mapping_feature_batch_cap_tokens=95000,
         reasoning=None,
         models=None,
         web_search=False,
+        diagnostics=False,
+        strict_mapping=False,
+        mapping_data_dir="data",
+        mapping_mode="per_set",
     )
     args = argparse.Namespace(
         input=str(input_path),
         output=str(output_path),
         model=None,
         mapping_model=None,
-        mapping_batch_size=5,
-        mapping_parallel_types=False,
+        strict_mapping=True,
         exhaustive_mapping=True,
         seed=None,
         web_search=None,
         strict=False,
+        diagnostics=None,
+        mapping_data_dir=None,
     )
 
     asyncio.run(_cmd_generate_mapping(args, settings))
@@ -154,8 +154,7 @@ def test_generate_mapping_updates_features(tmp_path, monkeypatch) -> None:
     assert payload["plateaus"][0]["features"][0]["mappings"] == {
         "cat": [{"item": "X", "contribution": 1.0}]
     }
-    assert called["batch_size"] == 5
-    assert called["parallel_types"] is False
+    assert called["strict"] is True
     assert init_called["ran"] is True
 
 
@@ -210,8 +209,6 @@ def test_generate_mapping_logs_stage_totals(tmp_path, monkeypatch) -> None:
         mapping_types=None,
         *,
         strict,
-        batch_size,
-        parallel_types,
         exhaustive,
         max_items_per_mapping,
     ):
@@ -243,26 +240,29 @@ def test_generate_mapping_logs_stage_totals(tmp_path, monkeypatch) -> None:
     settings = SimpleNamespace(
         model="cfg",
         openai_api_key="key",
-        mapping_batch_size=30,
-        mapping_parallel_types=True,
         exhaustive_mapping=True,
         max_items_per_mapping=None,
         mapping_feature_batch_cap_tokens=95000,
         reasoning=None,
         models=None,
         web_search=False,
+        diagnostics=False,
+        strict_mapping=False,
+        mapping_data_dir="data",
+        mapping_mode="per_set",
     )
     args = argparse.Namespace(
         input=str(input_path),
         output=str(output_path),
         model=None,
         mapping_model=None,
-        mapping_batch_size=5,
-        mapping_parallel_types=False,
+        strict_mapping=False,
         exhaustive_mapping=True,
         seed=None,
         web_search=None,
         strict=False,
+        diagnostics=None,
+        mapping_data_dir=None,
     )
 
     asyncio.run(_cmd_generate_mapping(args, settings))

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -30,6 +30,10 @@ def test_load_settings_reads_env(monkeypatch) -> None:
     assert settings.max_items_per_mapping is None
     assert settings.mapping_feature_batch_cap_tokens == 95000
     assert settings.token_weighting is True
+    assert settings.mapping_data_dir == Path("data")
+    assert settings.diagnostics is False
+    assert settings.strict_mapping is False
+    assert settings.mapping_mode == "per_set"
     assert settings.reasoning is not None
     assert settings.reasoning.effort == "medium"
 


### PR DESCRIPTION
## Summary
- add `--mapping-data-dir`, `--diagnostics`, and `--strict-mapping` CLI options
- remove obsolete mapping batching, parallel type, and token weighting CLI flags
- document new mapping controls and default mapping mode

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`


------
https://chatgpt.com/codex/tasks/task_e_68a6fe3d23c4832b85e6579141411398