### PR TITLE
feat(cli): default cache mode to read

### DIFF
--- a/docs/generate-mapping.md
+++ b/docs/generate-mapping.md
@@ -24,10 +24,11 @@ produces an empty list or contains unknown identifiers. Disable with
 troubleshooting. Instrumentation runs only when this verbose mode is enabled.
 Prompt text is omitted unless `--allow-prompt-logging` is supplied.
 
-`--use-local-cache` reads and writes mapping responses under `.cache/mapping` to
-avoid repeated network requests during development. `--cache-mode` controls
-how the cache is used (`off`, `read`, `refresh`, `write`) and `--cache-dir`
-sets the cache storage location.
+`--use-local-cache` reads mapping responses under `.cache/mapping` and
+optionally writes new entries to avoid repeated network requests during
+development. `--cache-mode` controls
+how the cache is used (`off`, `read`, `refresh`, `write`) with `read` as the
+default, and `--cache-dir` sets the cache storage location.
 
 Mapping runs once per configured set. Each prompt receives the relevant
 reference list—`applications`, `technologies` and `information` by default—and

--- a/src/cli.py
+++ b/src/cli.py
@@ -534,11 +534,12 @@ def main() -> None:
     common.add_argument(
         "--cache-mode",
         choices=("off", "read", "refresh", "write"),
-        default="write",
+        default="read",
         help=(
-            "Caching behaviour: 'off' disables caching, 'read' uses existing "
-            "entries without writing, 'refresh' refetches and overwrites "
-            "cache entries, and 'write' reads and writes to the cache"
+            "Caching behaviour (default 'read'): 'off' disables caching, "
+            "'read' uses existing entries without writing, 'refresh' "
+            "refetches and overwrites cache entries, and 'write' reads and "
+            "writes to the cache"
         ),
     )
     common.add_argument(

--- a/tests/test_cli_modes.py
+++ b/tests/test_cli_modes.py
@@ -81,7 +81,7 @@ def test_validate_sets_dry_run(monkeypatch):
 
 
 def test_cache_args_defaults(monkeypatch):
-    """Cache CLI options default to disabled caching."""
+    """Cache CLI options default to read-only caching."""
 
     called = {}
 
@@ -96,8 +96,8 @@ def test_cache_args_defaults(monkeypatch):
     cli.main()
 
     args = called["args"]
-    assert args.use_local_cache is False
-    assert args.cache_mode == "off"
+    assert args.use_local_cache is True
+    assert args.cache_mode == "read"
     assert args.cache_dir == ".cache"
 
 


### PR DESCRIPTION
## Summary
- default `--cache-mode` to `read`
- update cache tests and documentation for new defaults

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing . --exclude '\.idea/'`
- `poetry run ruff check --fix . --exclude .idea`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: 12 failed, 122 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad431d0e08832bb2bde686c200b6b0