### PR TITLE
feat: add diagnostics transcript logging

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -202,6 +202,7 @@ async def _generate_evolution_for_service(
                 diagnostics=settings.diagnostics,
                 log_prompts=not args.no_logs,
                 redact_prompts=True,
+                transcripts_dir=transcripts_dir,
             )
             feat_session = ConversationSession(
                 feat_agent,
@@ -210,6 +211,7 @@ async def _generate_evolution_for_service(
                 diagnostics=settings.diagnostics,
                 log_prompts=not args.no_logs,
                 redact_prompts=True,
+                transcripts_dir=transcripts_dir,
             )
             map_session = ConversationSession(
                 map_agent,
@@ -218,6 +220,7 @@ async def _generate_evolution_for_service(
                 diagnostics=settings.diagnostics,
                 log_prompts=not args.no_logs,
                 redact_prompts=True,
+                transcripts_dir=transcripts_dir,
             )
             generator = PlateauGenerator(
                 feat_session,

--- a/src/token_utils.py
+++ b/src/token_utils.py
@@ -7,7 +7,14 @@ available and otherwise falls back to a simple heuristic. It also provides
 
 from __future__ import annotations
 
+from typing import Any
+
 import tiktoken
+
+try:
+    _ENCODING: Any | None = tiktoken.get_encoding("cl100k_base")
+except Exception:  # pragma: no cover - fallback when encoding unavailable
+    _ENCODING = None
 
 
 def estimate_tokens(prompt: str, expected_output: int) -> int:
@@ -21,10 +28,9 @@ def estimate_tokens(prompt: str, expected_output: int) -> int:
         The estimated total number of tokens for the prompt plus the expected
         output.
     """
-    if tiktoken is not None:
+    if _ENCODING is not None:
         # Use the installed ``tiktoken`` package for accurate token counts.
-        encoding = tiktoken.get_encoding("cl100k_base")
-        return len(encoding.encode(prompt)) + expected_output
+        return len(_ENCODING.encode(prompt)) + expected_output
 
     # Fallback to a rough heuristic when ``tiktoken`` is unavailable.
     return len(prompt) // 4 + expected_output


### PR DESCRIPTION
## Summary
- support optional transcript logging for ConversationSession
- allow CLI to pass transcript directory for diagnostics runs
- safeguard token estimation from missing tiktoken models
- test ConversationSession transcript logging

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `pytest tests/test_conversation.py -vv`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a87167ed74832ba3e59db19882b52c