### PR TITLE
feat: add mapping data flags and defaults

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -411,6 +411,8 @@ async def _cmd_generate_evolution(
     )
 
     configure_prompt_dir(settings.prompt_dir)
+    if args.mapping_data_dir is None and not settings.diagnostics:
+        raise RuntimeError("--mapping-data-dir is required in production mode")
     configure_mapping_data_dir(args.mapping_data_dir or settings.mapping_data_dir)
     system_prompt = load_evolution_prompt(settings.context_id, settings.inspiration)
 
@@ -509,6 +511,8 @@ async def _cmd_generate_mapping(args: argparse.Namespace, settings) -> None:
         redact_prompts=True,
     )
 
+    if args.mapping_data_dir is None and not settings.diagnostics:
+        raise RuntimeError("--mapping-data-dir is required in production mode")
     configure_mapping_data_dir(args.mapping_data_dir or settings.mapping_data_dir)
 
     input_path = Path(args.input)
@@ -778,6 +782,8 @@ def main() -> None:
         settings.strict_mapping = args.strict_mapping
     if args.mapping_data_dir is not None:
         settings.mapping_data_dir = Path(args.mapping_data_dir)
+    if not hasattr(settings, "mapping_mode"):
+        settings.mapping_mode = "per_set"
 
     _configure_logging(args, settings)
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -62,6 +62,7 @@ class Settings(BaseSettings):
     strict_mapping: bool = Field(
         False, description="Fail when feature mappings are missing."
     )
+    mapping_mode: str = Field("per_set", description="Mapping enrichment strategy")
 
     model_config = SettingsConfigDict(extra="ignore")
 
@@ -105,6 +106,7 @@ def load_settings() -> Settings:
             mapping_data_dir=getattr(config, "mapping_data_dir", Path("data")),
             diagnostics=getattr(config, "diagnostics", False),
             strict_mapping=getattr(config, "strict_mapping", False),
+            mapping_mode=getattr(config, "mapping_mode", "per_set"),
             _env_file=env_file,
         )
     except ValidationError as exc:

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -204,7 +204,7 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
         strict=False,
         diagnostics=None,
         strict_mapping=None,
-        mapping_data_dir=None,
+        mapping_data_dir="data",
     )
 
     monkeypatch.setattr(cli, "_RUN_META", None)
@@ -311,7 +311,7 @@ def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:
         strict=False,
         diagnostics=None,
         strict_mapping=None,
-        mapping_data_dir=None,
+        mapping_data_dir="data",
     )
 
     monkeypatch.setattr(cli, "_RUN_META", None)
@@ -394,7 +394,7 @@ def test_generate_evolution_rejects_invalid_concurrency(tmp_path, monkeypatch) -
         strict=False,
         diagnostics=None,
         strict_mapping=None,
-        mapping_data_dir=None,
+        mapping_data_dir="data",
     )
 
     monkeypatch.setattr(cli, "_RUN_META", None)
@@ -532,7 +532,7 @@ def test_generate_evolution_writes_transcripts(tmp_path, monkeypatch) -> None:
         strict=False,
         diagnostics=None,
         strict_mapping=None,
-        mapping_data_dir=None,
+        mapping_data_dir="data",
     )
 
     monkeypatch.setattr(cli, "_RUN_META", None)


### PR DESCRIPTION
## Summary
- add diagnostics, strict-mapping, and mapping-data-dir flags to CLI
- default mapping_mode to per_set
- require --mapping-data-dir for evolution and mapping in production

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_cli.py::test_cli_flag_overrides_settings`
- `poetry run pytest tests/test_cli_generate_evolution.py tests/test_cli_generate_mapping.py`


------
https://chatgpt.com/codex/tasks/task_e_68a87174b54c832b8ae147dc1b5258ea