### PR TITLE
Remove batch size example and document CLI flags

### DIFF
--- a/config/app.example.json
+++ b/config/app.example.json
@@ -37,9 +37,8 @@
   // Optional inspiration list to influence outputs.
   "inspiration": "general",
 
-  // Concurrency and batching controls for API requests.
+  // Concurrency controls for API requests.
   "concurrency": 5,
-  "batch_size": 25,
   "request_timeout": 60,
   "retries": 5,
   "retry_base_delay": 0.5,

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -17,11 +17,14 @@ Example command:
 ```bash
 poetry run service-ambitions generate-evolution \
   --input-file sample-services.jsonl \
-  --output-file evolution.jsonl
+  --output-file evolution.jsonl \
+  --strict-mapping --diagnostics
 ```
 
+`--mapping-data-dir` points to a directory of mapping reference data.
+`--strict-mapping/--no-strict-mapping` fails when feature mappings are missing.
+`--diagnostics/--no-diagnostics` enables verbose diagnostics output.
 Use `--roles-file` to supply an alternative roles definition file when needed.
-Provide `--mapping-data-dir` to point to a directory of mapping reference data.
 
 Pass `--strict` to abort if any role lacks features or if generated features
 contain empty mapping lists. This turns on a fail-fast mode instead of the

--- a/tests/test_async_processing.py
+++ b/tests/test_async_processing.py
@@ -3,7 +3,7 @@ import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Iterable
+from typing import Any
 
 import pytest
 
@@ -365,44 +365,3 @@ async def test_run_one_counters_failure(monkeypatch):
     assert failed.value == 1
     assert queue.qsize() == 0
     assert gen._metrics.tokens == [0]
-
-
-def test_generate_async_consumes_in_batches(tmp_path, monkeypatch):
-    """The generator only consumes inputs in ``batch_size`` chunks."""
-
-    counter = {"count": 0}
-
-    def services() -> Iterable[ServiceInput]:
-        for i in range(10):  # Yield a fixed number of services lazily
-            counter["count"] += 1
-            yield ServiceInput(
-                service_id=f"svc{i}",
-                name=f"s{i}",
-                description="d",
-                jobs_to_be_done=[],
-            )
-
-    gen = generator.ServiceAmbitionGenerator(
-        SimpleNamespace(), concurrency=2, batch_size=3
-    )
-
-    async def run() -> None:
-        event = asyncio.Event()
-
-        async def fake_process_service(self, service, prompt=None):
-            await event.wait()
-            return {"id": service.service_id}, 1
-
-        monkeypatch.setattr(
-            generator.ServiceAmbitionGenerator, "process_service", fake_process_service
-        )
-
-        task = asyncio.create_task(
-            gen.generate_async(services(), "p", str(tmp_path / "out.jsonl"))
-        )
-        await asyncio.sleep(0.1)  # Allow the first batch to be scheduled
-        assert counter["count"] == 3  # Only one batch should be consumed
-        event.set()
-        await task
-
-    asyncio.run(run())


### PR DESCRIPTION
## Summary
- drop `batch_size` from sample config
- document `--mapping-data-dir`, `--diagnostics`, `--strict-mapping` flags in evolution docs
- remove batch processing test

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_cli.py tests/test_async_processing.py` *(fails: SimpleNamespace object has no attribute 'request_timeout'; async functions not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a31278e4832baf03f3877d82378b