### PR TITLE
feat: add prompt caching

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -197,6 +197,8 @@ async def _generate_evolution_for_service(
                 diagnostics=settings.diagnostics,
                 log_prompts=args.allow_prompt_logging,
                 transcripts_dir=transcripts_dir,
+                use_local_cache=args.use_local_cache,
+                cache_mode=args.cache_mode,
             )
             feat_session = ConversationSession(
                 feat_agent,
@@ -204,6 +206,8 @@ async def _generate_evolution_for_service(
                 diagnostics=settings.diagnostics,
                 log_prompts=args.allow_prompt_logging,
                 transcripts_dir=transcripts_dir,
+                use_local_cache=args.use_local_cache,
+                cache_mode=args.cache_mode,
             )
             map_session = ConversationSession(
                 map_agent,
@@ -211,6 +215,8 @@ async def _generate_evolution_for_service(
                 diagnostics=settings.diagnostics,
                 log_prompts=args.allow_prompt_logging,
                 transcripts_dir=transcripts_dir,
+                use_local_cache=args.use_local_cache,
+                cache_mode=args.cache_mode,
             )
             generator = PlateauGenerator(
                 feat_session,
@@ -220,6 +226,7 @@ async def _generate_evolution_for_service(
                 mapping_session=map_session,
                 strict=args.strict,
                 use_local_cache=args.use_local_cache,
+                cache_mode=args.cache_mode,
             )
             global _RUN_META
             if _RUN_META is None:


### PR DESCRIPTION
## Summary
- add cache-aware ConversationSession with atomic writes
- thread use_local_cache and cache_mode to conversations and plateau generation
- test prompt cache hits

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing --exclude '\.idea' .`
- `poetry run ruff check --fix --exclude .idea .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest`
- `poetry run pytest tests/test_conversation.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad1dd182e4832bb0628ebf5b405a94