### PR TITLE
chore: share additional ide settings

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <option name="RIGHT_MARGIN" value="88" />
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Project" />
   </state>
 </component>

--- a/.idea/copyright/MIT.xml
+++ b/.idea/copyright/MIT.xml
@@ -1,0 +1,8 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="myName" value="MIT License" />
+    <option name="keyword" value="Copyright" />
+    <option name="allowReplace" value="true" />
+    <option name="notice" value="Copyright (c) $today.year$ Service Ambitions contributors&#10;&#10;Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:&#10;&#10;The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.&#10;&#10;THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE." />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+  <settings default="MIT License">
+    <module2copyright>
+      <element module="All" copyright="MIT License" />
+    </module2copyright>
+  </settings>
+</component>

--- a/.idea/fileTemplates/includes/File Header.py
+++ b/.idea/fileTemplates/includes/File Header.py
@@ -1,0 +1,5 @@
+# Copyright (c) ${YEAR} Service Ambitions contributors
+#
+# This source code is licensed under the MIT License found in the
+# LICENSE file in the root directory of this source tree.
+#

--- a/.idea/fileTemplates/internal/Python Script.py
+++ b/.idea/fileTemplates/internal/Python Script.py
@@ -1,0 +1,5 @@
+#parse("File Header.py")
+
+"""${NAME}"""
+
+$END$

--- a/.idea/fileTemplates/internal/Python Unit Test.py
+++ b/.idea/fileTemplates/internal/Python Unit Test.py
@@ -1,0 +1,14 @@
+#parse("File Header.py")
+
+import unittest
+
+
+class ${NAME}(unittest.TestCase):
+    """Test cases for ${NAME}"""
+
+    def test_example(self):
+        self.fail("Not implemented")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,5 +2,7 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="TsLint" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyPep8Inspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyBroadExceptionInspection" enabled="true" level="WARNING" enabled_by_default="true" />
   </profile>
 </component>

--- a/.idea/runConfigurations/pytest.xml
+++ b/.idea/runConfigurations/pytest.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="pytest" type="tests" factoryName="py.test">
+    <module name="service-ambitions" />
+    <option name="ENV_FILES" value="$PROJECT_DIR$/.env" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Poetry (service-ambitions)" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="SCRIPT_NAME" value="" />
+    <option name="PARAMETERS" value="" />
+    <option name="TEST_TYPE" value="TEST_SCRIPT" />
+    <option name="PATTERN" value="" />
+    <option name="USE_PATTERN" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/scopes/Production.xml
+++ b/.idea/scopes/Production.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="DependencyValidationManager">
+  <scope name="Production" pattern="file[service-ambitions]:src//*&&!file[service-ambitions]:tests//*" />
+</component>

--- a/.idea/templates/Python.xml
+++ b/.idea/templates/Python.xml
@@ -1,0 +1,7 @@
+<templateSet group="project">
+  <template name="log" value="logger.debug(\"$END$\")" description="Insert debug log" toReformat="true" toShortenFQNames="true">
+    <context>
+      <option name="PYTHON" value="true" />
+    </context>
+  </template>
+</templateSet>

--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="FileWatcherManager">
+    <option name="tasks">
+      <FileWatcherTask>
+        <option name="name" value="Black" />
+        <option name="description" value="Format Python files with Black" />
+        <option name="program" value="poetry" />
+        <option name="arguments" value="run black --preview --enable-unstable-feature string_processing $FilePath$" />
+        <option name="workingDir" value="$ProjectFileDir$" />
+        <option name="trigger" value="ON_SAVE" />
+      </FileWatcherTask>
+      <FileWatcherTask>
+        <option name="name" value="Ruff" />
+        <option name="description" value="Run Ruff linter" />
+        <option name="program" value="poetry" />
+        <option name="arguments" value="run ruff check --fix $FilePath$" />
+        <option name="workingDir" value="$ProjectFileDir$" />
+        <option name="trigger" value="ON_SAVE" />
+      </FileWatcherTask>
+    </option>
+  </component>
+</project>


### PR DESCRIPTION
## Summary
- configure project code style with 88-character margin
- add pytest run configuration, file watcher, scope, and live template
- document python inspections in shared profile
- add velocity templates for Python script and unit test

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing --exclude '/\.idea/' .`
- `poetry run ruff check --fix . --exclude .idea`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest -q` *(fails: unsupported operand types for /, async not supported, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aa668c76f0832b91becb653ba6d39f