### PR TITLE
feat: embed mapping data as json

### DIFF
--- a/prompts/mapping_prompt.md
+++ b/prompts/mapping_prompt.md
@@ -2,8 +2,8 @@
 
 Map each feature to relevant {mapping_labels} from the lists below.
 
-Lists use a compact tab-separated layout:
-`ID\tname\tdescription`.
+Lists are provided as JSON arrays in code blocks.
+Each object contains `id`, `name`, and `description` fields.
 
 {mapping_sections}
 

--- a/prompts/mapping_prompt_diagnostics.md
+++ b/prompts/mapping_prompt_diagnostics.md
@@ -2,8 +2,8 @@
 
 Map each feature to relevant {mapping_labels} from the lists below.
 
-Lists use a compact tab-separated layout:
-`ID\tname\tdescription`.
+Lists are provided as JSON arrays in code blocks.
+Each object contains `id`, `name`, and `description` fields.
 
 {mapping_sections}
 


### PR DESCRIPTION
## Summary
- render mapping catalogue items and features as JSON arrays
- wrap mapping data in `json` code blocks to emphasise identifiers
- adjust tests to validate JSON-based prompt content

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing . --extend-exclude \.idea`
- `poetry run ruff check --fix . --extend-exclude \.idea`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: FileNotFoundError, AttributeError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68acfb7cad10832bbd8d154b94efc2b5