### PR TITLE
Handle literal braces in mapping prompt templates

### DIFF
--- a/src/mapping_prompt.py
+++ b/src/mapping_prompt.py
@@ -92,13 +92,23 @@ def render_set_prompt(
     catalogue_lines = _render_items(items)
     feature_lines = _render_features(features)
     mapping_section = f"## Available {set_name}\n\n```json\n{catalogue_lines}\n```"
-    return instruction.format(
-        mapping_labels=set_name,
-        mapping_sections=mapping_section,
-        mapping_fields=set_name,
-        features=f"```json\n{feature_lines}\n```",
-        schema=MAPPING_DIAGNOSTICS_SCHEMA if diagnostics else MAPPING_SCHEMA,
-    )
+
+    # Manual placeholder substitution avoids ``str.format`` interpreting JSON
+    # braces within the template as formatting fields. This ensures the prompt
+    # retains literal brace characters required for example JSON structures and
+    # narrative instructions.
+    replacements = {
+        "{mapping_labels}": set_name,
+        "{mapping_sections}": mapping_section,
+        "{mapping_fields}": set_name,
+        "{features}": f"```json\n{feature_lines}\n```",
+        "{schema}": MAPPING_DIAGNOSTICS_SCHEMA if diagnostics else MAPPING_SCHEMA,
+    }
+
+    for placeholder, value in replacements.items():
+        instruction = instruction.replace(placeholder, value)
+
+    return instruction
 
 
 __all__ = ["render_set_prompt"]

--- a/tests/test_mapping_prompt.py
+++ b/tests/test_mapping_prompt.py
@@ -145,3 +145,17 @@ def test_render_set_prompt_uses_diagnostics_template(monkeypatch) -> None:
     monkeypatch.setattr("mapping_prompt.load_prompt_text", fake_load)
     render_set_prompt("test", [], [], diagnostics=True)
     assert called["name"] == "mapping_prompt_diagnostics"
+
+
+def test_render_set_prompt_handles_literal_braces(monkeypatch) -> None:
+    """Unescaped braces in templates are preserved without KeyError."""
+
+    template = (
+        "{mapping_sections}\n"
+        'Each array element must be an object with only one field: { "item": <ID> }\n'
+        "{schema}"
+    )
+    monkeypatch.setattr("mapping_prompt.load_prompt_text", lambda _n: template)
+
+    result = render_set_prompt("test", [], [])
+    assert '{ "item": <ID> }' in result


### PR DESCRIPTION
## Summary
- prevent `KeyError` when rendering mapping prompts containing JSON braces
- add regression test ensuring literal braces are preserved

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing src/mapping_prompt.py tests/test_mapping_prompt.py`
- `poetry run ruff check --fix src/mapping_prompt.py tests/test_mapping_prompt.py`
- `poetry run mypy .` *(fails: invalid-syntax due to .idea templates)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: 7 failed, 129 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68af0105bdf0832b9de36fd16245a2ab