### PR TITLE
refactor: remove service loader spans

### DIFF
--- a/src/service_loader.py
+++ b/src/service_loader.py
@@ -41,72 +41,65 @@ def _process_line(
 ) -> ServiceInput | None:
     """Return validated service or ``None`` for invalid entries."""
 
-    with logfire.span("service_loader.read_line") as span:
-        span.set_attribute("file.path", str(path_obj))
-        span.set_attribute("line.number", line_number)
-        if not line:
-            span.set_attribute(SERVICE_ID_ATTR, None)
-            logfire.debug(
-                "Skipping blank line",
-                file_path=str(path_obj),
-                line_number=line_number,
-            )
-            return None
-        try:
-            service = adapter.validate_json(line)
-            span.set_attribute(SERVICE_ID_ATTR, service.service_id)
-            VALID_SERVICES.add(1)
-            return service
-        except Exception as exc:
-            QUARANTINED_LINES.add(1)
-            quarantine_dir = path_obj.parent / "quarantine"
-            quarantine_dir.mkdir(exist_ok=True)
-            service_id = _extract_service_id(line)
-            span.set_attribute(SERVICE_ID_ATTR, service_id)
-            filename = f"{service_id or line_number}.json"
-            quarantine_path = quarantine_dir / filename
-            quarantine_path.write_text(line, encoding="utf-8")
-            logfire.error(
-                "Invalid service entry",
-                file_path=str(path_obj),
-                line_number=line_number,
-                service_id=service_id,
-                quarantine_path=str(quarantine_path),
-                error=str(exc),
-            )
-            return None
+    if not line:
+        logfire.debug(
+            "Skipping blank line",
+            file_path=str(path_obj),
+            line_number=line_number,
+        )
+        return None
+    try:
+        service = adapter.validate_json(line)
+        VALID_SERVICES.add(1)
+        return service
+    except Exception as exc:
+        QUARANTINED_LINES.add(1)
+        quarantine_dir = path_obj.parent / "quarantine"
+        quarantine_dir.mkdir(exist_ok=True)
+        service_id = _extract_service_id(line)
+        filename = f"{service_id or line_number}.json"
+        quarantine_path = quarantine_dir / filename
+        quarantine_path.write_text(line, encoding="utf-8")
+        logfire.error(
+            "Invalid service entry",
+            file_path=str(path_obj),
+            line_number=line_number,
+            service_id=service_id,
+            quarantine_path=str(quarantine_path),
+            error=str(exc),
+        )
+        return None
 
 
 def _load_service_entries(path: Path | str) -> Generator[ServiceInput, None, None]:
     """Yield services from ``path`` while validating each JSON line."""
 
     path_obj = Path(path)
-    with logfire.span("Calling service_loader.load_services"):
-        adapter = TypeAdapter(ServiceInput)
-        try:
-            with path_obj.open("r", encoding="utf-8") as file:
-                for line_number, raw_line in enumerate(file, start=1):
-                    TOTAL_LINES.add(1)
-                    service = _process_line(
-                        raw_line.strip(), line_number, path_obj, adapter
-                    )
-                    if service is not None:
-                        yield service
-        except FileNotFoundError:
-            logfire.error(SERVICES_FILE_NOT_FOUND, file_path=str(path_obj))
-            raise FileNotFoundError(
-                f"{SERVICES_FILE_NOT_FOUND}. Please create a {path_obj} file in the"
-                " current directory."
-            ) from None
-        except Exception as exc:
-            logfire.error(
-                "Error reading services file",
-                file_path=str(path_obj),
-                error=str(exc),
-            )
-            raise RuntimeError(
-                f"An error occurred while reading the services file: {exc}"
-            ) from exc
+    adapter = TypeAdapter(ServiceInput)
+    try:
+        with path_obj.open("r", encoding="utf-8") as file:
+            for line_number, raw_line in enumerate(file, start=1):
+                TOTAL_LINES.add(1)
+                service = _process_line(
+                    raw_line.strip(), line_number, path_obj, adapter
+                )
+                if service is not None:
+                    yield service
+    except FileNotFoundError:
+        logfire.error(SERVICES_FILE_NOT_FOUND, file_path=str(path_obj))
+        raise FileNotFoundError(
+            f"{SERVICES_FILE_NOT_FOUND}. Please create a {path_obj} file in the"
+            " current directory."
+        ) from None
+    except Exception as exc:
+        logfire.error(
+            "Error reading services file",
+            file_path=str(path_obj),
+            error=str(exc),
+        )
+        raise RuntimeError(
+            f"An error occurred while reading the services file: {exc}"
+        ) from exc
 
 
 class ServiceLoader:


### PR DESCRIPTION
## Summary
- drop logfire spans from service loader

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: 39 failed, 89 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a95f46facc832b9d5a7b101854fabb