### PR TITLE
Quarantine unknown mapping IDs per service

### DIFF
--- a/tests/test_mapping_prompt.py
+++ b/tests/test_mapping_prompt.py
@@ -2,19 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Sequence
-import types
 import sys
+import types
+from typing import Sequence
 
 import pytest
 
 stub_loader = types.ModuleType("loader")
-stub_loader.load_prompt_text = lambda name: ""
+stub_loader.load_prompt_text = lambda name: ""  # type: ignore[attr-defined]
 sys.modules["loader"] = stub_loader
 
-import mapping_prompt
-from mapping_prompt import render_set_prompt
-from models import MappingItem, MaturityScore, PlateauFeature
+import mapping_prompt  # noqa: E402
+from mapping_prompt import render_set_prompt  # noqa: E402
+from models import MappingItem, MaturityScore, PlateauFeature  # noqa: E402
 
 
 @pytest.mark.parametrize("shuffle", [False, True])


### PR DESCRIPTION
## Summary
- quarantine unknown mapping IDs under service-specific folders
- plumb service IDs through mapping helpers
- test quarantines for distinct services

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest`
- `poetry run pytest tests/test_mapping.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7f28febcc832bb43c6218e6391d38