### PR TITLE
docs: refresh mapping flow and logfire details

### DIFF
--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -26,6 +26,10 @@ poetry run service-ambitions generate-evolution \
 `--diagnostics/--no-diagnostics` enables verbose diagnostics output.
 Use `--roles-file` to supply an alternative roles definition file when needed.
 
+Logfire is required by the CLI but the `LOGFIRE_TOKEN` environment variable is
+optional for local runs. Set the token to stream traces to Logfire; omit it to
+disable telemetry.
+
 Pass `--strict` to abort if any role lacks features or if generated features
 contain empty mapping lists. This turns on a fail-fast mode instead of the
 default best‑effort behaviour.
@@ -77,7 +81,6 @@ Each line in the output file is a JSON object with:
       "search": "openai:gpt-4o-search-preview"
     },
     "web_search": false,
-    "mapping_types": ["data", "applications", "technology"],
     "created": "2024-01-01T00:00:00Z"
   },
   "service": {
@@ -104,9 +107,9 @@ Each line in the output file is a JSON object with:
           },
           "customer_type": "string",
           "mappings": {
-            "data": [{ "item": "string", "contribution": 0.5 }],
+            "information": [{ "item": "string" }],
             "applications": [{ "item": "string", "contribution": 0.5 }],
-            "technology": [{ "item": "string", "contribution": 0.5 }]
+            "technologies": [{ "item": "string" }]
           }
         }
       ]

--- a/docs/generate-mapping.md
+++ b/docs/generate-mapping.md
@@ -22,6 +22,10 @@ mappings and continue.
 
 `--diagnostics` enables verbose logging and spans useful for troubleshooting.
 
+Mapping runs once per configured set. Each prompt receives the relevant
+reference list—`applications`, `technologies` and `information` by default—and
+returns items matched to the feature.
+
 ## Input format
 
 Provide a JSON Lines file produced by `generate-evolution`. Each line should be a
@@ -30,9 +34,17 @@ present, is replaced.
 
 ## Output format
 
-The output mirrors the input structure with refreshed mapping contributions under
-each feature. Mapping lists include an `item` identifier and a numeric
-`contribution` score in the range `[0.1, 1.0]`.
+The output mirrors the input structure with refreshed mappings under each
+feature. Mapping lists include an `item` identifier and may include a
+`contribution` weight in the range `[0.1, 1.0]`.
+
+```json
+"mappings": {
+  "applications": [{"item": "APP001"}],
+  "technologies": [{"item": "TECH002", "contribution": 0.5}],
+  "information": [{"item": "INFO003"}]
+}
+```
 
 ## Troubleshooting
 

--- a/docs/sd01-flow-of-evolution-prompts.md
+++ b/docs/sd01-flow-of-evolution-prompts.md
@@ -150,9 +150,9 @@ Generate service features for the Learning & Teaching service at plateau 1.
 ```
 
 ### Mapping Prompt
-Map each feature to relevant Data, Applications, Technologies from the lists below.
+Map each feature to relevant Information, Applications and Technologies from the lists below.
 
-#### Available Data
+#### Available Information
 - INFO001: User Data - Information about the user.
 - INFO002: Course Material - Content used for teaching.
 
@@ -169,11 +169,8 @@ Map each feature to relevant Data, Applications, Technologies from the lists bel
 
 #### Instructions
 - Return a JSON object with a top-level "features" array.
-- Each element must include "feature_id" and a "mappings" object containing "data", "applications" and "technology" arrays.
-- For each mapping list, return at most 5 items.
-- Items in these arrays must provide "item" and "contribution" fields. The
-  "contribution" value is a number in [0.1, 1.0] where 1.0 = critical, 0.5 =
-  helpful and 0.1 = weak.
+- Each element must include "feature_id" and a "mappings" object containing "information", "applications" and "technologies" arrays.
+- Items may include an optional "contribution" field in the range [0.1, 1.0] where 1.0 = critical, 0.5 = helpful and 0.1 = weak.
 - Do not invent IDs; only use those provided.
 - Maintain terminology consistent with the situational context, definitions and inspirations.
 - Do not include any text outside the JSON object.
@@ -190,11 +187,11 @@ Map each feature to relevant Data, Applications, Technologies from the lists bel
         "type": "object",
         "properties": {
           "feature_id": {"type": "string"},
-          "mappings": {"type": "object", "properties": {
-            "data": {"type": "array", "maxItems": 5, "items": {"type": "object", "properties": {"item": {"type": "string"}, "contribution": {"type": "number", "minimum": 0.1, "maximum": 1.0}}, "required": ["item", "contribution"]}},
-            "applications": {"type": "array", "maxItems": 5, "items": {"type": "object", "properties": {"item": {"type": "string"}, "contribution": {"type": "number", "minimum": 0.1, "maximum": 1.0}}, "required": ["item", "contribution"]}},
-            "technology": {"type": "array", "maxItems": 5, "items": {"type": "object", "properties": {"item": {"type": "string"}, "contribution": {"type": "number", "minimum": 0.1, "maximum": 1.0}}, "required": ["item", "contribution"]}}
-          }, "required": ["data", "applications", "technology"]}
+            "mappings": {"type": "object", "properties": {
+              "information": {"type": "array", "items": {"type": "object", "properties": {"item": {"type": "string"}, "contribution": {"type": "number", "minimum": 0.1, "maximum": 1.0}}, "required": ["item"]}},
+              "applications": {"type": "array", "items": {"type": "object", "properties": {"item": {"type": "string"}, "contribution": {"type": "number", "minimum": 0.1, "maximum": 1.0}}, "required": ["item"]}},
+              "technologies": {"type": "array", "items": {"type": "object", "properties": {"item": {"type": "string"}, "contribution": {"type": "number", "minimum": 0.1, "maximum": 1.0}}, "required": ["item"]}}
+            }, "required": ["information", "applications", "technologies"]}
         },
         "required": ["feature_id", "mappings"]
       }


### PR DESCRIPTION
## Summary
- clarify Logfire token requirements and remove deprecated flag references
- document per-set mapping prompts with optional contribution weights
- update mapping schemas to use applications, technologies, information

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: unsupported operand type(s) for /: 'str' and 'str')*


------
https://chatgpt.com/codex/tasks/task_e_68a9713639a0832b8b5d850a6bd85fdf