### PR TITLE
refactor: remove expected tokens config

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -325,7 +325,6 @@ async def _cmd_generate_ambitions(
                 request_timeout=settings.request_timeout,
                 retries=settings.retries,
                 retry_base_delay=settings.retry_base_delay,
-                expected_output_tokens=args.expected_output_tokens,
             )
 
             part_path, processed_path = _prepare_paths(output_path, args.resume)
@@ -717,12 +716,6 @@ def main() -> None:
         "--validate-only",
         action="store_true",
         help="Validate an existing output file and exit",
-    )
-    amb.add_argument(
-        "--expected-output-tokens",
-        type=int,
-        default=256,
-        help="Anticipated tokens per response for concurrency tuning",
     )
     amb.set_defaults(func=_cmd_generate_ambitions)
 

--- a/src/generator.py
+++ b/src/generator.py
@@ -193,7 +193,6 @@ class ServiceAmbitionGenerator:
         request_timeout: float = 60,
         retries: int = 5,
         retry_base_delay: float = 0.5,
-        expected_output_tokens: int = 256,
     ) -> None:
         """Initialize the generator.
 
@@ -203,8 +202,6 @@ class ServiceAmbitionGenerator:
             request_timeout: Per-request timeout in seconds.
             retries: Number of retry attempts on failure.
             retry_base_delay: Initial backoff delay in seconds.
-            expected_output_tokens: Anticipated tokens in each response. Retained
-                for backwards compatibility.
 
         Raises:
             ValueError: If ``concurrency`` is less than one.
@@ -218,7 +215,6 @@ class ServiceAmbitionGenerator:
         self.request_timeout = request_timeout
         self.retries = retries
         self.retry_base_delay = retry_base_delay
-        self.expected_output_tokens = expected_output_tokens
         self._prompt: str | None = None
         self._limiter: Semaphore | None = None
         self._metrics: RollingMetrics | None = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -556,68 +556,6 @@ def test_cli_help_shows_parameters(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "Generate service ambitions" in out
     assert "--input-file" in out
-    assert "--expected-output-tokens" in out
-
-
-def test_cli_passes_expected_output_tokens(tmp_path, monkeypatch):
-    base = tmp_path / "prompts"
-    (base / "situational_context").mkdir(parents=True)
-    (base / "inspirations").mkdir(parents=True)
-    (base / "situational_context" / "ctx.md").write_text("c", encoding="utf-8")
-    (base / "inspirations" / "insp.md").write_text("i", encoding="utf-8")
-    (base / "task_definition.md").write_text("t", encoding="utf-8")
-    (base / "response_structure.md").write_text("r", encoding="utf-8")
-
-    input_file = tmp_path / "services.jsonl"
-    input_file.write_text('{"name": "alpha"}\n', encoding="utf-8")
-    output_file = tmp_path / "out.jsonl"
-
-    settings = SimpleNamespace(
-        model="cfg",
-        log_level="INFO",
-        prompt_dir=str(base),
-        context_id="ctx",
-        inspiration="insp",
-        concurrency=1,
-        openai_api_key="dummy",
-        logfire_token=None,
-        reasoning=None,
-        models=None,
-        web_search=False,
-    )
-
-    captured: dict[str, int] = {}
-
-    def fake_init(
-        self,
-        model,
-        concurrency=5,
-        request_timeout=60,
-        retries=5,
-        retry_base_delay=0.5,
-        expected_output_tokens=256,
-    ) -> None:
-        captured["expected"] = expected_output_tokens
-
-    monkeypatch.setattr(ServiceAmbitionGenerator, "__init__", fake_init)
-    monkeypatch.setattr(cli, "load_settings", lambda: settings)
-
-    argv = [
-        "main",
-        "generate-ambitions",
-        "--input-file",
-        str(input_file),
-        "--output-file",
-        str(output_file),
-        "--dry-run",
-        "--expected-output-tokens",
-        "512",
-    ]
-    monkeypatch.setattr(sys, "argv", argv)
-
-    cli.main()
-
-    assert captured["expected"] == 512
 
 
 def test_cli_verbose_logging(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- drop expected_output_tokens from ServiceAmbitionGenerator and CLI
- tidy backpressure docs to remove expected_output_tokens references
- delete CLI test and flag for expected-output-tokens

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: FileNotFoundError, AttributeError, etc. – 43 failed, 89 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ac66e098832b801903834a095867