### PR TITLE
Consolidate service span logging and simplify metrics

### DIFF
--- a/src/conversation.py
+++ b/src/conversation.py
@@ -240,7 +240,6 @@ class ConversationSession:
         if self.metrics:
             # record request initiation metrics
             self.metrics.record_request()
-            self.metrics.record_start_tokens(prompt_token_estimate)
         with self._prepare_span(
             span_name, stage, model_name, prompt_token_estimate
         ) as span:

--- a/tests/test_async_processing.py
+++ b/tests/test_async_processing.py
@@ -34,9 +34,11 @@ def test_process_service_async(monkeypatch):
         jobs_to_be_done=[{"name": "job"}],
     )
     gen = generator.ServiceAmbitionGenerator(SimpleNamespace())
-    result, tokens = asyncio.run(gen.process_service(service, "prompt"))
+    result, tokens, cost, retries = asyncio.run(gen.process_service(service, "prompt"))
     assert json.loads(result["service"]) == service.model_dump()
     assert tokens == 1
+    assert cost >= 0
+    assert retries == 0
 
 
 def test_process_service_retries(monkeypatch):
@@ -67,11 +69,13 @@ def test_process_service_retries(monkeypatch):
         jobs_to_be_done=[{"name": "job"}],
     )
     gen = generator.ServiceAmbitionGenerator(SimpleNamespace())
-    result, tokens = asyncio.run(gen.process_service(service, "prompt"))
+    result, tokens, cost, retries = asyncio.run(gen.process_service(service, "prompt"))
 
     assert attempts["count"] == 3
     assert json.loads(result["service"]) == service.model_dump()
     assert tokens == 1
+    assert cost >= 0
+    assert retries == 2
 
 
 def test_with_retry_logs_attempt(monkeypatch):
@@ -196,7 +200,7 @@ def test_with_retry_honours_retry_after(monkeypatch):
     monkeypatch.setattr(generator.asyncio, "sleep", fake_sleep)
     monkeypatch.setattr(generator.random, "random", lambda: 0.0)
 
