### PR TITLE
docs: clarify diagnostics mode and disable logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,10 @@ supports swapping sections to suit different industries.
 This project depends on the [Pydantic Logfire](https://logfire.pydantic.dev/)
 libraries for telemetry. The `LOGFIRE_TOKEN` environment variable is optional:
 without it, Logfire still records logs and metrics locally but nothing is sent
-to the cloud. Provide a token to stream traces to Logfire. When configured, the
-CLI instruments Pydantic, Pydantic AI, OpenAI and system metrics automatically.
+to the cloud. Provide a token to stream traces to Logfire. The CLI only
+instruments Pydantic, Pydantic AI, OpenAI and system metrics when run with the
+`--diagnostics` flag, which enables verbose diagnostics. Use `--no-logs` to
+avoid writing local log files.
 
 ## Installation
 
@@ -114,19 +116,19 @@ Run the CLI through Poetry to ensure it uses the managed environment. Use
 subcommands to select the desired operation:
 
 ```bash
-poetry run service-ambitions generate-ambitions --input-file sample-services.jsonl --output-file ambitions.jsonl
-poetry run service-ambitions generate-evolution --input-file sample-services.jsonl --output-file evolution.jsonl
-poetry run service-ambitions generate-mapping --input evolution.jsonl --output remapped.jsonl
-poetry run service-ambitions migrate-jsonl --input ambitions.jsonl --output upgraded.jsonl --from 1.0 --to 1.1
+poetry run service-ambitions generate-ambitions --input-file sample-services.jsonl --output-file ambitions.jsonl --no-logs
+poetry run service-ambitions generate-evolution --input-file sample-services.jsonl --output-file evolution.jsonl --no-logs
+poetry run service-ambitions generate-mapping --input evolution.jsonl --output remapped.jsonl --no-logs
+poetry run service-ambitions migrate-jsonl --input ambitions.jsonl --output upgraded.jsonl --from 1.0 --to 1.1 --no-logs
 ```
 
 Alternatively, use the provided shell script which forwards all arguments to the CLI:
 
 ```bash
-./run.sh generate-ambitions --input-file sample-services.jsonl --output-file ambitions.jsonl
-./run.sh generate-evolution --input-file sample-services.jsonl --output-file evolution.jsonl
-./run.sh generate-mapping --input evolution.jsonl --output remapped.jsonl
-./run.sh migrate-jsonl --input ambitions.jsonl --output upgraded.jsonl --from 1.0 --to 1.1
+./run.sh generate-ambitions --input-file sample-services.jsonl --output-file ambitions.jsonl --no-logs
+./run.sh generate-evolution --input-file sample-services.jsonl --output-file evolution.jsonl --no-logs
+./run.sh generate-mapping --input evolution.jsonl --output remapped.jsonl --no-logs
+./run.sh migrate-jsonl --input ambitions.jsonl --output upgraded.jsonl --from 1.0 --to 1.1 --no-logs
 ```
 
 ## Usage
@@ -150,13 +152,14 @@ new mapping data. Adjust mapping behaviour with:
 
 - `--mapping-data-dir` – directory containing mapping reference data.
 - `--strict-mapping/--no-strict-mapping` – fail when mappings are missing.
-- `--diagnostics/--no-diagnostics` – enable verbose diagnostics output.
+- `--diagnostics/--no-diagnostics` – enable verbose diagnostics output and
+  instrumentation.
 
 Example invocation:
 
 ```bash
 ./run.sh generate-mapping --input evolution.jsonl --output remapped.jsonl \
-  --strict-mapping
+  --strict-mapping --no-logs
 ```
 
 See [generate-mapping](docs/generate-mapping.md) for detailed behaviour and
@@ -171,7 +174,7 @@ output file.
 Example:
 
 ```bash
-./run.sh migrate-jsonl --input ambitions.jsonl --output upgraded.jsonl --from 1.0 --to 1.1
+./run.sh migrate-jsonl --input ambitions.jsonl --output upgraded.jsonl --from 1.0 --to 1.1 --no-logs
 ```
 
 ## Concurrency control
@@ -205,12 +208,13 @@ Use the `generate-evolution` subcommand to score each service against all
 configured plateau features and customer segments. It reads services from an
 input JSON Lines file and writes a `ServiceEvolution` record for each line in
 the output file. Logs are written to `service.log` in the current working
-directory. Enable verbose logs with `-v` or `-vv`.
+directory. Enable verbose logs with `-v` or `-vv`, or pass `--no-logs` to skip
+writing this file.
 
 Basic invocation:
 
 ```bash
-./run.sh generate-evolution --input-file sample-services.jsonl --output-file evolution.jsonl
+./run.sh generate-evolution --input-file sample-services.jsonl --output-file evolution.jsonl --no-logs
 ```
 
 Processing happens concurrently; control parallel workers with `--concurrency`
@@ -218,13 +222,14 @@ which defaults to the `concurrency` value in your settings.
 
 Mapping requests default to a per-set strategy. Use `--mapping-data-dir` to
 point to alternative reference datasets. Enable `--strict-mapping` to fail when
-features return no mappings or `--diagnostics` for verbose request logging.
+features return no mappings. Pass `--diagnostics` to enable verbose mode and
+telemetry instrumentation.
 
 Example invocation tuning mapping behaviour:
 
 ```bash
 ./run.sh generate-evolution --input-file sample-services.jsonl \
-  --output-file evolution.jsonl --strict-mapping
+  --output-file evolution.jsonl --strict-mapping --no-logs
 ```
 
 ### Conversation seed

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -18,17 +18,19 @@ Example command:
 poetry run service-ambitions generate-evolution \
   --input-file sample-services.jsonl \
   --output-file evolution.jsonl \
-  --strict-mapping --diagnostics
+  --strict-mapping --diagnostics --no-logs
 ```
 
 `--mapping-data-dir` points to a directory of mapping reference data.
 `--strict-mapping/--no-strict-mapping` fails when feature mappings are missing.
-`--diagnostics/--no-diagnostics` enables verbose diagnostics output.
+`--diagnostics/--no-diagnostics` enables verbose diagnostics output and
+telemetry instrumentation.
 Use `--roles-file` to supply an alternative roles definition file when needed.
 
 Logfire is required by the CLI but the `LOGFIRE_TOKEN` environment variable is
 optional for local runs. Set the token to stream traces to Logfire; without it,
-telemetry remains local.
+telemetry remains local. Instrumentation only runs when `--diagnostics` is
+supplied.
 
 Pass `--strict` to abort if any role lacks features or if generated features
 contain empty mapping lists. This turns on a fail-fast mode instead of the

--- a/docs/generate-mapping.md
+++ b/docs/generate-mapping.md
@@ -10,7 +10,7 @@ Example command:
 poetry run service-ambitions generate-mapping \
   --input evolution.jsonl \
   --output remapped.jsonl \
-  --strict-mapping --diagnostics
+  --strict-mapping --diagnostics --no-logs
 ```
 
 `--mapping-data-dir` points to the directory containing mapping reference data
@@ -20,7 +20,8 @@ files.
 produces an empty list. Disable with `--no-strict-mapping` to keep existing
 mappings and continue.
 
-`--diagnostics` enables verbose logging and spans useful for troubleshooting.
+`--diagnostics` enables verbose logging and telemetry instrumentation useful for
+troubleshooting. Instrumentation runs only when this verbose mode is enabled.
 
 Mapping runs once per configured set. Each prompt receives the relevant
 reference list—`applications`, `technologies` and `information` by default—and


### PR DESCRIPTION
## Summary
- note that telemetry instrumentation only activates with `--diagnostics`
- add `--no-logs` to CLI examples and document verbose diagnostics mode

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`


------
https://chatgpt.com/codex/tasks/task_e_68a98ad57be8832bb00325ea9eb920bb