### PR TITLE
Allow optional mapping contributions

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -94,13 +94,8 @@ class Contribution(StrictModel):
     item: Annotated[
         str, Field(min_length=1, description="Identifier of the mapped element.")
     ]
-    contribution: float | None = Field(
-        default=None,
-        description=(
-            "Importance weight. ``None`` implies a default weight of 1.0 or"
-            " indicates the mapping should be ignored."
-        ),
-    )
+    contribution: float | None = None
+    """Importance weight. ``None`` uses a default of ``1.0`` or ignores the mapping."""
 
 
 class DefinitionItem(StrictModel):

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -60,6 +60,7 @@ async def test_map_set_retries_on_failure(monkeypatch) -> None:
     )
     assert session.prompts == ["PROMPT", "PROMPT\nReturn valid JSON only."]
     assert mapped[0].mappings["applications"][0].item == "a"
+    assert mapped[0].mappings["applications"][0].contribution is None
 
 
 @pytest.mark.asyncio()
@@ -150,6 +151,9 @@ def test_merge_mapping_results_aggregates_unknown_ids(monkeypatch, tmp_path) -> 
     assert merged[1].mappings["applications"] == []
     assert merged[0].mappings["technologies"] == []
     assert merged[1].mappings["technologies"] == []
+    assert (
+        merged[0].mappings["applications"][0].contribution is None
+    )  # Preserve ``None`` weights
 
     qfile = tmp_path / "quarantine" / "mappings" / "unknown" / "unknown_ids.json"
     data = json.loads(qfile.read_text())

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -138,3 +138,18 @@ def test_mapping_response_allows_unbounded_items() -> None:
 
     result = MappingResponse.model_validate(payload)
     assert len(result.features[0].mappings["data"]) == 6
+
+
+def test_mapping_response_accepts_none_contribution() -> None:
+    """Contributions with ``None`` weights should be preserved."""
+    payload = {
+        "features": [
+            {
+                "feature_id": "f1",
+                "data": [{"item": "INF-1", "contribution": None}],
+            }
+        ]
+    }
+
+    result = MappingResponse.model_validate(payload)
+    assert result.features[0].mappings["data"][0].contribution is None


### PR DESCRIPTION
## Summary
- Permit `Contribution.contribution` to be `None`
- Cover mapping behaviour with `None` weights in tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing src/models.py tests/test_mapping.py tests/test_models.py`
- `poetry run ruff check --fix src/models.py tests/test_mapping.py tests/test_models.py`
- `poetry run mypy src/models.py tests/test_mapping.py tests/test_models.py`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_models.py tests/test_mapping.py`
- `poetry run pytest` *(fails: unsupported operand type(s) for /: 'str' and 'str', ModuleNotFoundError: import of tiktoken halted, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a85959db30832b834534b576c81a31