### PR TITLE
refactor: support evolution generation roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,16 +109,16 @@ Run the CLI through Poetry to ensure it uses the managed environment. Use
 subcommands to select the desired operation:
 
 ```bash
-poetry run service-ambitions run --input-file sample-services.jsonl --output-file ambitions.jsonl --no-logs
-poetry run service-ambitions diagnose --input-file sample-services.jsonl --output-file ambitions.jsonl --no-logs
+poetry run service-ambitions run --input-file sample-services.jsonl --output-file evolutions.jsonl --no-logs
+poetry run service-ambitions diagnose --input-file sample-services.jsonl --output-file evolutions.jsonl --no-logs
 poetry run service-ambitions validate --input-file sample-services.jsonl --no-logs
 ```
 
 Alternatively, use the provided shell script which forwards all arguments to the CLI:
 
 ```bash
-./run.sh run --input-file sample-services.jsonl --output-file ambitions.jsonl --no-logs
-./run.sh diagnose --input-file sample-services.jsonl --output-file ambitions.jsonl --no-logs
+./run.sh run --input-file sample-services.jsonl --output-file evolutions.jsonl --no-logs
+./run.sh diagnose --input-file sample-services.jsonl --output-file evolutions.jsonl --no-logs
 ./run.sh validate --input-file sample-services.jsonl --no-logs
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "service-ambitions"
 version = "0.1.0"
-description = "Command-line tool for generating service ambitions using a chat model."
+description = "Command-line tool for generating service evolutions using a chat model."
 readme = "README.md"
 authors = [
     { name = "Jolyon Suthers", email = "201621+fenrick@users.noreply.github.com" }

--- a/tests/test_cli_modes.py
+++ b/tests/test_cli_modes.py
@@ -27,7 +27,7 @@ def test_run_invokes_generator(monkeypatch):
         called["args"] = args
         called["settings"] = settings
 
-    monkeypatch.setattr(cli, "_cmd_generate_ambitions", fake_generate)
+    monkeypatch.setattr(cli, "_cmd_generate_evolution", fake_generate)
     monkeypatch.setattr(cli, "load_settings", _prepare_settings)
     monkeypatch.setattr(cli, "_configure_logging", lambda *a, **k: None)
     monkeypatch.setattr(sys, "argv", ["main", "run", "--dry-run", "--no-logs"])
@@ -47,7 +47,7 @@ def test_diagnose_enables_diagnostics(monkeypatch):
         called["args"] = args
         called["settings"] = settings
 
-    monkeypatch.setattr(cli, "_cmd_generate_ambitions", fake_generate)
+    monkeypatch.setattr(cli, "_cmd_generate_evolution", fake_generate)
     monkeypatch.setattr(cli, "load_settings", _prepare_settings)
     monkeypatch.setattr(cli, "_configure_logging", lambda *a, **k: None)
     monkeypatch.setattr(sys, "argv", ["main", "diagnose", "--dry-run", "--no-logs"])
@@ -68,7 +68,7 @@ def test_validate_sets_dry_run(monkeypatch):
         called["args"] = args
         called["settings"] = settings
 
-    monkeypatch.setattr(cli, "_cmd_generate_ambitions", fake_generate)
+    monkeypatch.setattr(cli, "_cmd_generate_evolution", fake_generate)
     monkeypatch.setattr(cli, "load_settings", _prepare_settings)
     monkeypatch.setattr(cli, "_configure_logging", lambda *a, **k: None)
     monkeypatch.setattr(sys, "argv", ["main", "validate", "--no-logs"])


### PR DESCRIPTION
## Summary
- route run/diagnose/validate commands to evolution generator
- accept role IDs via new --roles-file option
- update CLI help and output defaults for evolution workflow
- remove obsolete ambition generator and align docs and tests with evolution terminology
- drop unused mapping and JSONL migration CLI handlers

## Testing
- ⚠️ `poetry run black --preview --enable-unstable-feature string_processing .` (cannot parse .idea templates)
- ✅ `poetry run black --preview --enable-unstable-feature string_processing --exclude '/\.idea/' .`
- ⚠️ `poetry run ruff check --fix .` (parse errors in .idea templates)
- ✅ `poetry run ruff check --fix --exclude .idea .`
- ✅ `poetry run mypy .`
- ✅ `poetry run bandit -r src -ll`
- ✅ `poetry run pip-audit`
- ❌ `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aab4f47f00832ba6c025561d340b24