### PR TITLE
refactor: add deterministic mapping prompt

### DIFF
--- a/src/mapping_prompt.py
+++ b/src/mapping_prompt.py
@@ -1,0 +1,62 @@
+"""Prompt rendering utilities for feature mappings.
+
+This module provides deterministic formatting for mapping prompts to ensure
+consistent interaction with the language model."""
+
+from __future__ import annotations
+
+import json
+from typing import Sequence
+
+from loader import load_prompt_text
+from models import MappingItem, MappingResponse, PlateauFeature
+
+
+def _render_items(items: Sequence[MappingItem]) -> str:
+    """Return bullet list representation of ``items`` sorted by identifier."""
+
+    return "\n".join(
+        f"- {entry.id}: {entry.name} - {entry.description}"
+        for entry in sorted(items, key=lambda i: i.id)
+    )
+
+
+def _render_features(features: Sequence[PlateauFeature]) -> str:
+    """Return bullet list representation of ``features`` sorted by feature ID."""
+
+    return "\n".join(
+        f"- {feat.feature_id}: {feat.name} - {feat.description}"
+        for feat in sorted(features, key=lambda f: f.feature_id)
+    )
+
+
+def render_set_prompt(
+    set_name: str,
+    items: Sequence[MappingItem],
+    features: Sequence[PlateauFeature],
+) -> str:
+    """Return a prompt requesting mappings for ``features`` against ``set_name``.
+
+    Args:
+        set_name: Name of the mapping catalogue.
+        items: Available catalogue items.
+        features: Features requiring mapping enrichment.
+
+    Returns:
+        Fully rendered prompt string.
+    """
+
+    template = load_prompt_text("mapping_prompt")
+    schema = json.dumps(MappingResponse.model_json_schema(), indent=2)
+    mapping_section = f"## Available {set_name}\n\n{_render_items(items)}\n"
+    prompt = template.format(
+        mapping_labels=set_name,
+        mapping_sections=mapping_section,
+        mapping_fields=set_name,
+        features=_render_features(features),
+        schema=str(schema),
+    )
+    return prompt
+
+
+__all__ = ["render_set_prompt"]

--- a/tests/test_cli_generate_mapping.py
+++ b/tests/test_cli_generate_mapping.py
@@ -11,6 +11,7 @@ import pytest
 
 import cli
 import mapping
+import mapping_prompt
 from backpressure import RollingMetrics
 from cli import _cmd_generate_mapping
 from conversation import ConversationSession
@@ -271,10 +272,10 @@ def test_generate_mapping_logs_stage_totals(tmp_path, monkeypatch) -> None:
 def test_request_mapping_retries(monkeypatch) -> None:
     """_request_mapping should retry transient errors and pass hooks."""
 
-    def fake_build_mapping_prompt(*_a, **_k) -> str:
+    def fake_render_set_prompt(*_a, **_k) -> str:
         return "prompt"
 
-    monkeypatch.setattr(mapping, "_build_mapping_prompt", fake_build_mapping_prompt)
+    monkeypatch.setattr(mapping_prompt, "render_set_prompt", fake_render_set_prompt)
 
     recorded: dict[str, object] = {}
 

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -43,7 +43,7 @@ async def test_map_feature_returns_mappings(monkeypatch) -> None:
     def fake_loader(name, *_, **__):
         return template
 
