### PR TITLE
Validate definitions with Pydantic model

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -103,6 +103,26 @@ class Contribution(StrictModel):
     )
 
 
+class DefinitionItem(StrictModel):
+    """Named definition entry used when rendering reference sections."""
+
+    name: Annotated[str, Field(min_length=1, description="Definition term.")]
+    description: Annotated[
+        str, Field(min_length=1, description="Explanation of the term.")
+    ]
+
+
+class DefinitionBlock(StrictModel):
+    """Container for a definition title and its bullet entries."""
+
+    title: Annotated[
+        str, Field(min_length=1, description="Definitions section heading.")
+    ] = "Definitions"
+    bullets: list[DefinitionItem] = Field(
+        default_factory=list, description="Collection of definition items."
+    )
+
+
 class ServiceFeature(StrictModel):
     """Feature already delivered by the service.
 
@@ -555,6 +575,8 @@ class MappingResponse(StrictModel):
 __all__ = [
     "AppConfig",
     "Contribution",
+    "DefinitionBlock",
+    "DefinitionItem",
     "DescriptionResponse",
     "PlateauDescription",
     "PlateauDescriptionsResponse",

--- a/tests/test_load_definitions.py
+++ b/tests/test_load_definitions.py
@@ -1,0 +1,44 @@
+"""Tests for :func:`loader.load_definitions`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from loader import load_definitions
+
+
+def test_load_definitions_roundtrip(tmp_path: Path) -> None:
+    """Definitions file is rendered as Markdown with numbered bullets."""
+
+    content = {
+        "title": "Key definitions",
+        "bullets": [
+            {"name": "Alpha", "description": "First"},
+            {"name": "Beta", "description": "Second"},
+        ],
+    }
+    file = tmp_path / "definitions.json"
+    file.write_text(json.dumps(content), encoding="utf-8")
+
+    text = load_definitions(tmp_path, file.name)
+
+    assert "## Key definitions" in text
+    assert "1. **Alpha**: First" in text
+    assert "2. **Beta**: Second" in text
+
+
+def test_load_definitions_validation_error(tmp_path: Path) -> None:
+    """Invalid definition entries raise ``RuntimeError``."""
+
+    content = {
+        "title": "Key definitions",
+        "bullets": [{"name": "Alpha"}],
+    }
+    file = tmp_path / "definitions.json"
+    file.write_text(json.dumps(content), encoding="utf-8")
+
+    with pytest.raises(RuntimeError):
+        load_definitions(tmp_path, file.name)


### PR DESCRIPTION
## Summary
- define strict DefinitionItem/DefinitionBlock models for definition bullets
- load definitions with schema validation and improved error handling
- cover definition loader with unit tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: list index out of range; async functions not supported, missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a71ceee770832b9fef61a8c42f13b3