### PR TITLE
Organize cache files by service and stage

### DIFF
--- a/docs/generate-mapping.md
+++ b/docs/generate-mapping.md
@@ -24,7 +24,7 @@ produces an empty list or contains unknown identifiers. Disable with
 troubleshooting. Instrumentation runs only when this verbose mode is enabled.
 Prompt text is omitted unless `--allow-prompt-logging` is supplied.
 
-`--use-local-cache` reads mapping responses under `.cache/mapping` and
+`--use-local-cache` reads mapping responses under `.cache/<service>/mappings` and
 optionally writes new entries to avoid repeated network requests during
 development. `--cache-mode` controls
 how the cache is used (`off`, `read`, `refresh`, `write`) with `read` as the

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -144,7 +144,7 @@ class PlateauGenerator:
         items, catalogue_hash = load_mapping_items(
             MAPPING_DATA_DIR, settings.mapping_sets
         )
-        service_name = self._service.name if self._service else "unknown"
+        service_id = self._service.service_id if self._service else "unknown"
 
         groups: dict[str, list[MappingFeatureGroup]] = {}
         for cfg in settings.mapping_sets:
@@ -155,7 +155,7 @@ class PlateauGenerator:
                 cfg.field,
                 items[cfg.field],
                 list(features),
-                service=service_name,
+                service=service_id,
                 strict=self.strict,
                 cache_mode=(self.cache_mode if self.use_local_cache else "off"),
                 catalogue_hash=catalogue_hash,

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -206,7 +206,7 @@ def test_ask_uses_cache_when_available(tmp_path, monkeypatch) -> None:
         conversation, "load_settings", lambda: SimpleNamespace(cache_dir=tmp_path)
     )
     key = conversation._prompt_cache_key("hello", "", "stage")
-    path = conversation._prompt_cache_path(key)
+    path = conversation._prompt_cache_path("unknown", "stage", key)
     path.write_text(json.dumps("cached"), encoding="utf-8")
 
     reply = session.ask("hello")

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -308,7 +308,7 @@ async def test_map_set_writes_cache(monkeypatch, tmp_path) -> None:
         [_feature()],
         cache_mode="read",
     )
-    cache_file = Path(".cache") / "mapping" / "applications" / "key.json"
+    cache_file = Path(".cache") / "unknown" / "mappings" / "applications" / "key.json"
     assert cache_file.exists()
     content = cache_file.read_text()
     assert content == response.model_dump_json()
@@ -325,7 +325,7 @@ async def test_map_set_reads_cache(monkeypatch, tmp_path) -> None:
     cached = json.dumps(
         {"features": [{"feature_id": "f1", "applications": [{"item": "a"}]}]}
     )
-    cache_dir = Path(".cache") / "mapping" / "applications"
+    cache_dir = Path(".cache") / "unknown" / "mappings" / "applications"
     cache_dir.mkdir(parents=True, exist_ok=True)
     (cache_dir / "key.json").write_text(cached)
 
@@ -352,7 +352,7 @@ async def test_map_set_bad_cache_renamed(monkeypatch, tmp_path) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr("mapping.render_set_prompt", lambda *a, **k: "PROMPT")
     monkeypatch.setattr(mapping, "_build_cache_key", lambda *a, **k: "key")
-    cache_dir = Path(".cache") / "mapping" / "applications"
+    cache_dir = Path(".cache") / "unknown" / "mappings" / "applications"
     cache_dir.mkdir(parents=True, exist_ok=True)
     bad_file = cache_dir / "key.json"
     bad_file.write_text("not json", encoding="utf-8")
@@ -414,7 +414,7 @@ async def test_map_set_cache_invalidation(monkeypatch, tmp_path, change) -> None
         cache_mode="read",
         catalogue_hash=cat_hash2,
     )
-    cache_dir = Path(".cache") / "mapping" / "applications"
+    cache_dir = Path(".cache") / "unknown" / "mappings" / "applications"
     assert len(list(cache_dir.glob("*.json"))) == 2
     assert len(session.prompts) == 2
 
@@ -440,7 +440,7 @@ async def test_map_set_logs_cache_status(
         {"features": [{"feature_id": "f1", "applications": [{"item": "a"}]}]}
     )
     if prepopulate:
-        cache_dir = Path(".cache") / "mapping" / "applications"
+        cache_dir = Path(".cache") / "unknown" / "mappings" / "applications"
         cache_dir.mkdir(parents=True, exist_ok=True)
         (cache_dir / "key.json").write_text(response)
     session = DummySession([response])
@@ -481,7 +481,7 @@ async def test_map_set_cache_modes(
     response = json.dumps(
         {"features": [{"feature_id": "f1", "applications": [{"item": "a"}]}]}
     )
-    cache_file = Path(".cache") / "mapping" / "applications" / "key.json"
+    cache_file = Path(".cache") / "unknown" / "mappings" / "applications" / "key.json"
     if prepopulate:  # Seed cache file when required
         cache_file.parent.mkdir(parents=True, exist_ok=True)
         cache_file.write_text("cached")


### PR DESCRIPTION
## Summary
- scope cache paths by service ID and stage for descriptions, features and mapping types
- pass service IDs into mapping cache and update plateau generator accordingly
- adjust docs and tests for new cache layout

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing . --extend-exclude '\.idea'`
- `poetry run ruff check --fix . --extend-exclude '\.idea'`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af0be9c07c832babf0ab8d9c72334a