### PR TITLE
Fix datetime serialization errors

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -260,7 +260,7 @@ async def _generate_evolution_for_service(
             evolution = await generator.generate_service_evolution_async(
                 service, transcripts_dir=transcripts_dir, meta=_RUN_META
             )
-            record = canonicalise_record(evolution.model_dump(mode="python"))
+            record = canonicalise_record(evolution.model_dump(mode="json"))
             line = json.dumps(
                 record, separators=(",", ":"), ensure_ascii=False, sort_keys=True
             )

--- a/src/generator.py
+++ b/src/generator.py
@@ -281,7 +281,7 @@ class ServiceAmbitionGenerator:
 
         if payload is not None:
             record = canonicalise_record(
-                AmbitionModel.model_validate(payload).model_dump(mode="python")
+                AmbitionModel.model_validate(payload).model_dump(mode="json")
             )
             line = json.dumps(
                 record, separators=(",", ":"), ensure_ascii=False, sort_keys=True

--- a/tests/test_canonical.py
+++ b/tests/test_canonical.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: MIT
 """Tests for canonicalise_record helper."""
 
+import json
+from datetime import datetime, timezone
+
 from canonical import canonicalise_record
+from models import ServiceMeta
 
 
 def test_canonicalise_record_sorts_features_and_mappings() -> None:
@@ -49,3 +53,11 @@ def test_canonicalise_record_sorts_features_and_mappings() -> None:
     assert result["meta"]["context_window"] == 0
     assert result["meta"]["diagnostics"] is False
     assert result["meta"]["catalogue_hash"] == ""
+
+
+def test_canonicalise_record_handles_datetime() -> None:
+    meta = ServiceMeta(run_id="r1", created=datetime(2024, 1, 1, tzinfo=timezone.utc))
+    record = {"meta": meta.model_dump(mode="json")}
+    canonical = canonicalise_record(record)
+    assert isinstance(canonical["meta"]["created"], str)
+    json.dumps(canonical, separators=(",", ":"), sort_keys=True)


### PR DESCRIPTION
## Summary
- serialize datetimes by dumping models in JSON mode
- test canonicalise_record handles ISO datetimes

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: FileNotFoundError, AssertionError, AttributeError, ValueError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ac68e7a298832ba84ff3eb76711c32