-    result = asyncio.run(
+    result, retries = asyncio.run(
         generator._with_retry(
             lambda: flaky(),
             request_timeout=0.1,
@@ -208,6 +212,7 @@ def test_with_retry_honours_retry_after(monkeypatch):
     )
 
     assert result == "ok"
+    assert retries == 1
     assert slept["delay"] == 10.0
     assert throttled["called"] == 1
 
@@ -252,7 +257,7 @@ async def test_process_all_fsyncs(tmp_path, monkeypatch):
     monkeypatch.setattr(generator.os, "fsync", fake_fsync)
 
     async def fake_process_service(self, service, prompt=None):
-        return {"id": service.service_id}, 1
+        return {"id": service.service_id}, 1, 0.0, 0
 
     monkeypatch.setattr(
         generator.ServiceAmbitionGenerator, "process_service", fake_process_service
@@ -276,7 +281,7 @@ async def test_run_one_counters_success(tmp_path, monkeypatch):
     """Successful runs update processed and token counters."""
 
     async def ok(self, service):
-        return ({"line": service.service_id}, service.service_id, 1)
+        return ({"line": service.service_id}, service.service_id, 1, 0.0, 0, "success")
 
     class DummyCounter:
         def __init__(self) -> None:
@@ -328,7 +333,7 @@ async def test_run_one_counters_failure(tmp_path, monkeypatch):
     """Failures increment the failed counter and release tokens."""
 
     async def bad(self, service):
-        return (None, service.service_id, 0)
+        return (None, service.service_id, 0, 0.0, 0, "error")
 
     class DummyCounter:
         def __init__(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,7 +61,7 @@ def test_cli_generates_output(tmp_path, monkeypatch):
 
     async def fake_process_service(self, service, prompt=None):
         assert prompt is not None
-        return {"service": service["name"], "prompt": prompt[:3]}, 0
+        return {"service": service["name"], "prompt": prompt[:3]}, 0, 0.0, 0
 
     monkeypatch.setattr(
         ServiceAmbitionGenerator, "process_service", fake_process_service
@@ -191,7 +191,7 @@ def test_cli_switches_context(tmp_path, monkeypatch):
 
     async def fake_process_service(self, service, prompt=None):
         assert prompt is not None
-        return {"prompt": prompt}, 0
+        return {"prompt": prompt}, 0, 0.0, 0
 
     monkeypatch.setattr(
         ServiceAmbitionGenerator, "process_service", fake_process_service
@@ -270,7 +270,7 @@ def test_cli_model_instantiation_arguments(tmp_path, monkeypatch):
     monkeypatch.setattr(cli, "build_model", fake_build_model)
 
     async def fake_process_service(self, service, prompt=None):
-        return {"ok": True}, 0
+        return {"ok": True}, 0, 0.0, 0
 
     monkeypatch.setattr(
         ServiceAmbitionGenerator, "process_service", fake_process_service
@@ -336,7 +336,7 @@ def test_cli_seed_sets_random(tmp_path, monkeypatch):
         return "test"
 
     async def fake_process_service(self, service, prompt=None):
-        return {"ok": True}, 0
+        return {"ok": True}, 0, 0.0, 0
 
     monkeypatch.setattr(generator, "build_model", fake_build_model)
     monkeypatch.setattr(cli, "build_model", fake_build_model)
@@ -401,7 +401,7 @@ def test_cli_enables_logfire(tmp_path, monkeypatch):
     )
 
     async def fake_process_service(self, service, prompt=None):
-        return {"ok": True}, 0
+        return {"ok": True}, 0, 0.0, 0
 
     monkeypatch.setattr(
         ServiceAmbitionGenerator, "process_service", fake_process_service
@@ -585,7 +585,7 @@ def test_cli_verbose_logging(tmp_path, monkeypatch):
     )
 
     async def fake_process_service(self, service, prompt=None):
-        return {"ok": True}, 0
+        return {"ok": True}, 0, 0.0, 0
 
     monkeypatch.setattr(
         ServiceAmbitionGenerator, "process_service", fake_process_service
@@ -652,7 +652,7 @@ def test_cli_resume_skips_processed(tmp_path, monkeypatch):
 
     async def fake_process_service(self, service, prompt=None):
         processed.append(service.service_id)
-        return {"service_id": service.service_id}, 0
+        return {"service_id": service.service_id}, 0, 0.0, 0
 
     monkeypatch.setattr(
         ServiceAmbitionGenerator, "process_service", fake_process_service

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,50 @@
+import asyncio
+from types import SimpleNamespace
+
+import generator
+from models import ServiceInput
+
+
+class DummySpan:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.attributes: dict[str, object] = {}
+
+    def __enter__(self):
+        spans.append(self)
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+
+
+async def fake_process_service(self, service, prompt=None):
+    return {"id": service.service_id}, 3, 0.5, 1
+
+
+spans: list[DummySpan] = []
+
+
+def test_service_span_records_metrics(monkeypatch, tmp_path):
+    spans.clear()
+    monkeypatch.setattr(generator.logfire, "span", lambda name: DummySpan(name))
+    monkeypatch.setattr(
+        generator.ServiceAmbitionGenerator, "process_service", fake_process_service
+    )
+    monkeypatch.setattr(generator.os, "fsync", lambda fd: None)
+
+    service = ServiceInput(
+        service_id="svc1", name="svc", description="d", jobs_to_be_done=[]
+    )
+    gen = generator.ServiceAmbitionGenerator(SimpleNamespace())
+    asyncio.run(gen.generate_async([service], "prompt", str(tmp_path / "out.jsonl")))
+
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.attributes["tokens.total"] == 3
+    assert span.attributes["cost.estimate"] == 0.5
+    assert span.attributes["retries"] == 1
+    assert span.attributes["status"] == "success"

--- a/tests/test_golden_output.py
+++ b/tests/test_golden_output.py
@@ -19,7 +19,8 @@ class DummyAgent:
 
     async def run(self, user_prompt: str, output_type):
         return SimpleNamespace(
-            output=SimpleNamespace(model_dump=lambda: {"service": user_prompt})
+            output=SimpleNamespace(model_dump=lambda: {"service": user_prompt}),
+            usage=lambda: SimpleNamespace(total_tokens=1),
         )
 
 


### PR DESCRIPTION
## Summary
- collapse per-service logging into a single span with token, cost, retry and status details
- drop queue-size metrics and default prompt spans for leaner telemetry
- cover new span behaviour with integration tests

## Testing
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: unsupported operand type(s) for /: 'str' and 'str', async functions not supported, missing module tiktoken, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a869bf7e9c832b974c8ef547f15075