### PR TITLE
Pass diagnostics flag to logfire initialization

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -81,7 +81,7 @@ def _configure_logging(args: argparse.Namespace, settings) -> None:
     )
     # Initialize logfire regardless of token availability; a missing token
     # keeps logging local without sending telemetry to the cloud.
-    init_logfire(settings.logfire_token)
+    init_logfire(settings.logfire_token, diagnostics=settings.diagnostics)
 
 
 def _prepare_paths(output: Path, resume: bool) -> tuple[Path, Path]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,6 +57,7 @@ def test_cli_generates_output(tmp_path, monkeypatch):
         reasoning=None,
         models=None,
         web_search=False,
+        diagnostics=False,
     )
 
     async def fake_process_service(self, service, prompt=None):
@@ -115,6 +116,7 @@ def test_cli_dry_run_skips_processing(tmp_path, monkeypatch):
         reasoning=None,
         models=None,
         web_search=False,
+        diagnostics=False,
     )
 
     called = {"ran": False}
@@ -187,6 +189,7 @@ def test_cli_switches_context(tmp_path, monkeypatch):
         logfire_token=None,
         reasoning=None,
         web_search=False,
+        diagnostics=False,
     )
 
     async def fake_process_service(self, service, prompt=None):
@@ -248,6 +251,7 @@ def test_cli_model_instantiation_arguments(tmp_path, monkeypatch):
         logfire_token=None,
         reasoning=None,
         web_search=False,
+        diagnostics=False,
     )
 
     captured: dict[str, str] = {}
@@ -319,6 +323,7 @@ def test_cli_seed_sets_random(tmp_path, monkeypatch):
         logfire_token=None,
         reasoning=None,
         web_search=False,
+        diagnostics=False,
     )
 
     captured: dict[str, int | None] = {}
@@ -398,6 +403,7 @@ def test_cli_enables_logfire(tmp_path, monkeypatch):
         logfire_token="lf-key",
         reasoning=None,
         web_search=False,
+        diagnostics=False,
     )
 
     async def fake_process_service(self, service, prompt=None):
@@ -476,11 +482,12 @@ def test_cli_no_logs_disables_logging(tmp_path, monkeypatch):
         request_timeout=60,
         retries=5,
         retry_base_delay=0.5,
+        diagnostics=False,
     )
 
     called = {"init": False}
 
-    def fake_init(token):
+    def fake_init(token, diagnostics=False):
         called["init"] = True
 
     async def fake_generate_async(
@@ -539,6 +546,7 @@ def test_cli_rejects_invalid_concurrency(monkeypatch):
         logfire_token=None,
         reasoning=None,
         web_search=False,
+        diagnostics=False,
     )
     monkeypatch.setattr(cli, "load_settings", lambda: settings)
 
@@ -582,6 +590,7 @@ def test_cli_verbose_logging(tmp_path, monkeypatch):
         logfire_token=None,
         reasoning=None,
         web_search=False,
+        diagnostics=False,
     )
 
     async def fake_process_service(self, service, prompt=None):
@@ -646,6 +655,7 @@ def test_cli_resume_skips_processed(tmp_path, monkeypatch):
         logfire_token=None,
         reasoning=None,
         web_search=False,
+        diagnostics=False,
     )
 
     processed: list[str] = []
@@ -716,6 +726,7 @@ def test_cli_validate_only(tmp_path, monkeypatch):
         reasoning=None,
         models=None,
         web_search=False,
+        diagnostics=False,
     )
 
     monkeypatch.setattr(cli, "load_settings", lambda: settings)
@@ -754,6 +765,7 @@ def test_cli_flag_overrides_settings(monkeypatch, tmp_path):
         logfire_token=None,
         reasoning=None,
         web_search=False,
+        diagnostics=False,
     )
     captured: dict[str, object] = {}
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -37,7 +37,7 @@ def test_init_logfire_configures_sdk(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "logfire", dummy_module)
 
-    monitoring.init_logfire("token")
+    monitoring.init_logfire("token", diagnostics=True)
 
     assert called["token"] == "token"
     assert called["service_name"] == "service-ambition-generator"


### PR DESCRIPTION
## Summary
- forward diagnostics flag when initializing logfire
- update CLI tests and monitoring tests for new signature

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing tests/test_cli.py tests/test_monitoring.py src/cli.py`
- `poetry run ruff check --fix tests/test_cli.py tests/test_monitoring.py src/cli.py`
- `poetry run mypy src/cli.py tests/test_cli.py tests/test_monitoring.py`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: ModuleNotFoundError: import of tiktoken halted)*

------
https://chatgpt.com/codex/tasks/task_e_68a983fc49e8832ba071e1ceeffc8a0b