### PR TITLE
refactor: cache mapping schema for rendering prompts

### DIFF
--- a/src/mapping_prompt.py
+++ b/src/mapping_prompt.py
@@ -11,6 +11,8 @@ from typing import Sequence
 from loader import load_prompt_text
 from models import MappingItem, MappingResponse, PlateauFeature
 
+MAPPING_SCHEMA = json.dumps(MappingResponse.model_json_schema(), indent=2)
+
 
 def _render_items(items: Sequence[MappingItem]) -> str:
     """Return bullet list representation of ``items`` sorted by identifier."""
@@ -47,14 +49,13 @@ def render_set_prompt(
     """
 
     template = load_prompt_text("mapping_prompt")
-    schema = json.dumps(MappingResponse.model_json_schema(), indent=2)
     mapping_section = f"## Available {set_name}\n\n{_render_items(items)}\n"
     prompt = template.format(
         mapping_labels=set_name,
         mapping_sections=mapping_section,
         mapping_fields=set_name,
         features=_render_features(features),
-        schema=str(schema),
+        schema=MAPPING_SCHEMA,
     )
     return prompt
 


### PR DESCRIPTION
## Summary
- cache MappingResponse JSON schema in `MAPPING_SCHEMA`
- reuse cached schema when rendering mapping prompts

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_mapping_prompt.py::test_render_set_prompt_orders_content`
- `poetry run pytest` *(fails: TypeError: unsupported operand type(s) for /: 'str' and 'str')*

------
https://chatgpt.com/codex/tasks/task_e_68a71a77de68832b98408f6a10fd310d