### PR TITLE
Hash mapping catalogues for cache invalidation

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import hashlib
 import inspect
 import json
 import logging
@@ -232,16 +231,9 @@ async def _generate_evolution_for_service(
                         "search", args.search_model or args.model
                     ),
                 }
-                items = load_mapping_items(MAPPING_DATA_DIR, settings.mapping_sets)
-                serialised = json.dumps(
-                    {
-                        k: [i.model_dump(mode="json") for i in v]
-                        for k, v in items.items()
-                    },
-                    separators=(",", ":"),
-                    sort_keys=True,
+                _, catalogue_hash = load_mapping_items(
+                    MAPPING_DATA_DIR, settings.mapping_sets
                 )
-                catalogue_hash = hashlib.sha256(serialised.encode("utf-8")).hexdigest()
                 context_window = getattr(feat_model, "max_input_tokens", 0)
                 _RUN_META = ServiceMeta(
                     run_id=str(uuid4()),

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -132,7 +132,9 @@ class PlateauGenerator:
         """
 
         settings = load_settings()
-        items = load_mapping_items(MAPPING_DATA_DIR, settings.mapping_sets)
+        items, catalogue_hash = load_mapping_items(
+            MAPPING_DATA_DIR, settings.mapping_sets
+        )
         service_name = self._service.name if self._service else "unknown"
 
         base = list(features)
@@ -148,6 +150,7 @@ class PlateauGenerator:
                 service=service_name,
                 strict=self.strict,
                 cache_mode=(settings.cache_mode if self.use_local_cache else "off"),
+                catalogue_hash=catalogue_hash,
             )
             mapped_sets.append(result)
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: MIT
+import hashlib
 import json
 from pathlib import Path
 
 import pytest
 
-from loader import load_mapping_items
+from loader import compile_catalogue_for_set, load_mapping_items
 from models import MappingSet
 
 
@@ -29,9 +30,12 @@ def test_load_mapping_items_sorted(tmp_path: Path) -> None:
     (data_dir / "applications.json").write_text(json.dumps(items), encoding="utf-8")
 
     sets = [MappingSet(name="Apps", file="applications.json", field="applications")]
-    result = load_mapping_items(data_dir, sets)
+    result, catalogue_hash = load_mapping_items(data_dir, sets)
 
     ids = [item.id for item in result["applications"]]
     names = [item.name for item in result["applications"]]
     assert ids == ["1", "2", "2"]
     assert names == ["A", "B", "C"]
+    _, per_digest = compile_catalogue_for_set(result["applications"])
+    expected = hashlib.sha256(f"applications:{per_digest}".encode("utf-8")).hexdigest()
+    assert catalogue_hash == expected

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -120,7 +120,7 @@ async def test_map_features_maps_all_sets_with_full_list(monkeypatch) -> None:
     )
     monkeypatch.setattr(
         "plateau_generator.load_mapping_items",
-        lambda path, sets: {s.field: [] for s in sets},
+        lambda path, sets: ({s.field: [] for s in sets}, "hash"),
     )
     session = DummySession([])
     gen = PlateauGenerator(cast(ConversationSession, session))

--- a/tests/test_small_mapping.py
+++ b/tests/test_small_mapping.py
@@ -44,7 +44,7 @@ def test_mapping_run_matches_golden(tmp_path) -> None:
         MappingSet(name="Applications", file="applications.json", field="applications"),
         MappingSet(name="Technologies", file="technologies.json", field="technologies"),
     ]
-    items = loader.load_mapping_items(loader.MAPPING_DATA_DIR, sets)
+    items, catalogue_hash = loader.load_mapping_items(loader.MAPPING_DATA_DIR, sets)
     evolutions = _load_evolutions()
     features = [f for evo in evolutions for p in evo.plateaus for f in p.features]
     session_apps = DummySession(
@@ -65,6 +65,7 @@ def test_mapping_run_matches_golden(tmp_path) -> None:
             "applications",
             items["applications"],
             features,
+            catalogue_hash=catalogue_hash,
         )
     )
     session_tech = DummySession(
@@ -85,6 +86,7 @@ def test_mapping_run_matches_golden(tmp_path) -> None:
             "technologies",
             items["technologies"],
             mapped,
+            catalogue_hash=catalogue_hash,
         )
     )
     by_id = {f.feature_id: f for f in mapped}
@@ -108,7 +110,7 @@ def test_default_mode_quarantines_unknown_ids(monkeypatch, tmp_path) -> None:
     sets = [
         MappingSet(name="Applications", file="applications.json", field="applications")
     ]
-    items = loader.load_mapping_items(loader.MAPPING_DATA_DIR, sets)
+    items, catalogue_hash = loader.load_mapping_items(loader.MAPPING_DATA_DIR, sets)
     evolutions = _load_evolutions()
     features = [f for evo in evolutions for p in evo.plateaus for f in p.features]
     session = DummySession(
@@ -134,6 +136,7 @@ def test_default_mode_quarantines_unknown_ids(monkeypatch, tmp_path) -> None:
             "applications",
             items["applications"],
             features,
+            catalogue_hash=catalogue_hash,
         )
     )
     assert mapped[0].mappings["applications"][0].item == "app1"
@@ -151,7 +154,7 @@ def test_strict_mapping_raises_on_unknown_ids(monkeypatch, tmp_path) -> None:
     sets = [
         MappingSet(name="Applications", file="applications.json", field="applications")
     ]
-    items = loader.load_mapping_items(loader.MAPPING_DATA_DIR, sets)
+    items, catalogue_hash = loader.load_mapping_items(loader.MAPPING_DATA_DIR, sets)
     evolutions = _load_evolutions()
     features = [f for evo in evolutions for p in evo.plateaus for f in p.features]
     session = DummySession(
@@ -175,6 +178,7 @@ def test_strict_mapping_raises_on_unknown_ids(monkeypatch, tmp_path) -> None:
                 items["applications"],
                 features,
                 strict=True,
+                catalogue_hash=catalogue_hash,
             )
         )
     qfile = Path("quarantine/unknown/applications/unknown_ids_1.json")


### PR DESCRIPTION
## Summary
- add `compile_catalogue_for_set` to serialise mapping catalogues and compute a digest
- include `catalogue_hash` when loading catalogues and feed it into `map_set` cache keys
- adjust CLI, plateau generator and tests to work with the new hashing

## Testing
- `poetry run ruff check --fix src tests`
- `poetry run black --preview --enable-unstable-feature string_processing src tests`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `pytest` *(fails: ModuleNotFoundError: No module named 'logfire')*

------
https://chatgpt.com/codex/tasks/task_e_68ad1647b3b4832b92d339c01c4c25f5