### PR TITLE
Enable cache read mode by default

### DIFF
--- a/config/app.example.yaml
+++ b/config/app.example.yaml
@@ -60,6 +60,6 @@ request_timeout: 60         # Per-request timeout in seconds.
 retries: 5                  # Number of retry attempts.
 retry_base_delay: 0.5       # Initial backoff delay in seconds.
 features_per_role: 5        # Required number of features per role.
-use_local_cache: false      # Enable reading/writing the cache directory.
-cache_mode: "off"           # Cache behaviour: off, read, refresh or write.
+use_local_cache: true       # Enable reading/writing the cache directory.
+cache_mode: "read"          # Cache behaviour: off, read, refresh or write.
 cache_dir: .cache           # Directory to store cache files.

--- a/config/app.yaml
+++ b/config/app.yaml
@@ -58,6 +58,6 @@ request_timeout: 60         # Per-request timeout in seconds.
 retries: 5                  # Number of retry attempts.
 retry_base_delay: 0.5       # Initial backoff delay in seconds.
 features_per_role: 5        # Required number of features per role.
-use_local_cache: false      # Enable reading/writing the cache directory.
-cache_mode: "off"           # Cache behaviour: off, read, refresh or write.
+use_local_cache: true       # Enable reading/writing the cache directory.
+cache_mode: "read"          # Cache behaviour: off, read, refresh or write.
 cache_dir: .cache           # Directory to store cache files.

--- a/src/models.py
+++ b/src/models.py
@@ -437,11 +437,11 @@ class AppConfig(StrictModel):
         Field(ge=1, description="Required number of features per role."),
     ] = 5
     use_local_cache: bool = Field(
-        False,
+        True,
         description="Enable reading and writing the cache directory.",
     )
     cache_mode: Literal["off", "read", "refresh", "write"] = Field(
-        "off",
+        "read",
         description="Caching strategy applied to local cache entries.",
     )
     cache_dir: Annotated[

--- a/src/settings.py
+++ b/src/settings.py
@@ -46,10 +46,10 @@ class Settings(BaseSettings):
         5, ge=1, description="Required number of features per role."
     )
     use_local_cache: bool = Field(
-        False, description="Enable reading and writing the cache directory."
+        True, description="Enable reading and writing the cache directory."
     )
     cache_mode: Literal["off", "read", "refresh", "write"] = Field(
-        "off", description="Caching strategy for local cache entries."
+        "read", description="Caching strategy for local cache entries."
     )
     cache_dir: Path = Field(
         Path(".cache"), description="Directory to store cache files."
@@ -120,9 +120,9 @@ def load_settings() -> Settings:
             use_local_cache=(
                 env_use_local_cache.lower() in {"1", "true", "yes"}
                 if env_use_local_cache is not None
-                else getattr(config, "use_local_cache", False)
+                else getattr(config, "use_local_cache", True)
             ),
-            cache_mode=env_cache_mode or getattr(config, "cache_mode", "off"),
+            cache_mode=env_cache_mode or getattr(config, "cache_mode", "read"),
             cache_dir=(
                 Path(env_cache_dir)
                 if env_cache_dir


### PR DESCRIPTION
## Summary
- default to using the local cache in read mode for models and settings
- update example and production app configs for cache changes

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing . --exclude '/\.idea/'`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `pytest` *(fails: 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3597d42c832b83c9e8b5a3d998cd