### PR TITLE
ci: add docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,32 @@
+name: Docs
+
+on:
+  push:
+    paths:
+      - 'docs/**'
+      - '**/*.md'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '**/*.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions: read-all
+    steps:
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs
+      - name: Build documentation site
+        run: mkdocs build --strict


### PR DESCRIPTION
## Summary
- build documentation in dedicated workflow when markdown or docs change

## Testing
- `poetry run pre-commit run --files .github/workflows/docs.yml .github/workflows/ci-main.yml .github/workflows/ci-quick.yml`
- `poetry run black --preview --enable-unstable-feature string_processing .` (fails: Cannot parse .idea templates)
- `poetry run ruff check --fix .` (fails: invalid syntax in .idea templates)
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `pytest -q` (fails: ModuleNotFoundError: No module named 'logfire')

------
https://chatgpt.com/codex/tasks/task_e_68ad10fcb950832b985d3f5316f3586a