### PR TITLE
feat: add optional local cache for mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ new mapping data. Adjust mapping behaviour with:
   contain unknown identifiers.
 - `--diagnostics/--no-diagnostics` – enable verbose diagnostics output and
   instrumentation.
+- `--use-local-cache` – reuse cached mapping responses under `.cache/mapping`.
 
 Example invocation:
 

--- a/docs/generate-mapping.md
+++ b/docs/generate-mapping.md
@@ -24,6 +24,9 @@ produces an empty list or contains unknown identifiers. Disable with
 troubleshooting. Instrumentation runs only when this verbose mode is enabled.
 Prompt text is omitted unless `--allow-prompt-logging` is supplied.
 
+`--use-local-cache` reads and writes mapping responses under `.cache/mapping` to
+avoid repeated network requests during development.
+
 Mapping runs once per configured set. Each prompt receives the relevant
 reference list—`applications`, `technologies` and `information` by default—and
 returns items matched to the feature.

--- a/src/cli.py
+++ b/src/cli.py
@@ -226,6 +226,7 @@ async def _generate_evolution_for_service(
                 description_session=desc_session,
                 mapping_session=map_session,
                 strict=args.strict,
+                use_local_cache=args.use_local_cache,
             )
             global _RUN_META
             if _RUN_META is None:
@@ -539,7 +540,11 @@ async def _cmd_generate_mapping(args: argparse.Namespace, settings) -> None:
         if getattr(args, "strict_mapping", None) is not None
         else settings.strict_mapping
     )
-    generator = PlateauGenerator(session, strict=strict_mapping)
+    generator = PlateauGenerator(
+        session,
+        strict=strict_mapping,
+        use_local_cache=args.use_local_cache,
+    )
     mapped = await generator._map_features(session, features)
     mapped_by_id = {f.feature_id: f for f in mapped}
     for evo in evolutions:
@@ -694,6 +699,11 @@ def main() -> None:
         action=argparse.BooleanOptionalAction,
         default=False,
         help="Fail on missing roles or mappings when enabled",
+    )
+    common.add_argument(
+        "--use-local-cache",
+        action="store_true",
+        help="Cache mapping responses under .cache/mapping for offline runs",
     )
 
     subparsers = parser.add_subparsers(dest="command", required=True)

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -77,6 +77,7 @@ class PlateauGenerator:
         description_session: ConversationSession | None = None,
         mapping_session: ConversationSession | None = None,
         strict: bool = False,
+        use_local_cache: bool = False,
     ) -> None:
         """Initialise the generator.
 
@@ -87,6 +88,8 @@ class PlateauGenerator:
             description_session: Session used for plateau descriptions.
             mapping_session: Session used for feature mapping.
             strict: Enforce feature and mapping completeness when ``True``.
+            use_local_cache: Read and write mapping results from ``.cache`` when
+                ``True``.
         """
         if required_count < 1:
             raise ValueError("required_count must be positive")
@@ -96,6 +99,7 @@ class PlateauGenerator:
         self.required_count = required_count
         self.roles = list(roles or DEFAULT_ROLE_IDS)
         self.strict = strict
+        self.use_local_cache = use_local_cache
         self._service: ServiceInput | None = None
         # Track quarantine file paths for invalid plateau descriptions.
         self.quarantined_descriptions: list[Path] = []
@@ -140,6 +144,7 @@ class PlateauGenerator:
                 base,
                 service=service_name,
                 strict=self.strict,
+                use_local_cache=self.use_local_cache,
             )
             mapped_sets.append(result)
 

--- a/tests/test_cli_generate_mapping.py
+++ b/tests/test_cli_generate_mapping.py
@@ -1,5 +1,6 @@
 import argparse
 import asyncio
+import json
 from types import SimpleNamespace
 from typing import Any
 
@@ -54,6 +55,11 @@ def test_generate_mapping_maps_features(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(
         cli, "configure_mapping_data_dir", lambda p: called.setdefault("path", p)
     )
+    monkeypatch.setattr(
+        cli,
+        "canonicalise_record",
+        lambda r: json.loads(json.dumps(r, default=str)),
+    )
 
     settings = SimpleNamespace(
         model="m",
@@ -76,6 +82,7 @@ def test_generate_mapping_maps_features(tmp_path, monkeypatch) -> None:
         allow_prompt_logging=False,
         mapping_data_dir="maps",
         web_search=None,
+        use_local_cache=False,
     )
 
     asyncio.run(_cmd_generate_mapping(args, settings))


### PR DESCRIPTION
## Summary
- add `--use-local-cache` CLI flag for optional mapping cache
- cache mapping responses under `.cache/mapping` keyed by `hash(prompt)`
- test cache hit and miss behaviour

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing src/cli.py src/mapping.py src/plateau_generator.py tests/test_mapping.py tests/test_cli_generate_mapping.py`
- `poetry run ruff check --fix src/cli.py src/mapping.py src/plateau_generator.py tests/test_mapping.py tests/test_cli_generate_mapping.py`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 poetry run pytest -p pytest_asyncio.plugin tests/test_mapping.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 poetry run pytest -p pytest_asyncio.plugin tests/test_cli_generate_mapping.py::test_generate_mapping_maps_features`


------
https://chatgpt.com/codex/tasks/task_e_68aa35fed458832b81bcdedac3abd4fd