### PR TITLE
test: adapt tests for caching defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ OPENAI_API_KEY=your_api_key_here
 For production deployments, inject the variable using your platform's secret
 manager instead of committing keys to source control.
 
-Caching of mapping responses is disabled by default. Configure caching in
-`config/app.yaml` or via environment variables:
+Caching of mapping responses is enabled by default in read-only mode.
+Configure caching in `config/app.yaml` or via environment variables:
 
 ```yaml
-use_local_cache: false  # Enable reading/writing the cache directory
-cache_mode: "off"       # off, read, refresh or write
-cache_dir: .cache       # Directory to store cache files
+use_local_cache: true  # Enable reading/writing the cache directory
+cache_mode: "read"     # off, read, refresh or write
+cache_dir: .cache      # Directory to store cache files
 ```
 
 The chat model can be set with the `--model` flag or the `MODEL` environment

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ def _mock_openai(monkeypatch):
     """Provide dummy credentials and block outbound OpenAI requests."""
 
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("USE_LOCAL_CACHE", "0")
     try:
         import openai
 

--- a/tests/test_cli_modes.py
+++ b/tests/test_cli_modes.py
@@ -81,7 +81,7 @@ def test_validate_sets_dry_run(monkeypatch):
 
 
 def test_cache_args_defaults(monkeypatch):
-    """Cache CLI options default to read-only caching."""
+    """Cache CLI options enable read-only caching by default."""
 
     called = {}
 

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -34,7 +34,10 @@ class DummyAgent:
 def test_add_parent_materials_records_history() -> None:
     """``add_parent_materials`` should append service info to history."""
 
-    session = ConversationSession(cast(Agent[None, str], DummyAgent()))
+    session = ConversationSession(
+        cast(Agent[None, str], DummyAgent()),
+        use_local_cache=False,
+    )
     service = ServiceInput(
         service_id="svc-1",
         name="svc",
@@ -61,7 +64,10 @@ def test_add_parent_materials_records_history() -> None:
 def test_add_parent_materials_includes_features() -> None:
     """Seed materials should list existing service features when provided."""
 
-    session = ConversationSession(cast(Agent[None, str], DummyAgent()))
+    session = ConversationSession(
+        cast(Agent[None, str], DummyAgent()),
+        use_local_cache=False,
+    )
     service = ServiceInput(
         service_id="svc-1",
         name="svc",
@@ -93,7 +99,10 @@ def test_add_parent_materials_includes_features() -> None:
 def test_ask_adds_responses_to_history() -> None:
     """``ask`` should forward prompts and store new messages."""
 
-    session = ConversationSession(cast(Agent[None, str], DummyAgent()))
+    session = ConversationSession(
+        cast(Agent[None, str], DummyAgent()),
+        use_local_cache=False,
+    )
     reply = session.ask("ping")
 
     assert reply == "pong"
@@ -103,7 +112,10 @@ def test_ask_adds_responses_to_history() -> None:
 def test_ask_forwards_prompt_to_agent() -> None:
     """``ask`` should delegate to the underlying agent."""
     agent = DummyAgent()
-    session = ConversationSession(cast(Agent[None, str], agent))
+    session = ConversationSession(
+        cast(Agent[None, str], agent),
+        use_local_cache=False,
+    )
     session.ask("hello")
     assert agent.called_with == ["hello"]
 
@@ -117,6 +129,7 @@ def test_ask_omits_prompt_logging_when_disabled(tmp_path, monkeypatch) -> None:
         diagnostics=True,
         log_prompts=False,
         transcripts_dir=tmp_path,
+        use_local_cache=False,
     )
     calls: list[str] = []
     monkeypatch.setattr(conversation.logfire, "debug", lambda msg: calls.append(msg))
@@ -134,6 +147,7 @@ def test_catalogue_strings_not_logged_by_default(monkeypatch) -> None:
         cast(Agent[None, str], agent),
         diagnostics=True,
         log_prompts=False,
+        use_local_cache=False,
     )
     logged: list[str] = []
     monkeypatch.setattr(conversation.logfire, "debug", lambda msg: logged.append(msg))
@@ -153,6 +167,7 @@ def test_diagnostics_writes_transcript(tmp_path) -> None:
         stage="stage",
         diagnostics=True,
         transcripts_dir=tmp_path,
