### PR TITLE
Document CI requirements and restrict doc workflow pushes

### DIFF
--- a/.github/workflows/ci-quick.yml
+++ b/.github/workflows/ci-quick.yml
@@ -1,4 +1,4 @@
-name: CI Quick
+name: CI — Quick
 
 on:
   pull_request:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,10 +2,12 @@ name: Docs
 
 on:
   push:
+    branches: [main]
     paths:
       - 'docs/**'
       - '**/*.md'
   pull_request:
+    branches: [main]
     paths:
       - 'docs/**'
       - '**/*.md'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,5 +14,11 @@ See `.pre-commit-config.yaml` for the exact tools (Black, Ruff, mypy and
 Bandit). Please ensure all checks pass and include appropriate tests and
 documentation for any new functionality.
 
+## Continuous Integration
+
+- The only required status check for merging into `main` is **CI — Quick**.
+- GitHub Actions workflows do not run on pushes to non-`main` branches; open a
+  pull request to trigger checks.
+
 All contributors are expected to follow the project's
 [Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary
- rename quick CI workflow to "CI — Quick" and limit docs workflow to main branches
- document required status check and branch push policy in contributing guide

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`


------
https://chatgpt.com/codex/tasks/task_e_68ad13fdcdbc832b9842ed129efa4bbd