### PR TITLE
Add editor configuration for IDE support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs.
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{json,yml,yaml,md}]
+indent_style = space
+indent_size = 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,20 @@
-{}
+{
+  "python.defaultInterpreterPath": ".venv/bin/python",
+  "python.formatting.provider": "black",
+  "python.formatting.blackArgs": [
+    "--preview",
+    "--enable-unstable-feature",
+    "string_processing"
+  ],
+  "python.linting.ruffEnabled": true,
+  "python.linting.mypyEnabled": true,
+  "python.linting.banditEnabled": true,
+  "python.testing.pytestEnabled": true,
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -313,6 +313,13 @@ Map each feature to relevant Applications from the list below.
 
 Repeat this structure for the `technologies` and `information` datasets. Run with `--diagnostics` to additionally request a one-line rationale for each mapping.
 
+## IDE support
+
+The repository includes an `.editorconfig` file and default VS Code settings.
+Opening the workspace in VS Code enables format-on-save with Black, import
+sorting and linting via Ruff, plus Mypy and Bandit checks. Editors that support
+EditorConfig will automatically apply the same indentation and newline rules.
+
 ## Testing
 
 Run the following checks before committing:


### PR DESCRIPTION
## Summary
- provide project-wide `.editorconfig` for consistent whitespace and newlines
- configure VS Code for Black formatting, Ruff linting, and test discovery
- document IDE setup in README

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing --extend-exclude ".idea" .`
- `poetry run ruff check --fix --extend-exclude ".idea" .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: 24 failed, 92 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68aa7c7bdcc4832b8c1ff7d99106882a