### PR TITLE
refactor: compact tab-separated mapping output

### DIFF
--- a/prompts/mapping_prompt.md
+++ b/prompts/mapping_prompt.md
@@ -2,6 +2,9 @@
 
 Map each feature to relevant {mapping_labels} from the lists below.
 
+Lists use a compact tab-separated layout:
+`ID\tname\tdescription`.
+
 {mapping_sections}
 
 ## Features

--- a/src/mapping_prompt.py
+++ b/src/mapping_prompt.py
@@ -15,19 +15,27 @@ MAPPING_SCHEMA = json.dumps(MappingResponse.model_json_schema(), indent=2)
 
 
 def _render_items(items: Sequence[MappingItem]) -> str:
-    """Return bullet list representation of ``items`` sorted by identifier."""
+    """Return tab-separated ``items`` sorted by identifier.
+
+    Each line follows the compact format ``ID\tname\tdescription`` to simplify
+    parsing by the language model and remove decorative bullets.
+    """
 
     return "\n".join(
-        f"- {entry.id}: {entry.name} - {entry.description}"
+        f"{entry.id}\t{entry.name}\t{entry.description}"
         for entry in sorted(items, key=lambda i: i.id)
     )
 
 
 def _render_features(features: Sequence[PlateauFeature]) -> str:
-    """Return bullet list representation of ``features`` sorted by feature ID."""
+    """Return tab-separated ``features`` sorted by feature ID.
+
+    Lines are formatted as ``ID\tname\tdescription`` without leading bullets or
+    repeated delimiters.
+    """
 
     return "\n".join(
-        f"- {feat.feature_id}: {feat.name} - {feat.description}"
+        f"{feat.feature_id}\t{feat.name}\t{feat.description}"
         for feat in sorted(features, key=lambda f: f.feature_id)
     )
 

--- a/tests/test_mapping_prompt.py
+++ b/tests/test_mapping_prompt.py
@@ -44,10 +44,10 @@ def test_render_set_prompt_orders_content(shuffle: bool, monkeypatch) -> None:
 
     prompt = render_set_prompt("test", items, features)
     lines = prompt.splitlines()
-    idx_a = lines.index("- A: Item A - desc")
-    idx_b = lines.index("- B: Item B - desc")
-    idx_1 = lines.index("- 1: First - d")
-    idx_2 = lines.index("- 2: Second - d")
+    idx_a = lines.index("A\tItem A\tdesc")
+    idx_b = lines.index("B\tItem B\tdesc")
+    idx_1 = lines.index("1\tFirst\td")
+    idx_2 = lines.index("2\tSecond\td")
     assert idx_a < idx_b
     assert idx_1 < idx_2
 


### PR DESCRIPTION
## Summary
- format mapping items and features as tab-separated lines
- document the compact layout in the mapping prompt
- update mapping prompt tests for new layout

## Testing
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_mapping_prompt.py`


------
https://chatgpt.com/codex/tasks/task_e_68a720db601c832bbd6bd663b25a398e