### PR TITLE
refactor: drop max items per mapping

### DIFF
--- a/src/mapping.py
+++ b/src/mapping.py
@@ -85,7 +85,6 @@ def _merge_mapping_results(
     payload: MappingResponse,
     mapping_types: Mapping[str, MappingTypeConfig],
     *,
-    max_items_per_mapping: int | None = None,
     catalogue_items: Mapping[str, list[MappingItem]] | None = None,
 ) -> list[PlateauFeature]:
     """Return ``features`` merged with mapping ``payload``.
@@ -120,8 +119,6 @@ def _merge_mapping_results(
                 logfire.warning(
                     f"Missing mappings: feature={feature.feature_id} key={key}"
                 )
-            if max_items_per_mapping is not None:
-                cleaned = cleaned[:max_items_per_mapping]
             update_data[key] = cleaned
         merged = feature.model_copy(update={"mappings": feature.mappings | update_data})
         results.append(merged)


### PR DESCRIPTION
## Summary
- simplify mapping merge logic by removing max item limit parameter

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `pytest` *(fails: ModuleNotFoundError: No module named 'logfire')*

------
https://chatgpt.com/codex/tasks/task_e_68a7af6d14a8832b93665249892ab06b