### PR TITLE
chore: remove quiet flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ runs concurrently with a worker pool bounded by this setting. Pass `--progress`
 to display a progress bar during long runs; it is suppressed automatically in
 CI environments or when stdout is not a TTY. Provide `--seed` to make
 stochastic behaviour such as backoff jitter deterministic during tests and
-demos. Pass `--quiet` to disable per-call logging spans.
+demos.
 
 ### Remapping mode
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -10,7 +10,6 @@ import logging
 import os
 import random
 import sys
-from contextlib import nullcontext
 from datetime import datetime, timezone
 from itertools import islice
 from pathlib import Path
@@ -83,9 +82,6 @@ def _configure_logging(args: argparse.Namespace, settings) -> None:
     # Initialize logfire regardless of token availability; a missing token
     # keeps logging local without sending telemetry to the cloud.
     init_logfire(settings.logfire_token)
-    if args.quiet:
-        # Replace log spans with a no-op context manager when quiet
-        logfire.span = lambda *a, **k: nullcontext()  # type: ignore[assignment]
 
 
 def _prepare_paths(output: Path, resume: bool) -> tuple[Path, Path]:
@@ -659,11 +655,6 @@ def main() -> None:
         "--no-logs",
         action="store_true",
         help="Disable file logging and Logfire telemetry",
-    )
-    common.add_argument(
-        "--quiet",
-        action="store_true",
-        help="Disable per-call log spans",
     )
     common.add_argument(
         "--strict",


### PR DESCRIPTION
## Summary
- drop `--quiet` CLI flag and per-call log span suppression
- update docs to remove `--quiet` references

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_cli.py tests/test_cli_generate_evolution.py tests/test_cli_generate_mapping.py` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'request_timeout')*
- `poetry run pytest tests/test_cli_generate_evolution.py tests/test_cli_generate_mapping.py`

------
https://chatgpt.com/codex/tasks/task_e_68a94dc581a8832b8bbd3ae0da1e918c