### PR TITLE
chore: configure JetBrains copyright plugin

### DIFF
--- a/.idea/copyright/MIT.xml
+++ b/.idea/copyright/MIT.xml
@@ -1,0 +1,8 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="myName" value="MIT License" />
+    <option name="keyword" value="Copyright" />
+    <option name="allowReplace" value="true" />
+    <option name="notice" value="Copyright (c) $today.year$ Service Ambitions contributors&#10;&#10;Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:&#10;&#10;The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.&#10;&#10;THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE." />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+  <settings default="MIT License">
+    <module2copyright>
+      <element module="All" copyright="MIT License" />
+    </module2copyright>
+  </settings>
+</component>

--- a/.idea/fileTemplates/includes/File Header.py
+++ b/.idea/fileTemplates/includes/File Header.py
@@ -1,0 +1,5 @@
+# Copyright (c) ${YEAR} Service Ambitions contributors
+#
+# This source code is licensed under the MIT License found in the
+# LICENSE file in the root directory of this source tree.
+#


### PR DESCRIPTION
## Summary
- add MIT License copyright profile for JetBrains IDE
- include file header template referencing MIT license

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest -q` *(fails: 32 failed, 84 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa668c76f0832b91becb653ba6d39f