### PR TITLE
feat: configure mapping sets

### DIFF
--- a/config/app.example.json
+++ b/config/app.example.json
@@ -29,6 +29,11 @@
     "applications": {"dataset": "applications", "label": "Applications"},
     "technology": {"dataset": "technologies", "label": "Technologies"}
   },
+  "mapping_sets": [
+    {"name": "Applications", "file": "applications.json", "field": "applications"},
+    {"name": "Technologies", "file": "technologies.json", "field": "technology"},
+    {"name": "Data", "file": "information.json", "field": "data"}
+  ],
 
   // Directory containing prompt components.
   "prompt_dir": "prompts",

--- a/config/app.json
+++ b/config/app.json
@@ -14,6 +14,11 @@
         "applications": {"dataset": "applications", "label": "Applications"},
         "technology": {"dataset": "technologies", "label": "Technologies"}
     },
+    "mapping_sets": [
+        {"name": "Applications", "file": "applications.json", "field": "applications"},
+        {"name": "Technologies", "file": "technologies.json", "field": "technology"},
+        {"name": "Data", "file": "information.json", "field": "data"}
+    ],
     "prompt_dir": "prompts",
     "context_id": "university",
     "inspiration": "general",

--- a/src/cli.py
+++ b/src/cli.py
@@ -238,7 +238,7 @@ async def _generate_evolution_for_service(
                         "search", args.search_model or args.model
                     ),
                 }
-                items = load_mapping_items(MAPPING_DATA_DIR)
+                items = load_mapping_items(MAPPING_DATA_DIR, settings.mapping_sets)
                 serialised = json.dumps(
                     {
                         k: [i.model_dump(mode="json") for i in v]

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -28,6 +28,7 @@ from models import (
     StrictModel,
 )
 from quarantine import QuarantineWriter
+from settings import load_settings
 from telemetry import record_mapping_set
 
 if TYPE_CHECKING:
@@ -57,7 +58,9 @@ def _merge_mapping_results(
     presence of unknown or missing identifiers raises :class:`MappingError`.
     """
 
-    catalogues = catalogue_items or load_mapping_items(MAPPING_DATA_DIR)
+    catalogues = catalogue_items or load_mapping_items(
+        MAPPING_DATA_DIR, load_settings().mapping_sets
+    )
     valid_ids: dict[str, set[str]] = {
         key: {item.id for item in catalogues[cfg.dataset]}
         for key, cfg in mapping_types.items()

--- a/src/models.py
+++ b/src/models.py
@@ -278,6 +278,27 @@ class MappingTypeConfig(StrictModel):
     ]
 
 
+class MappingSet(StrictModel):
+    """Configuration for a mapping dataset.
+
+    Each set links a feature mapping field to a JSON file on disk that
+    provides the corresponding :class:`MappingItem` catalogue.
+    """
+
+    name: Annotated[
+        str,
+        Field(min_length=1, description="Human readable mapping set name."),
+    ]
+    file: Annotated[
+        str,
+        Field(min_length=1, description="Filename containing mapping items."),
+    ]
+    field: Annotated[
+        str,
+        Field(min_length=1, description="Feature mapping field name."),
+    ]
+
+
 class ReasoningConfig(StrictModel):
     """Optional reasoning parameters for OpenAI models.
 
@@ -384,6 +405,10 @@ class AppConfig(StrictModel):
         int,
         Field(ge=1, description="Required number of features per role."),
     ] = 5
+    mapping_sets: list[MappingSet] = Field(
+        default_factory=list,
+        description="Mapping dataset configurations.",
+    )
     mapping_types: dict[str, MappingTypeConfig] = Field(
         default_factory=dict,
         description="Mapping type definitions keyed by field name.",

--- a/src/settings.py
+++ b/src/settings.py
@@ -14,7 +14,7 @@ from pydantic import Field, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from loader import load_app_config
-from models import ReasoningConfig, StageModels
+from models import MappingSet, ReasoningConfig, StageModels
 
 
 class Settings(BaseSettings):
@@ -52,6 +52,10 @@ class Settings(BaseSettings):
 
     mapping_data_dir: Path = Field(
         Path("data"), description="Directory containing mapping reference data."
+    )
+    mapping_sets: list[MappingSet] = Field(
+        default_factory=list,
+        description="Mapping dataset configurations.",
     )
     diagnostics: bool = Field(
         False, description="Enable verbose diagnostics and tracing."
@@ -100,6 +104,7 @@ def load_settings() -> Settings:
             features_per_role=config.features_per_role,
             web_search=config.web_search,
             mapping_data_dir=getattr(config, "mapping_data_dir", Path("data")),
+            mapping_sets=getattr(config, "mapping_sets", []),
             diagnostics=getattr(config, "diagnostics", False),
             strict_mapping=getattr(config, "strict_mapping", False),
             mapping_mode=getattr(config, "mapping_mode", "per_set"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,7 @@ def test_cli_generates_output(tmp_path, monkeypatch):
         models=None,
         web_search=False,
         diagnostics=False,
+        mapping_sets=[],
     )
 
     async def fake_process_service(self, service, prompt=None):
@@ -117,6 +118,7 @@ def test_cli_dry_run_skips_processing(tmp_path, monkeypatch):
         models=None,
         web_search=False,
         diagnostics=False,
+        mapping_sets=[],
     )
 
     called = {"ran": False}
@@ -190,6 +192,7 @@ def test_cli_switches_context(tmp_path, monkeypatch):
         reasoning=None,
         web_search=False,
         diagnostics=False,
+        mapping_sets=[],
     )
 
     async def fake_process_service(self, service, prompt=None):
@@ -252,6 +255,7 @@ def test_cli_model_instantiation_arguments(tmp_path, monkeypatch):
         reasoning=None,
         web_search=False,
         diagnostics=False,
+        mapping_sets=[],
     )
 
     captured: dict[str, str] = {}
@@ -324,6 +328,7 @@ def test_cli_seed_sets_random(tmp_path, monkeypatch):
         reasoning=None,
         web_search=False,
         diagnostics=False,
+        mapping_sets=[],
     )
 
     captured: dict[str, int | None] = {}
