### PR TITLE
feat: add cache helpers and modes for mapping

### DIFF
--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -147,7 +147,7 @@ class PlateauGenerator:
                 base,
                 service=service_name,
                 strict=self.strict,
-                use_local_cache=self.use_local_cache,
+                cache_mode=(settings.cache_mode if self.use_local_cache else "off"),
             )
             mapped_sets.append(result)
 


### PR DESCRIPTION
## Summary
- add `_cache_path` and `cache_write_json_atomic` for secured caching
- support `off`, `read`, `refresh`, and `write` cache modes in `map_set`
- adjust mapping tests for new cache semantics

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing . --exclude '/\.idea/'`
- `poetry run ruff check --fix . --exclude .idea`
- `poetry run mypy . --exclude '.idea'`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: FileNotFoundError: No such file or directory: '/tmp/.../svc-123.json' and others)*
- `poetry run pytest tests/test_mapping.py::test_map_set_writes_cache tests/test_mapping.py::test_map_set_reads_cache tests/test_mapping.py::test_map_set_bad_cache_renamed`


------
https://chatgpt.com/codex/tasks/task_e_68ad1404d0bc832bb6982e8dcd5dc823