### PR TITLE
ci: test across Python 3.11-3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,18 +8,21 @@ on:
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python-version }}
       - name: Install Poetry
         run: pip install poetry
       - name: Cache Poetry
         uses: actions/cache@v4
         with:
           path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          key: ${{ runner.os }}-poetry-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
         run: poetry install --no-root --with dev
       - name: Check formatting


### PR DESCRIPTION
## Summary
- run CI against Python 3.11–3.13
- differentiate Poetry cache by Python version

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest -q -n auto` *(fails: test_service_span_records_metrics, test_run_one_counters_failure, test_valid_fixture_parses, test_service_evolution_across_four_plateaus, test_build_model_enables_web_search_when_requested, test_generate_async_saves_transcripts, test_request_description_invalid_json, test_request_descriptions_returns_mapping, test_generate_service_evolution_filters, test_generate_service_evolution_deduplicates_features, test_run_one_counters_success, test_mapping_run_matches_golden, test_default_mode_quarantines_unknown_ids, test_strict_mapping_raises_on_unknown_ids, test_load_settings_reads_env)*

------
https://chatgpt.com/codex/tasks/task_e_68aa95b4161c832bb8433f6edbd92dd9