### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Report suspected security vulnerabilities using GitHub's private security advisories or by emailing security@example.com. Include details to help us reproduce and assess the issue.
+
+## Response Expectations
+
+- **Acknowledgement:** within 2 business days.
+- **Initial assessment:** within 7 days of acknowledgement.
+- **Fix:** within 30 days, depending on severity and complexity.
+
+Please follow responsible disclosure practices and avoid public disclosure until a fix is available.


### PR DESCRIPTION
## Summary
- add SECURITY.md with vulnerability reporting instructions and response timelines
- expose file for GitHub's security policy link

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing . --exclude ".idea/fileTemplates/internal"`
- `poetry run ruff check --fix . --exclude ".idea/fileTemplates/internal"`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: 25 failed, 91 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68aa95722308832b94141fe4039e54d8