-    monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
+    monkeypatch.setattr("mapping_prompt.load_prompt_text", fake_loader)
     monkeypatch.setattr(
         "mapping.load_mapping_items",
         lambda types, *a, **k: {
@@ -113,7 +113,7 @@ async def test_map_feature_injects_reference_data(monkeypatch) -> None:
     def fake_loader(name, *_, **__):
         return template
 
-    monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
+    monkeypatch.setattr("mapping_prompt.load_prompt_text", fake_loader)
     monkeypatch.setattr(
         "mapping.load_mapping_items",
         lambda types, *a, **k: {
@@ -182,7 +182,7 @@ async def test_map_feature_rejects_invalid_json(monkeypatch) -> None:
     def fake_loader(name, *_, **__):
         return template
 
-    monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
+    monkeypatch.setattr("mapping_prompt.load_prompt_text", fake_loader)
     monkeypatch.setattr(
         "mapping.load_mapping_items",
         lambda types, *a, **k: {
@@ -209,7 +209,7 @@ def test_map_feature_ignores_unknown_ids(monkeypatch) -> None:
     def fake_loader(name, *_, **__):
         return template
 
-    monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
+    monkeypatch.setattr("mapping_prompt.load_prompt_text", fake_loader)
     monkeypatch.setattr(
         "mapping.load_mapping_items",
         lambda types, *a, **k: {
@@ -273,7 +273,7 @@ async def test_map_feature_flattens_nested_mappings(monkeypatch) -> None:
     def fake_loader(name, *_, **__):
         return template
 
-    monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
+    monkeypatch.setattr("mapping_prompt.load_prompt_text", fake_loader)
     monkeypatch.setattr(
         "mapping.load_mapping_items",
         lambda types, *a, **k: {
@@ -328,7 +328,7 @@ async def test_map_feature_flattens_repeated_mapping_keys(monkeypatch) -> None:
     def fake_loader(name, *_, **__):
         return template
 
-    monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
+    monkeypatch.setattr("mapping_prompt.load_prompt_text", fake_loader)
     monkeypatch.setattr(
         "mapping.load_mapping_items",
         lambda types, *a, **k: {
@@ -389,7 +389,7 @@ async def test_map_features_returns_mappings(monkeypatch) -> None:
     def fake_loader(name, *_, **__):
         return template
 
-    monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
+    monkeypatch.setattr("mapping_prompt.load_prompt_text", fake_loader)
     monkeypatch.setattr(
         "mapping.load_mapping_items",
         lambda types, *a, **k: {
@@ -456,7 +456,7 @@ async def test_map_features_allows_empty_lists(monkeypatch) -> None:
     def fake_loader(name, *_, **__):
         return template
 
-    monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
+    monkeypatch.setattr("mapping_prompt.load_prompt_text", fake_loader)
     monkeypatch.setattr(
         "mapping.load_mapping_items",
         lambda types, *a, **k: {
@@ -510,7 +510,7 @@ async def test_map_features_retries_on_empty(monkeypatch) -> None:
             MappingItem(id="INF-2", name="Traffic", description="traffic stats"),
         ]
     }
-    monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
+    monkeypatch.setattr("mapping_prompt.load_prompt_text", fake_loader)
     monkeypatch.setattr("mapping.load_mapping_items", lambda types, *a, **k: items)
 
     initial = json.dumps({"features": [{"feature_id": "f1", "data": []}]})
@@ -558,7 +558,7 @@ async def test_map_features_reprompts_per_feature(monkeypatch, parallel) -> None
         ]
     }
 
-    monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
+    monkeypatch.setattr("mapping_prompt.load_prompt_text", fake_loader)
     monkeypatch.setattr("mapping.load_mapping_items", lambda types, *a, **k: items)
     monkeypatch.setattr(
         "mapping._top_k_items", lambda features, dataset: items[dataset]
@@ -645,7 +645,7 @@ async def test_map_features_reprompts_missing_app_and_tech(monkeypatch) -> None:
         ],
     }
 
-    monkeypatch.setattr("mapping.load_prompt_text", fake_loader)
+    monkeypatch.setattr("mapping_prompt.load_prompt_text", fake_loader)
     monkeypatch.setattr("mapping.load_mapping_items", lambda types, *a, **k: items)
     monkeypatch.setattr(
         "mapping._top_k_items", lambda features, dataset: items[dataset]

--- a/tests/test_mapping_prompt.py
+++ b/tests/test_mapping_prompt.py
@@ -1,0 +1,58 @@
+"""Tests for prompt rendering utilities."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import pytest
+
+from mapping_prompt import render_set_prompt
+from models import MappingItem, MaturityScore, PlateauFeature
+
+
+@pytest.mark.parametrize("shuffle", [False, True])
+def test_render_set_prompt_orders_content(shuffle: bool, monkeypatch) -> None:
+    """Catalogue items and features are sorted deterministically."""
+
+    template = "{mapping_sections}\n{features}\n{schema}"
+    monkeypatch.setattr("mapping_prompt.load_prompt_text", lambda _n: template)
+
+    items: Sequence[MappingItem] = [
+        MappingItem(id="B", name="Item B", description="desc"),
+        MappingItem(id="A", name="Item A", description="desc"),
+    ]
+    features: Sequence[PlateauFeature] = [
+        PlateauFeature(
+            feature_id="2",
+            name="Second",
+            description="d",
+            score=MaturityScore(level=1, label="Initial", justification="j"),
+            customer_type="learners",
+        ),
+        PlateauFeature(
+            feature_id="1",
+            name="First",
+            description="d",
+            score=MaturityScore(level=1, label="Initial", justification="j"),
+            customer_type="learners",
+        ),
+    ]
+
+    if shuffle:
+        items = list(reversed(items))
+        features = list(reversed(features))
+
+    prompt = render_set_prompt("test", items, features)
+    lines = prompt.splitlines()
+    idx_a = lines.index("- A: Item A - desc")
+    idx_b = lines.index("- B: Item B - desc")
+    idx_1 = lines.index("- 1: First - d")
+    idx_2 = lines.index("- 2: Second - d")
+    assert idx_a < idx_b
+    assert idx_1 < idx_2
+
+    if shuffle:
+        prompt_again = render_set_prompt(
+            "test", list(reversed(items)), list(reversed(features))
+        )
+        assert prompt_again == prompt


### PR DESCRIPTION
## Summary
- add `render_set_prompt` for deterministic catalogue and feature formatting
- refactor mapping to use `render_set_prompt`
- add tests for prompt rendering and update existing tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: async def functions are not natively supported)*
- `poetry run pytest tests/test_mapping_prompt.py::test_render_set_prompt_orders_content --maxfail=1 -q`


------
https://chatgpt.com/codex/tasks/task_e_68a70700d2d4832b8c24ac6c2b241e81