+        use_local_cache=False,
     )
     service = ServiceInput(
         service_id="svc-1",

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -80,8 +80,8 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
     responses: list[str] = [desc_payload]
     responses += [_feature_payload(5) for _ in range(4)]
     agent = DummyAgent(responses)
-    session = ConversationSession(cast(Agent[None, str], agent))
-    generator = PlateauGenerator(session, required_count=5)
+    session = ConversationSession(cast(Agent[None, str], agent), use_local_cache=False)
+    generator = PlateauGenerator(session, required_count=5, use_local_cache=False)
 
     map_calls = {"n": 0}
 

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -683,8 +683,10 @@ def test_generate_service_evolution_filters(monkeypatch) -> None:
         def run_sync(self, prompt, message_history):
             return type("R", (), {"output": "", "new_messages": lambda: []})()
 
-    session = ConversationSession(cast(Agent[None, str], DummyAgent()))
-    generator = PlateauGenerator(session)
+    session = ConversationSession(
+        cast(Agent[None, str], DummyAgent()), use_local_cache=False
+    )
+    generator = PlateauGenerator(session, use_local_cache=False)
 
     called: list[int] = []
     sessions: set[int] = set()
@@ -758,8 +760,10 @@ def test_generate_service_evolution_invalid_role_raises(monkeypatch) -> None:
         def run_sync(self, prompt, message_history):
             return type("R", (), {"output": "", "new_messages": lambda: []})()
 
-    session = ConversationSession(cast(Agent[None, str], DummyAgent()))
-    generator = PlateauGenerator(session)
+    session = ConversationSession(
+        cast(Agent[None, str], DummyAgent()), use_local_cache=False
+    )
+    generator = PlateauGenerator(session, use_local_cache=False)
 
     async def fake_generate_plateau_async(
         self, level, plateau_name, *, session=None, description
@@ -814,8 +818,10 @@ def test_generate_service_evolution_unknown_plateau_raises(monkeypatch) -> None:
         def run_sync(self, prompt, message_history):
             return type("R", (), {"output": "", "new_messages": lambda: []})()
 
-    session = ConversationSession(cast(Agent[None, str], DummyAgent()))
-    generator = PlateauGenerator(session)
+    session = ConversationSession(
+        cast(Agent[None, str], DummyAgent()), use_local_cache=False
+    )
+    generator = PlateauGenerator(session, use_local_cache=False)
 
     async def fake_generate_plateau_async(
         self, level, plateau_name, *, session=None, description
@@ -870,8 +876,10 @@ def test_generate_service_evolution_deduplicates_features(monkeypatch) -> None:
         def run_sync(self, prompt, message_history):
             return type("R", (), {"output": "", "new_messages": lambda: []})()
 
-    session = ConversationSession(cast(Agent[None, str], DummyAgent()))
-    generator = PlateauGenerator(session)
+    session = ConversationSession(
+        cast(Agent[None, str], DummyAgent()), use_local_cache=False
+    )
+    generator = PlateauGenerator(session, use_local_cache=False)
 
     async def fake_generate_plateau_async(
         self, level, plateau_name, *, session=None, description


### PR DESCRIPTION
## Summary
- update CLI caching docs for default read mode
- disable caching globally in tests and ensure sessions opt-out
- clarify caching behaviour in cache CLI tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: tests/test_async_processing.py::test_generate_async_saves_transcripts, tests/test_async_processing.py::test_run_one_counters_success, tests/test_async_processing.py::test_run_one_counters_failure, tests/test_build_model.py::test_build_model_enables_web_search_when_requested, tests/test_generator.py::test_service_span_records_metrics, tests/test_golden_output.py::test_sample_run_matches_golden, tests/test_integration_service_evolution.py::test_service_evolution_across_four_plateaus, tests/test_loading.py::test_valid_fixture_parses, tests/test_plateau_generator.py::test_request_description_invalid_json, tests/test_plateau_generator.py::test_generate_service_evolution_filters, tests/test_plateau_generator.py::test_generate_service_evolution_deduplicates_features, tests/test_settings.py::test_load_settings_reads_env)`


------
https://chatgpt.com/codex/tasks/task_e_68ad467e90d8832bbb6a6f9be19fb625