### PR TITLE
Retry mapping prompts on failure and quarantine invalid responses

### DIFF
--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -125,8 +125,16 @@ class PlateauGenerator:
 
         items = load_mapping_items(("applications", "technologies", "information"))
         mapped = list(features)
+        service_name = self._service.name if self._service else "unknown"
         for key in ("applications", "technologies", "information"):
-            mapped = await map_set(session, key, items[key], mapped)
+            mapped = await map_set(
+                session,
+                key,
+                items[key],
+                mapped,
+                service=service_name,
+                strict=self.strict,
+            )
         return mapped
 
     def _request_description(

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,0 +1,87 @@
+import json
+from typing import Sequence, cast
+
+import pytest
+
+from conversation import ConversationSession
+from mapping import MappingError, map_set
+from models import MappingItem, MaturityScore, PlateauFeature
+
+
+class DummySession:
+    """Session returning queued responses for ``ask_async``."""
+
+    def __init__(self, responses: Sequence[str]) -> None:
+        self._responses = list(responses)
+        self.prompts: list[str] = []
+
+    async def ask_async(self, prompt: str, output_type=None) -> str:
+        self.prompts.append(prompt)
+        return self._responses.pop(0)
+
+
+def _feature() -> PlateauFeature:
+    return PlateauFeature(
+        feature_id="f1",
+        name="Feat",
+        description="d",
+        score=MaturityScore(level=1, label="Initial", justification="j"),
+        customer_type="learners",
+    )
+
+
+def _item() -> MappingItem:
+    return MappingItem(id="a", name="A", description="d")
+
+
+@pytest.mark.asyncio()
+async def test_map_set_retries_on_failure(monkeypatch) -> None:
+    monkeypatch.setattr("mapping.render_set_prompt", lambda *a, **k: "PROMPT")
+    valid = json.dumps(
+        {"features": [{"feature_id": "f1", "applications": [{"item": "a"}]}]}
+    )
+    session = DummySession(["bad", valid])
+    mapped = await map_set(
+        cast(ConversationSession, session),
+        "applications",
+        [_item()],
+        [_feature()],
+        service="svc",
+    )
+    assert session.prompts == ["PROMPT", "PROMPT\nReturn valid JSON only."]
+    assert mapped[0].mappings["applications"][0].item == "a"
+
+
+@pytest.mark.asyncio()
+async def test_map_set_quarantines_on_double_failure(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("mapping.render_set_prompt", lambda *a, **k: "PROMPT")
+    session = DummySession(["bad", "still bad"])
+    mapped = await map_set(
+        cast(ConversationSession, session),
+        "applications",
+        [_item()],
+        [_feature()],
+        service="svc",
+    )
+    assert mapped[0].mappings["applications"] == []
+    qfile = tmp_path / "quarantine" / "mappings" / "svc" / "applications.txt"
+    assert qfile.read_text() == "still bad"
+
+
+@pytest.mark.asyncio()
+async def test_map_set_strict_raises(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("mapping.render_set_prompt", lambda *a, **k: "PROMPT")
+    session = DummySession(["bad", "still bad"])
+    with pytest.raises(MappingError):
+        await map_set(
+            cast(ConversationSession, session),
+            "applications",
+            [_item()],
+            [_feature()],
+            service="svc",
+            strict=True,
+        )
+    qfile = tmp_path / "quarantine" / "mappings" / "svc" / "applications.txt"
+    assert qfile.exists()

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -96,7 +96,7 @@ async def test_map_features_calls_sets_in_order(monkeypatch) -> None:
 
     called: list[str] = []
 
-    async def fake_map_set(session, name, items, feats):
+    async def fake_map_set(session, name, items, feats, **kwargs):
         called.append(name)
         return list(feats)
 


### PR DESCRIPTION
## Summary
- retry `map_set` prompts when mapping responses fail validation, add JSON-only hint, and quarantine failures per service/set
- propagate service name and strict flag through mapping helpers and plateau generator
- exercise new behaviour with mapping tests and update existing test stubs

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing src/mapping.py src/plateau_generator.py tests/test_mapping.py tests/test_plateau_generator.py`
- `poetry run ruff check --fix src/mapping.py src/plateau_generator.py tests/test_mapping.py tests/test_plateau_generator.py`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `pytest tests/test_mapping.py tests/test_plateau_generator.py -k test_map_features_calls_sets_in_order` *(fails: ModuleNotFoundError: No module named 'tiktoken')*


------
https://chatgpt.com/codex/tasks/task_e_68a70d576a6c832ba42170cdc2e28ef0