### PR TITLE
Simplify mapping CLI to sequential flow

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -631,16 +631,6 @@ def main() -> None:
         help="Process at most this many services",
     )
     common.add_argument(
-        "--exhaustive-mapping",
-        action=argparse.BooleanOptionalAction,
-        default=settings.exhaustive_mapping,
-        help="Retry mapping prompts until minimum items are found",
-    )
-    common.add_argument(
-        "--mapping-data-dir",
-        help="Directory containing mapping reference data",
-    )
-    common.add_argument(
         "--diagnostics",
         action=argparse.BooleanOptionalAction,
         default=None,
@@ -792,8 +782,6 @@ def main() -> None:
     if args.seed is not None:
         random.seed(args.seed)
 
-    if args.mapping_data_dir:
-        settings.mapping_data_dir = Path(args.mapping_data_dir)
     if args.diagnostics is not None:
         settings.diagnostics = args.diagnostics
     if args.strict_mapping is not None:

--- a/src/settings.py
+++ b/src/settings.py
@@ -68,7 +68,6 @@ class Settings(BaseSettings):
     strict_mapping: bool = Field(
         False, description="Fail when feature mappings are missing."
     )
-    mapping_mode: str = Field("per_set", description="Mapping execution mode.")
 
     model_config = SettingsConfigDict(extra="ignore")
 
@@ -114,7 +113,6 @@ def load_settings() -> Settings:
             mapping_data_dir=getattr(config, "mapping_data_dir", Path("data")),
             diagnostics=getattr(config, "diagnostics", False),
             strict_mapping=getattr(config, "strict_mapping", False),
-            mapping_mode=getattr(config, "mapping_mode", "per_set"),
             _env_file=env_file,
         )
     except ValidationError as exc:

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -4,7 +4,6 @@ import argparse
 import asyncio
 import json
 import sys
-from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -95,7 +94,6 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
         diagnostics=False,
         strict_mapping=False,
         mapping_data_dir="data",
-        mapping_mode="per_set",
     )
     args = argparse.Namespace(
         input_file=str(input_path),
@@ -111,7 +109,6 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
         resume=False,
         seed=None,
         roles_file="data/roles.json",
-        exhaustive_mapping=True,
         transcripts_dir=None,
         web_search=None,
         no_logs=False,
@@ -119,7 +116,6 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
         strict=False,
         diagnostics=None,
         strict_mapping=None,
-        mapping_data_dir=None,
     )
 
     monkeypatch.setattr(cli, "_RUN_META", None)
@@ -184,7 +180,6 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
         diagnostics=False,
         strict_mapping=False,
         mapping_data_dir="data",
-        mapping_mode="per_set",
     )
     args = argparse.Namespace(
         input_file=str(input_path),
@@ -200,7 +195,6 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
         resume=False,
         seed=None,
         roles_file="data/roles.json",
-        exhaustive_mapping=True,
         transcripts_dir=None,
         web_search=None,
         no_logs=False,
@@ -208,7 +202,6 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
         strict=False,
         diagnostics=None,
         strict_mapping=None,
-        mapping_data_dir=None,
     )
 
     monkeypatch.setattr(cli, "_RUN_META", None)
@@ -277,7 +270,6 @@ def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:
         diagnostics=False,
         strict_mapping=False,
         mapping_data_dir="data",
-        mapping_mode="per_set",
     )
     args = argparse.Namespace(
         input_file=str(input_path),
@@ -293,7 +285,6 @@ def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:
         resume=True,
         seed=None,
         roles_file="data/roles.json",
-        exhaustive_mapping=True,
         transcripts_dir=None,
         web_search=None,
         no_logs=False,
@@ -301,7 +292,6 @@ def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:
         strict=False,
         diagnostics=None,
         strict_mapping=None,
-        mapping_data_dir=None,
     )
 
     monkeypatch.setattr(cli, "_RUN_META", None)
@@ -359,7 +349,6 @@ def test_generate_evolution_rejects_invalid_concurrency(tmp_path, monkeypatch) -
         diagnostics=False,
         strict_mapping=False,
         mapping_data_dir="data",
-        mapping_mode="per_set",
     )
     args = argparse.Namespace(
         input_file=str(input_path),
@@ -375,7 +364,6 @@ def test_generate_evolution_rejects_invalid_concurrency(tmp_path, monkeypatch) -
         resume=False,
         seed=None,
         roles_file="data/roles.json",
-        exhaustive_mapping=True,
         transcripts_dir=None,
         web_search=None,
         no_logs=False,
@@ -383,7 +371,6 @@ def test_generate_evolution_rejects_invalid_concurrency(tmp_path, monkeypatch) -
         strict=False,
         diagnostics=None,
         strict_mapping=None,
-        mapping_data_dir=None,
     )
 
     monkeypatch.setattr(cli, "_RUN_META", None)
@@ -409,7 +396,6 @@ def test_cli_parses_mapping_options(tmp_path, monkeypatch) -> None:
     )
     monkeypatch.setattr("cli.logfire.force_flush", lambda: None)
 
-    data_dir = tmp_path / "data"
     argv = [
         "prog",
         "generate-evolution",
@@ -417,8 +403,6 @@ def test_cli_parses_mapping_options(tmp_path, monkeypatch) -> None:
         str(tmp_path / "services.jsonl"),
         "--output-file",
         str(tmp_path / "out.jsonl"),
-        "--mapping-data-dir",
-        str(data_dir),
         "--diagnostics",
         "--strict-mapping",
     ]
@@ -426,11 +410,9 @@ def test_cli_parses_mapping_options(tmp_path, monkeypatch) -> None:
 
     cli.main()
 
