### PR TITLE
feat(cli): add cache configuration arguments

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -525,9 +525,30 @@ def main() -> None:
     )
     common.add_argument(
         "--use-local-cache",
-        default=True,
-        action="store_true",
-        help="Cache mapping responses under .cache/mapping for offline runs",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "Enable reading/writing the cache directory for mapping results. "
+            "When disabled, cache options are ignored"
+        ),
+    )
+    common.add_argument(
+        "--cache-mode",
+        choices=("off", "read", "refresh", "write"),
+        default="off",
+        help=(
+            "Caching behaviour: 'off' disables caching, 'read' uses existing "
+            "entries without writing, 'refresh' refetches and overwrites "
+            "cache entries, and 'write' reads and writes to the cache"
+        ),
+    )
+    common.add_argument(
+        "--cache-dir",
+        default=".cache",
+        help=(
+            "Directory to store cache files; defaults to '.cache' in the "
+            "current working directory"
+        ),
     )
 
     subparsers = parser.add_subparsers(dest="command", required=True)

--- a/tests/test_cli_modes.py
+++ b/tests/test_cli_modes.py
@@ -78,3 +78,59 @@ def test_validate_sets_dry_run(monkeypatch):
     assert called["args"].dry_run is True
     assert hasattr(called["args"], "transcripts_dir")
     assert called["args"].transcripts_dir is None
+
+
+def test_cache_args_defaults(monkeypatch):
+    """Cache CLI options default to disabled caching."""
+
+    called = {}
+
+    async def fake_generate(args, settings, transcripts_dir):
+        called["args"] = args
+
+    monkeypatch.setattr(cli, "_cmd_generate_evolution", fake_generate)
+    monkeypatch.setattr(cli, "load_settings", _prepare_settings)
+    monkeypatch.setattr(cli, "_configure_logging", lambda *a, **k: None)
+    monkeypatch.setattr(sys, "argv", ["main", "run", "--dry-run", "--no-logs"])
+
+    cli.main()
+
+    args = called["args"]
+    assert args.use_local_cache is False
+    assert args.cache_mode == "off"
+    assert args.cache_dir == ".cache"
+
+
+def test_cache_args_custom(monkeypatch):
+    """Custom cache options propagate to runtime."""
+
+    called = {}
+
+    async def fake_generate(args, settings, transcripts_dir):
+        called["args"] = args
+
+    monkeypatch.setattr(cli, "_cmd_generate_evolution", fake_generate)
+    monkeypatch.setattr(cli, "load_settings", _prepare_settings)
+    monkeypatch.setattr(cli, "_configure_logging", lambda *a, **k: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "main",
+            "run",
+            "--dry-run",
+            "--no-logs",
+            "--use-local-cache",
+            "--cache-mode",
+            "write",
+            "--cache-dir",
+            "/tmp/cache",
+        ],
+    )
+
+    cli.main()
+
+    args = called["args"]
+    assert args.use_local_cache is True
+    assert args.cache_mode == "write"
+    assert args.cache_dir == "/tmp/cache"


### PR DESCRIPTION
## Summary
- allow toggling and configuring cache via `--use-local-cache`, `--cache-mode` and `--cache-dir`
- document cache behaviours in CLI help
- test cache argument defaults and overrides

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing src tests`
- `poetry run ruff check --fix src tests`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest -q` *(fails: FileNotFoundError, AssertionError, ValueError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0dcf8908832b85140e63ddc20896