@@ -404,6 +409,7 @@ def test_cli_enables_logfire(tmp_path, monkeypatch):
         reasoning=None,
         web_search=False,
         diagnostics=False,
+        mapping_sets=[],
     )
 
     async def fake_process_service(self, service, prompt=None):
@@ -483,6 +489,7 @@ def test_cli_no_logs_disables_logging(tmp_path, monkeypatch):
         retries=5,
         retry_base_delay=0.5,
         diagnostics=False,
+        mapping_sets=[],
     )
 
     called: dict[str, object] = {}
@@ -548,6 +555,7 @@ def test_cli_rejects_invalid_concurrency(monkeypatch):
         reasoning=None,
         web_search=False,
         diagnostics=False,
+        mapping_sets=[],
     )
     monkeypatch.setattr(cli, "load_settings", lambda: settings)
 
@@ -592,6 +600,7 @@ def test_cli_verbose_logging(tmp_path, monkeypatch):
         reasoning=None,
         web_search=False,
         diagnostics=False,
+        mapping_sets=[],
     )
 
     async def fake_process_service(self, service, prompt=None):
@@ -657,6 +666,7 @@ def test_cli_resume_skips_processed(tmp_path, monkeypatch):
         reasoning=None,
         web_search=False,
         diagnostics=False,
+        mapping_sets=[],
     )
 
     processed: list[str] = []
@@ -728,6 +738,7 @@ def test_cli_validate_only(tmp_path, monkeypatch):
         models=None,
         web_search=False,
         diagnostics=False,
+        mapping_sets=[],
     )
 
     monkeypatch.setattr(cli, "load_settings", lambda: settings)
@@ -767,6 +778,7 @@ def test_cli_flag_overrides_settings(monkeypatch, tmp_path):
         reasoning=None,
         web_search=False,
         diagnostics=False,
