### PR TITLE
docs: clarify optional Logfire token

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ handled via [Pydantic AI](https://pydantic.dev/pydantic-ai/).
 Create a `.env` file in the project root with:
 
 ```
+# Required for API access
 OPENAI_API_KEY=your_api_key_here
+# Optional: provide to publish telemetry to Logfire
+# LOGFIRE_TOKEN=your_logfire_token
 ```
 
 For production deployments, inject the variable using your platform's secret
@@ -80,10 +83,10 @@ directory, `--context-id` to select a situational context, and
 supports swapping sections to suit different industries.
 
 This project depends on the [Pydantic Logfire](https://logfire.pydantic.dev/)
-libraries even when telemetry is disabled. Logfire is required but the
-`LOGFIRE_TOKEN` environment variable is optional for local runs. Set the token
-to send traces to Logfire. When configured, the CLI instruments Pydantic,
-Pydantic AI, OpenAI and system metrics automatically.
+libraries for telemetry. The `LOGFIRE_TOKEN` environment variable is optional:
+without it, Logfire still records logs and metrics locally but nothing is sent
+to the cloud. Provide a token to stream traces to Logfire. When configured, the
+CLI instruments Pydantic, Pydantic AI, OpenAI and system metrics automatically.
 
 ## Installation
 

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -27,8 +27,8 @@ poetry run service-ambitions generate-evolution \
 Use `--roles-file` to supply an alternative roles definition file when needed.
 
 Logfire is required by the CLI but the `LOGFIRE_TOKEN` environment variable is
-optional for local runs. Set the token to stream traces to Logfire; omit it to
-disable telemetry.
+optional for local runs. Set the token to stream traces to Logfire; without it,
+telemetry remains local.
 
 Pass `--strict` to abort if any role lacks features or if generated features
 contain empty mapping lists. This turns on a fail-fast mode instead of the


### PR DESCRIPTION
## Summary
- document that `LOGFIRE_TOKEN` is optional and telemetry runs locally without it
- show optional token in `.env` examples

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_cli.py` *(fails: AttributeError: <module 'cli'... has no attribute 'main_async'>)*
- `poetry run pytest tests/test_monitoring.py`


------
https://chatgpt.com/codex/tasks/task_e_68a974f3ad70832b839764e5c7113299