### PR TITLE
test: expect caching enabled by default

### DIFF
--- a/tests/test_cli_modes.py
+++ b/tests/test_cli_modes.py
@@ -2,6 +2,7 @@
 """Integration tests for CLI subcommands."""
 
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import cli
@@ -15,6 +16,9 @@ def _prepare_settings():
         logfire_token=None,
         diagnostics=False,
         strict_mapping=False,
+        use_local_cache=True,
+        cache_mode="read",
+        cache_dir=Path(".cache"),
     )
 
 
@@ -87,6 +91,7 @@ def test_cache_args_defaults(monkeypatch):
 
     async def fake_generate(args, settings, transcripts_dir):
         called["args"] = args
+        called["settings"] = settings
 
     monkeypatch.setattr(cli, "_cmd_generate_evolution", fake_generate)
     monkeypatch.setattr(cli, "load_settings", _prepare_settings)
@@ -96,9 +101,13 @@ def test_cache_args_defaults(monkeypatch):
     cli.main()
 
     args = called["args"]
+    settings = called["settings"]
     assert args.use_local_cache is True
     assert args.cache_mode == "read"
     assert args.cache_dir == ".cache"
+    assert settings.use_local_cache is True
+    assert settings.cache_mode == "read"
+    assert settings.cache_dir == Path(".cache")
 
 
 def test_cache_args_custom(monkeypatch):


### PR DESCRIPTION
## Summary
- update CLI mode tests to reflect read-only caching as the default and verify settings

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing . --extend-exclude '\.idea'`
- `poetry run ruff check --fix . --extend-exclude .idea`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(failed: test_generate_async_saves_transcripts, test_run_one_counters_success, test_run_one_counters_failure, test_build_model_enables_web_search_when_requested, test_service_span_records_metrics, test_golden_output, test_service_evolution_across_four_plateaus, test_valid_fixture_parses, test_service_input_validates, test_load_settings_reads_env)*


------
https://chatgpt.com/codex/tasks/task_e_68ad4f6be2f0832b962d0a354979b2ee