-    assert called["args"].mapping_data_dir == str(data_dir)
     assert called["args"].diagnostics is True
     assert called["args"].strict_mapping is True
     settings_ns = called["settings"]
-    assert settings_ns.mapping_data_dir == Path(data_dir)
     assert settings_ns.diagnostics is True
     assert settings_ns.strict_mapping is True
 
@@ -497,7 +479,6 @@ def test_generate_evolution_writes_transcripts(tmp_path, monkeypatch) -> None:
         diagnostics=False,
         strict_mapping=False,
         mapping_data_dir="data",
-        mapping_mode="per_set",
     )
     args = argparse.Namespace(
         input_file=str(input_path),
@@ -513,7 +494,6 @@ def test_generate_evolution_writes_transcripts(tmp_path, monkeypatch) -> None:
         resume=False,
         seed=None,
         roles_file="data/roles.json",
-        exhaustive_mapping=True,
         transcripts_dir=None,
         web_search=None,
         no_logs=False,
@@ -521,7 +501,6 @@ def test_generate_evolution_writes_transcripts(tmp_path, monkeypatch) -> None:
         strict=False,
         diagnostics=None,
         strict_mapping=None,
-        mapping_data_dir=None,
     )
 
     monkeypatch.setattr(cli, "_RUN_META", None)

--- a/tests/test_cli_generate_mapping.py
+++ b/tests/test_cli_generate_mapping.py
@@ -1,0 +1,82 @@
+import argparse
+import asyncio
+from types import SimpleNamespace
+
+import cli
+from cli import _cmd_generate_mapping
+from models import (
+    MaturityScore,
+    PlateauFeature,
+    PlateauResult,
+    ServiceEvolution,
+    ServiceInput,
+    ServiceMeta,
+)
+
+
+def test_generate_mapping_maps_features(tmp_path, monkeypatch) -> None:
+    feature = PlateauFeature(
+        feature_id="f1",
+        name="feat",
+        description="desc",
+        score=MaturityScore(level=1, label="Initial", justification="j"),
+        customer_type="learner",
+    )
+    plateau = PlateauResult(
+        plateau=1,
+        plateau_name="alpha",
+        service_description="desc",
+        features=[feature],
+    )
+    evo = ServiceEvolution(
+        meta=ServiceMeta(run_id="r1"),
+        service=ServiceInput(
+            service_id="s1",
+            name="svc",
+            description="d",
+            jobs_to_be_done=[{"name": "job"}],
+        ),
+        plateaus=[plateau],
+    )
+    input_path = tmp_path / "evo.jsonl"
+    output_path = tmp_path / "out.jsonl"
+    input_path.write_text(f"{evo.model_dump_json()}\n", encoding="utf-8")
+
+    called: dict[str, int] = {}
+
+    async def fake_map_features(self, session, feats):
+        called["count"] = len(feats)
+        return [f.model_copy(update={"mappings": {"applications": []}}) for f in feats]
+
+    async def fake_init_embeddings() -> None:
+        return None
+
+    monkeypatch.setattr(cli, "Agent", lambda *a, **k: SimpleNamespace())
+    monkeypatch.setattr(cli.PlateauGenerator, "_map_features", fake_map_features)
+    monkeypatch.setattr(cli, "init_embeddings", fake_init_embeddings)
+    monkeypatch.setattr(cli, "configure_mapping_data_dir", lambda _p: None)
+
+    settings = SimpleNamespace(
+        model="m",
+        openai_api_key="k",
+        diagnostics=False,
+        strict_mapping=False,
+        mapping_data_dir="data",
+    )
+    args = argparse.Namespace(
+        input=str(input_path),
+        output=str(output_path),
+        model=None,
+        mapping_model=None,
+        diagnostics=None,
+        strict_mapping=None,
+        seed=None,
+        no_logs=False,
+    )
+
+    asyncio.run(_cmd_generate_mapping(args, settings))
+
+    out = output_path.read_text(encoding="utf-8").strip()
+    parsed = ServiceEvolution.model_validate_json(out)
+    assert parsed.plateaus[0].features[0].mappings["applications"] == []
+    assert called["count"] == 1

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -29,7 +29,6 @@ def test_load_settings_reads_env(monkeypatch) -> None:
     assert settings.mapping_data_dir == Path("data")
     assert settings.diagnostics is False
     assert settings.strict_mapping is False
-    assert settings.mapping_mode == "per_set"
     assert settings.reasoning is not None
     assert settings.reasoning.effort == "medium"
 


### PR DESCRIPTION
## Summary
- remove batching flags from CLI and rely on PlateauGenerator's sequential mapping
- drop unused mapping mode setting
- add tests for mapping CLI and update existing expectations

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing tests/test_cli_generate_mapping.py src/cli.py src/settings.py tests/test_cli_generate_evolution.py tests/test_settings.py`
- `poetry run ruff check --fix tests/test_cli_generate_mapping.py src/cli.py src/settings.py tests/test_cli_generate_evolution.py tests/test_settings.py`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: tests/test_loading.py::test_valid_fixture_parses - IndexError: list index out of range, tests/test_mapping.py::test_map_set_retries_on_failure - Failed: async def functions are not natively supported, tests/test_mapping.py::test_map_set_quarantines_on_double_failure - Failed: async def functions are not natively supported, tests/test_mapping.py::test_map_set_strict_raises - Failed: async def functions are not natively supported, tests/test_monitoring.py::test_init_logfire_replaces_root_handlers - ImportError: cannot import name 'DEFAULT_LOGFIRE_<...>')*

------
https://chatgpt.com/codex/tasks/task_e_68a7117d4214832b9462ff77143a40e9