### PR TITLE
fix: add transcripts dir to validate subcommand

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -788,6 +788,7 @@ def main() -> None:
         default="ambitions.jsonl",
         help=OUTPUT_FILE_HELP,
     )
+    val_p.add_argument("--transcripts-dir", help=TRANSCRIPTS_HELP)
     val_p.set_defaults(func=_cmd_validate)
 
     args = parser.parse_args()

--- a/tests/test_cli_modes.py
+++ b/tests/test_cli_modes.py
@@ -76,3 +76,5 @@ def test_validate_sets_dry_run(monkeypatch):
     cli.main()
 
     assert called["args"].dry_run is True
+    assert hasattr(called["args"], "transcripts_dir")
+    assert called["args"].transcripts_dir is None


### PR DESCRIPTION
## Summary
- ensure `validate` subcommand accepts `--transcripts-dir` like other modes
- test that validate exposes a `transcripts_dir` attribute

## Testing
- `./run.sh validate --dry-run`
- `poetry run black --preview --enable-unstable-feature string_processing .` (fails: Cannot parse for target version Python 3.13: .idea/fileTemplates/internal/Python Unit Test.py)
- `poetry run black --preview --enable-unstable-feature string_processing src tests`
- `poetry run ruff check --fix .` (fails: invalid-syntax: Got unexpected token $ --> .idea/fileTemplates/internal/Python Script.py:5:1)
- `poetry run ruff check --fix src tests`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` (fails: 24 failed, 92 passed, 13 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68aa90f9e46c832ba8121e476116fa73