+        mapping_sets=[],
     )
     captured: dict[str, object] = {}
 

--- a/tests/test_cli_generate_evolution.py
+++ b/tests/test_cli_generate_evolution.py
@@ -91,6 +91,7 @@ def test_generate_evolution_writes_results(tmp_path, monkeypatch) -> None:
         diagnostics=False,
         strict_mapping=False,
         mapping_data_dir="data",
+        mapping_sets=[],
     )
     args = argparse.Namespace(
         input_file=str(input_path),
@@ -178,6 +179,7 @@ def test_generate_evolution_dry_run(tmp_path, monkeypatch) -> None:
         diagnostics=False,
         strict_mapping=False,
         mapping_data_dir="data",
+        mapping_sets=[],
     )
     args = argparse.Namespace(
         input_file=str(input_path),
@@ -285,6 +287,7 @@ def test_generate_evolution_resume(tmp_path, monkeypatch) -> None:
         diagnostics=False,
         strict_mapping=False,
         mapping_data_dir="data",
+        mapping_sets=[],
     )
     args = argparse.Namespace(
         input_file=str(input_path),
@@ -369,6 +372,7 @@ def test_generate_evolution_rejects_invalid_concurrency(tmp_path, monkeypatch) -
         diagnostics=False,
         strict_mapping=False,
         mapping_data_dir="data",
+        mapping_sets=[],
     )
     args = argparse.Namespace(
         input_file=str(input_path),
@@ -417,7 +421,7 @@ def test_cli_parses_mapping_options(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(
         cli,
         "load_settings",
-        lambda: SimpleNamespace(log_level="INFO", logfire_token=None),
+        lambda: SimpleNamespace(log_level="INFO", logfire_token=None, mapping_sets=[]),
     )
     monkeypatch.setattr("cli.logfire.force_flush", lambda: None)
 
@@ -507,6 +511,7 @@ def test_generate_evolution_writes_transcripts(tmp_path, monkeypatch) -> None:
         diagnostics=False,
         strict_mapping=False,
         mapping_data_dir="data",
+        mapping_sets=[],
     )
     args = argparse.Namespace(
         input_file=str(input_path),

--- a/tests/test_cli_generate_mapping.py
+++ b/tests/test_cli_generate_mapping.py
@@ -67,6 +67,7 @@ def test_generate_mapping_maps_features(tmp_path, monkeypatch) -> None:
         diagnostics=False,
         strict_mapping=False,
         mapping_data_dir="data",
+        mapping_sets=[],
         web_search=False,
         reasoning=None,
     )

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from loader import load_mapping_items
+from models import MappingSet
 
 
 def test_load_mapping_items_missing_dir(tmp_path: Path) -> None:
@@ -11,7 +12,7 @@ def test_load_mapping_items_missing_dir(tmp_path: Path) -> None:
 
     missing = tmp_path / "missing"
     with pytest.raises(FileNotFoundError):
-        load_mapping_items(missing)
+        load_mapping_items(missing, [])
 
 
 def test_load_mapping_items_sorted(tmp_path: Path) -> None:
@@ -26,7 +27,8 @@ def test_load_mapping_items_sorted(tmp_path: Path) -> None:
     ]
     (data_dir / "applications.json").write_text(json.dumps(items), encoding="utf-8")
 
-    result = load_mapping_items(data_dir)
+    sets = [MappingSet(name="Apps", file="applications.json", field="applications")]
+    result = load_mapping_items(data_dir, sets)
 
     ids = [item.id for item in result["applications"]]
     names = [item.name for item in result["applications"]]


### PR DESCRIPTION
## Summary
- support mapping sets defined in config
- load mapping sets into settings and plateau generator
- cover dynamic mapping sets in tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: async def functions are not natively supported; FileNotFoundError; ModuleNotFoundError: tiktoken)*

------
https://chatgpt.com/codex/tasks/task_e_68aa38005794832b90ad82b1173a3a5c