### PR TITLE
refactor: drop obsolete embedding init

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -32,7 +32,6 @@ from loader import (
     load_evolution_prompt,
     load_role_ids,
 )
-from mapping import init_embeddings
 from model_factory import ModelFactory
 from models import ServiceEvolution, ServiceInput, ServiceMeta
 from monitoring import LOG_FILE_NAME, init_logfire
@@ -430,10 +429,6 @@ async def _cmd_generate_evolution(
         logfire.info(f"Validated {len(services)} services")
         return
 
-    # Warm mapping embeddings upfront so subsequent requests reuse cached vectors.
-    # Failures are logged by ``init_embeddings`` and do not interrupt startup.
-    await init_embeddings()
-
     concurrency = (
         args.concurrency if args.concurrency is not None else settings.concurrency
     )
@@ -515,10 +510,6 @@ async def _cmd_generate_mapping(args: argparse.Namespace, settings) -> None:
     )
 
     configure_mapping_data_dir(args.mapping_data_dir or settings.mapping_data_dir)
-
-    # Warm mapping embeddings upfront so subsequent requests reuse cached vectors.
-    # Failures are logged by ``init_embeddings`` and do not interrupt startup.
-    await init_embeddings()
 
     input_path = Path(args.input)
     lines = await asyncio.to_thread(input_path.read_text, encoding="utf-8")

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -41,11 +41,6 @@ def set_quarantine_logger(callback: Callable[[Path], None] | None) -> None:
     _quarantine_logger = callback
 
 
-async def init_embeddings() -> None:
-    """Legacy no-op kept for backwards compatibility."""
-    return None
-
-
 def _quarantine_unknown_ids(data: Mapping[str, set[str]], service_id: str) -> Path:
     """Persist unknown mapping identifiers for ``service_id`` across all sets."""
 
@@ -202,6 +197,5 @@ class MappingError(RuntimeError):
 __all__ = [
     "map_set",
     "MappingError",
-    "init_embeddings",
     "set_quarantine_logger",
 ]

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -29,13 +29,6 @@ class DummyFactory:
 cli.ModelFactory = DummyFactory  # type: ignore[assignment,misc]
 
 
-async def _noop_init_embeddings() -> None:
-    """Test stub for ``init_embeddings``."""
-
-
-cli.init_embeddings = _noop_init_embeddings
-
-
 def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
     """_cmd_generate_evolution should write evolution results to disk."""
     input_path = tmp_path / "services.jsonl"
@@ -147,10 +140,7 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
         def __init__(self, model, instructions):
             pass
 
-    called = {"ran": False, "embed": False}
-
-    async def fake_init_embeddings() -> None:
-        called["embed"] = True
+    called = {"ran": False}
 
     async def fake_generate(
         self,
@@ -168,7 +158,6 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(
         "cli.PlateauGenerator.generate_service_evolution_async", fake_generate
     )
-    monkeypatch.setattr("cli.init_embeddings", fake_init_embeddings)
     monkeypatch.setattr("cli.configure_prompt_dir", lambda _path: None)
     monkeypatch.setattr("cli.load_evolution_prompt", lambda _ctx, _insp: "prompt")
     monkeypatch.setattr("cli.logfire.force_flush", lambda: None)
@@ -223,7 +212,6 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
 
     assert not output_path.exists()
     assert not called["ran"]
-    assert not called["embed"]
 
 
 def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:

--- a/tests/test_cli_generate_mapping.py
+++ b/tests/test_cli_generate_mapping.py
@@ -49,12 +49,8 @@ def test_generate_mapping_maps_features(tmp_path, monkeypatch) -> None:
         called["count"] = len(feats)
         return [f.model_copy(update={"mappings": {"applications": []}}) for f in feats]
 
-    async def fake_init_embeddings() -> None:
-        return None
-
     monkeypatch.setattr(cli, "Agent", lambda *a, **k: SimpleNamespace())
     monkeypatch.setattr(cli.PlateauGenerator, "_map_features", fake_map_features)
-    monkeypatch.setattr(cli, "init_embeddings", fake_init_embeddings)
     monkeypatch.setattr(
         cli, "configure_mapping_data_dir", lambda p: called.setdefault("path", p)
     )


### PR DESCRIPTION
## Summary
- remove legacy `init_embeddings` stub and drop export
- stop warming embeddings in CLI commands
- clean up CLI tests that no longer patch `init_embeddings`

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: TypeError in tests/test_loading.py::test_load_prompt_text_mapping, tests/test_loading.py::test_load_prompt_text_description; multiple async test failures and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a841f71af0832b8cc6409ebff3ff6b