### PR TITLE
feat: add diagnostics flag to logfire init

### DIFF
--- a/src/monitoring.py
+++ b/src/monitoring.py
@@ -1,9 +1,9 @@
 """Helpers for enabling Pydantic Logfire telemetry.
 
 Logfire operates locally without an API token; the token is only required for
-publishing telemetry to the cloud. These helpers configure the SDK and enable
-instrumentation regardless of token availability so the rest of the
-application can remain oblivious to monitoring details.
+publishing telemetry to the cloud. These helpers configure the SDK and, when
+requested, instrument the application regardless of token availability so the
+rest of the application can remain oblivious to monitoring details.
 """
 
 from __future__ import annotations
@@ -14,29 +14,33 @@ import os
 LOG_FILE_NAME = "service.log"
 
 
-def init_logfire(token: str | None = None) -> None:
-    """Configure the Logfire SDK and enable instrumentation.
+def init_logfire(token: str | None = None, diagnostics: bool = False) -> None:
+    """Configure the Logfire SDK and optionally enable diagnostics.
 
     Args:
         token: Optional Logfire API token. When omitted the ``LOGFIRE_TOKEN``
             environment variable is used. A missing token means logs remain
             local but the SDK still operates.
+        diagnostics: When ``True``, enable system metrics and available
+            instrumentation helpers to collect diagnostic telemetry.
     """
 
     import logfire
 
     key = token or os.getenv("LOGFIRE_TOKEN")
     logfire.configure(token=key, service_name="service-ambition-generator")
-    logfire.instrument_system_metrics(base="full")
 
-    # Dynamically enable available instrumentation helpers on the logfire module.
-    for name in (
-        "instrument_pydantic_ai",
-        "instrument_pydantic",
-        "instrument_openai",
-    ):
-        instrument = getattr(logfire, name, None)
-        if instrument:
-            instrument()
+    if diagnostics:  # Enable instrumentation only when diagnostics are requested
+        logfire.instrument_system_metrics(base="full")
 
-    logfire.info("Logfire telemetry enabled")
+        # Dynamically enable available instrumentation helpers on the logfire module.
+        for name in (
+            "instrument_pydantic_ai",
+            "instrument_pydantic",
+            "instrument_openai",
+        ):
+            instrument = getattr(logfire, name, None)
+            if instrument:  # Skip helpers missing from the current Logfire build
+                instrument()
+
+        logfire.info("Logfire telemetry enabled")


### PR DESCRIPTION
## Summary
- add diagnostics flag to `init_logfire`
- enable instrumentation and telemetry logging only when diagnostics are requested

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`


------
https://chatgpt.com/codex/tasks/task_e_68a983253338832bb2fa61bb22041034