### PR TITLE
feat: add quarantine writer for mapping errors

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -35,12 +35,12 @@ from loader import (
     load_mapping_items,
     load_role_ids,
 )
-from mapping import set_quarantine_logger
 from model_factory import ModelFactory
 from models import ServiceEvolution, ServiceInput, ServiceMeta
 from monitoring import LOG_FILE_NAME, init_logfire
 from persistence import atomic_write, read_lines
 from plateau_generator import PlateauGenerator
+from quarantine import QuarantineWriter
 from schema_migration import migrate_record
 from service_loader import load_services
 from settings import load_settings
@@ -50,6 +50,7 @@ EVOLUTIONS_GENERATED = logfire.metric_counter("evolutions_generated")
 LINES_WRITTEN = logfire.metric_counter("lines_written")
 
 _RUN_META: ServiceMeta | None = None
+_writer = QuarantineWriter()
 
 SERVICES_FILE_HELP = "Path to the services JSONL file"
 OUTPUT_FILE_HELP = "File to write the results"
@@ -276,13 +277,12 @@ async def _generate_evolution_for_service(
                 output_path=getattr(output, "name", ""),
             )
         except Exception as exc:  # noqa: BLE001
-            quarantine_dir = Path("quarantine")
-            await asyncio.to_thread(quarantine_dir.mkdir, parents=True, exist_ok=True)
-            quarantine_file = quarantine_dir / f"{service.service_id}.json"
-            await asyncio.to_thread(
-                quarantine_file.write_text,
-                service.model_dump_json(indent=2),
-                encoding="utf-8",
+            quarantine_file = await asyncio.to_thread(
+                _writer.write,
+                "evolution",
+                service.service_id,
+                "schema_mismatch",
+                service.model_dump(),
             )
             logfire.exception(
                 "Failed to generate evolution",
@@ -790,7 +790,6 @@ def main() -> None:
     _configure_logging(args, settings)
 
     telemetry.reset()
-    set_quarantine_logger(telemetry.record_quarantine)
     result = args.func(args, settings, None)
     if inspect.isawaitable(result):
         # Cast ensures that asyncio.run receives a proper Coroutine

--- a/src/quarantine.py
+++ b/src/quarantine.py
@@ -1,0 +1,80 @@
+"""Utilities for writing quarantined payloads."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import logfire
+
+import telemetry
+
+MANIFEST = "manifest.json"
+ALLOWED_KINDS = {"json_parse_error", "unknown_ids", "schema_mismatch", "timeout"}
+
+
+class QuarantineWriter:
+    """Persist invalid payloads and maintain a manifest."""
+
+    def __init__(self, base_dir: Path | str = Path("quarantine")) -> None:
+        self.base_dir = Path(base_dir)
+
+    def write(self, set_name: str, service_id: str, kind: str, payload: Any) -> Path:
+        """Persist ``payload`` and update manifest.
+
+        Parameters
+        ----------
+        set_name:
+            Mapping set or processing stage name.
+        service_id:
+            Identifier of the service associated with ``payload``.
+        kind:
+            Nature of the quarantine, such as ``json_parse_error`` or ``unknown_ids``.
+        payload:
+            Offending data to store.
+
+        Returns
+        -------
+        Path
+            Location of the written payload file.
+        """
+
+        if kind not in ALLOWED_KINDS:
+            raise ValueError(f"Unsupported quarantine kind: {kind}")
+
+        qdir = self.base_dir / service_id / set_name
+        qdir.mkdir(parents=True, exist_ok=True)
+
+        index = sum(1 for _ in qdir.glob(f"{kind}_*.json")) + 1
+        file_path = qdir / f"{kind}_{index}.json"
+
+        if isinstance(payload, str):
+            file_path.write_text(payload, encoding="utf-8")
+        else:
+            file_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+        manifest_path = qdir / MANIFEST
+        if manifest_path.exists():
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        else:
+            manifest = {}
+        entry = manifest.setdefault(kind, {"count": 0, "examples": []})
+        entry["count"] += 1
+        if len(entry["examples"]) < 3:
+            entry["examples"].append(payload)
+        manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+        logfire.warning(
+            "Quarantined payload",
+            path=str(file_path),
+            kind=kind,
+            service_id=service_id,
+            set_name=set_name,
+        )
+
+        telemetry.record_quarantine(file_path)
+        return file_path
+
+
+__all__ = ["QuarantineWriter"]


### PR DESCRIPTION
## Summary
- centralize quarantine handling via `QuarantineWriter`
- quarantine mapping errors and CLI failures with manifest tracking
- adjust mapping tests for new quarantine layout

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_mapping.py -q`
- `poetry run pytest` *(fails: TypeError, missing data)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cd60fa7c832b91eae06c1ea68859