### PR TITLE
chore: enable Dependabot for CI tooling and container images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- extend Dependabot config with weekly GitHub Actions updates
- extend Dependabot config with weekly Docker image updates

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing --exclude \.idea .`
- `poetry run ruff check --fix --exclude .idea .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: FileNotFoundError, assertion errors, AttributeError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68aa95bc5bd4832b988323f403020a2d