### PR TITLE
Add MIT licensing to project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Service Ambitions contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -333,6 +333,10 @@ bandit -r src -ll
 pip-audit
 ```
 
+## License
+
+This project is licensed under the [MIT License](LICENSE).
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines and mandatory

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -139,3 +139,7 @@ mypy .
 bandit -r src -ll
 pip-audit
 ```
+
+---
+
+This documentation is licensed under the [MIT License](../LICENSE).

--- a/docs/generate-mapping.md
+++ b/docs/generate-mapping.md
@@ -56,3 +56,7 @@ to also receive a `rationale` explaining each match.
 - Ensure `OPENAI_API_KEY` is set and valid.
 - Use `--dry-run` to validate input files without making API calls.
 - Check network access and API quotas if mapping requests fail repeatedly.
+
+---
+
+This documentation is licensed under the [MIT License](../LICENSE).

--- a/docs/sd01-flow-of-evolution-prompts.md
+++ b/docs/sd01-flow-of-evolution-prompts.md
@@ -246,3 +246,7 @@ Generate service features for the Learning & Teaching service at plateau 4 using
 ### Mapping Prompt
 Map features produced for plateau 4 using the same Data, Applications and Technologies lists, instructions and schema as Stage 5.
 
+
+---
+
+This documentation is licensed under the [MIT License](../LICENSE).

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Wrapper script for the service ambitions CLI."""
 
 from cli import main

--- a/src/canonical.py
+++ b/src/canonical.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Utilities for deterministic serialisation of service records."""
 
 from __future__ import annotations

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Command-line interface for generating service ambitions and evolutions."""
 
 from __future__ import annotations

--- a/src/conversation.py
+++ b/src/conversation.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Conversational session wrapper for LLM interactions.
 
 This module exposes :class:`ConversationSession`, a light abstraction over a

--- a/src/diagnostics.py
+++ b/src/diagnostics.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Helpers for validating generated output files."""
 
 from __future__ import annotations

--- a/src/generator.py
+++ b/src/generator.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Async ambition generation using Pydantic AI.
 
 This module orchestrates concurrent requests to an LLM and streams the

--- a/src/loader.py
+++ b/src/loader.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Utilities for loading prompts, configuration and reference data.
 
 The helpers in this module centralise file-system access for prompt templates,

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Utilities for enriching plateau features with mapping data.
 
 Mapping information such as related applications or technologies is gathered by

--- a/src/mapping_prompt.py
+++ b/src/mapping_prompt.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Prompt rendering utilities for feature mappings.
 
 This module provides deterministic formatting for mapping prompts to ensure

--- a/src/model_factory.py
+++ b/src/model_factory.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Factory for constructing stage-specific OpenAI models."""
 
 from __future__ import annotations

--- a/src/models.py
+++ b/src/models.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Pydantic models describing service inputs, evaluation outputs, and configuration.
 
 These definitions act as the contract between the command-line interface, the

--- a/src/monitoring.py
+++ b/src/monitoring.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Helpers for enabling Pydantic Logfire telemetry.
 
 Logfire operates locally without an API token; the token is only required for

--- a/src/persistence.py
+++ b/src/persistence.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Utilities for safe, resumable file writes.
 
 This module centralises helper functions used to atomically update output files

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Plateau feature generation and service evolution utilities.
 
 The :class:`PlateauGenerator` coordinates prompt construction, model

--- a/src/quarantine.py
+++ b/src/quarantine.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Utilities for writing quarantined payloads."""
 
 from __future__ import annotations

--- a/src/redaction.py
+++ b/src/redaction.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Utility helpers for sanitising sensitive data in logs."""
 
 from __future__ import annotations

--- a/src/schema_migration.py
+++ b/src/schema_migration.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Schema version migration utilities."""
 
 from __future__ import annotations

--- a/src/service_loader.py
+++ b/src/service_loader.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Iterators for service definition files.
 
 This module provides :class:`ServiceLoader` and :func:`load_services` for

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Centralised application configuration management.
 
 This module exposes :class:`Settings`, a ``pydantic-settings`` model that

--- a/src/telemetry.py
+++ b/src/telemetry.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Aggregate mapping metrics for end-of-run reporting."""
 
 from __future__ import annotations

--- a/src/token_utils.py
+++ b/src/token_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Utility helpers for estimating token usage and cost.
 
 This module exposes :func:`estimate_tokens`, which uses ``tiktoken`` when

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Test configuration for service-ambitions.
 
 Ensures OpenAI calls are stubbed and a deterministic API key is present.

--- a/tests/test_async_processing.py
+++ b/tests/test_async_processing.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 import asyncio
 import json
 import sys

--- a/tests/test_build_model.py
+++ b/tests/test_build_model.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Tests for ``build_model`` utility."""
 
 from generator import build_model

--- a/tests/test_canonical.py
+++ b/tests/test_canonical.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Tests for canonicalise_record helper."""
 
 from canonical import canonicalise_record

--- a/tests/test_cli_modes.py
+++ b/tests/test_cli_modes.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Integration tests for CLI subcommands."""
 
 import sys

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Unit tests for the :mod:`conversation` module."""
 
 import json

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 from pathlib import Path
 
 import pytest

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 import asyncio
 from types import SimpleNamespace
 

--- a/tests/test_golden_output.py
+++ b/tests/test_golden_output.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Verify generator output against a locked golden file."""
 
 from __future__ import annotations

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Integration test for four-plateau service evolution."""
 
 import json

--- a/tests/test_load_definitions.py
+++ b/tests/test_load_definitions.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Tests for :func:`loader.load_definitions`."""
 
 from __future__ import annotations

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 import json
 from pathlib import Path
 

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 import sys
 from pathlib import Path
 

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 import json
 from pathlib import Path
 from typing import Any, Sequence, cast

--- a/tests/test_mapping_prompt.py
+++ b/tests/test_mapping_prompt.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Tests for prompt rendering utilities."""
 
 from __future__ import annotations

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 from model_factory import ModelFactory
 from models import StageModels
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Unit tests for Pydantic models."""
 
 import sys

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 import sys
 from types import SimpleNamespace
 

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Tests for plateau feature generation."""
 
 import asyncio

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Tests for the :mod:`redaction` helpers."""
 
 from redaction import redact_pii

--- a/tests/test_roundtrip_models.py
+++ b/tests/test_roundtrip_models.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Property-based tests ensuring schema round-trips preserve data."""
 
 from __future__ import annotations

--- a/tests/test_sample_services.py
+++ b/tests/test_sample_services.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 import json
 from pathlib import Path
 

--- a/tests/test_schema_migration.py
+++ b/tests/test_schema_migration.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Tests for schema migration utilities."""
 
 import pytest

--- a/tests/test_serviceinput_hypothesis.py
+++ b/tests/test_serviceinput_hypothesis.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Property-based tests for ServiceInput model."""
 
 import pytest

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Tests for configuration loading."""
 
 import sys

--- a/tests/test_small_mapping.py
+++ b/tests/test_small_mapping.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 import asyncio
 import json
 from pathlib import Path

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 from __future__ import annotations
 
 import sys

--- a/tests/test_token_utils.py
+++ b/tests/test_token_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Tests for the :mod:`token_utils` module."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- add MIT License file and reference in documentation
- annotate all Python files with SPDX license headers
- note licensing in existing docs

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`


------
https://chatgpt.com/codex/tasks/task_e_68aa646b6f54832b953a4389f925009d