### PR TITLE
feat: add e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,22 @@
+name: E2E
+
+on:
+  pull_request:
+    branches: [main]
+    types: [labeled, synchronize]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-e2e') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - run: echo "Running heavy E2E..."


### PR DESCRIPTION
## Summary
- add e2e workflow triggered on `run-e2e` labeled PRs or manual dispatch
- gate job on label, checkout repository, and run placeholder E2E command
- ensure only one E2E run per PR with concurrency guard

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing . --exclude '\.idea'`
- `poetry run ruff check --fix . --exclude .idea`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest -q` *(fails: file not found, assertion mismatches, unknown plateau, and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0e56fe84832ba8f87ea699b8575e