### PR TITLE
Add CODEOWNERS for core paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# This CODEOWNERS file designates reviewers for key repository paths.
+# Learn more: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @repo-maintainers
+
+/src/ @engineering-team
+/tests/ @qa-team
+/docs/ @documentation-team


### PR DESCRIPTION
## Summary
- define teams responsible for src, tests and docs via CODEOWNERS
- attempt to require CODEOWNERS review via branch protection rules

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing . --extend-exclude '/\.idea/'`
- `poetry run ruff check --fix . --extend-exclude '.idea'`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: 16 failed, 100 passed)*
- `gh api repos/OWNER/REPO/branches/main/protection --method PUT -f required_pull_request_reviews='{"require_code_owner_reviews":true}'` *(fails: Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9587e264832bb272a9fd00c0451f