### PR TITLE
Include service metadata in mapping prompts

### DIFF
--- a/src/mapping_prompt.py
+++ b/src/mapping_prompt.py
@@ -72,6 +72,9 @@ def render_set_prompt(
     items: Sequence[MappingItem],
     features: Sequence[PlateauFeature],
     *,
+    service_name: str,
+    service_description: str,
+    plateau: int,
     diagnostics: bool = False,
 ) -> str:
     """Return a prompt requesting mappings for ``features`` against ``set_name``.
@@ -80,12 +83,16 @@ def render_set_prompt(
         set_name: Name of the mapping catalogue.
         items: Available catalogue items.
         features: Features requiring mapping enrichment.
+        service_name: Human readable name of the service.
+        service_description: Description of the service at ``plateau``.
+        plateau: Numeric plateau level being evaluated.
 
     Returns:
         Fully rendered prompt string.
     """
-    # Instruction template defines sections for catalogue items and feature
-    # descriptions. Rendering is deterministic as both helpers sort inputs.
+    # Instruction template defines sections for catalogue items, feature
+    # descriptions and service metadata. Rendering is deterministic as both
+    # helpers sort inputs and the plateau description is sanitised.
     instruction = load_prompt_text(
         "mapping_prompt_diagnostics" if diagnostics else "mapping_prompt"
     )
@@ -103,6 +110,9 @@ def render_set_prompt(
         "{mapping_fields}": set_name,
         "{features}": f"```json\n{feature_lines}\n```",
         "{schema}": MAPPING_DIAGNOSTICS_SCHEMA if diagnostics else MAPPING_SCHEMA,
+        "{service_name}": _sanitize(service_name),
+        "{service_description}": _sanitize(service_description),
+        "{plateau}": str(plateau),
     }
 
     for placeholder, value in replacements.items():

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -132,8 +132,19 @@ class PlateauGenerator:
         self,
         session: ConversationSession,
         features: Sequence[PlateauFeature],
+        *,
+        plateau: int,
+        service_name: str,
+        service_description: str,
     ) -> dict[str, list[MappingFeatureGroup]]:
         """Return mapping groups keyed by mapping type for ``features``.
+
+        Args:
+            session: Conversation session for API calls.
+            features: Plateau features to map.
+            plateau: Numeric plateau level being mapped.
+            service_name: Human readable name of the service.
+            service_description: Description of the service at ``plateau``.
 
         Each mapping set defined in the application settings receives the full
         ``features`` list. Results are grouped by mapping item so that each item
@@ -155,6 +166,9 @@ class PlateauGenerator:
                 cfg.field,
                 items[cfg.field],
                 list(features),
+                service_name=service_name,
+                service_description=service_description,
+                plateau=plateau,
                 service=service_id,
                 strict=self.strict,
                 cache_mode=(self.cache_mode if self.use_local_cache else "off"),
@@ -690,7 +704,13 @@ class PlateauGenerator:
             )
             if self._service is not None:
                 map_session.add_parent_materials(self._service)
-            mappings = await self._map_features(map_session, features)
+            mappings = await self._map_features(
+                map_session,
+                features,
+                plateau=level,
+                service_name=self._service.name,
+                service_description=description,
+            )
             return PlateauResult(
                 plateau=level,
                 plateau_name=plateau_name,

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -102,7 +102,7 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
 
     map_calls = {"n": 0}
 
-    async def _fake_map_features(self, session, features):
+    async def _fake_map_features(self, session, features, **kwargs):
         map_calls["n"] += 1
         refs = [
             FeatureMappingRef(feature_id=f.feature_id, description=f.description)

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -70,6 +70,9 @@ async def test_map_set_successful_mapping(monkeypatch) -> None:
         "applications",
         [_item()],
         [_feature()],
+        service_name="svc",
+        service_description="desc",
+        plateau=1,
         service="svc",
     )
     assert session.prompts == ["PROMPT", "PROMPT\nReturn valid JSON only."]
@@ -107,6 +110,9 @@ async def test_map_set_quarantines_unknown_ids(monkeypatch, tmp_path) -> None:
         "applications",
         [_item()],
         [_feature()],
+        service_name="svc",
+        service_description="desc",
+        plateau=1,
         service="svc",
     )
     assert [c.item for c in mapped[0].mappings["applications"]] == ["a"]
@@ -138,6 +144,9 @@ async def test_quarantine_separates_unknown_ids_by_service(
         "applications",
         [_item()],
         [_feature()],
+        service_name="svc1",
+        service_description="desc",
+        plateau=1,
         service="svc1",
     )
     await map_set(
@@ -145,6 +154,9 @@ async def test_quarantine_separates_unknown_ids_by_service(
         "applications",
         [_item()],
         [_feature()],
+        service_name="svc2",
+        service_description="desc",
+        plateau=1,
         service="svc2",
     )
     qfile1 = tmp_path / "quarantine" / "svc1" / "applications" / "unknown_ids_1.json"
@@ -168,6 +180,9 @@ async def test_map_set_strict_raises(monkeypatch, tmp_path) -> None:
             "applications",
             [_item()],
             [_feature()],
+            service_name="svc",
+            service_description="desc",
+            plateau=1,
             service="svc",
             strict=True,
         )
@@ -196,6 +211,9 @@ async def test_map_set_strict_unknown_ids(monkeypatch, tmp_path) -> None:
             "applications",
             [_item()],
             [_feature()],
+            service_name="svc",
+            service_description="desc",
+            plateau=1,
             service="svc",
             strict=True,
         )
@@ -285,6 +303,9 @@ async def test_map_set_diagnostics_includes_rationale(monkeypatch) -> None:
         "applications",
         [_item()],
         [_feature()],
+        service_name="svc",
+        service_description="desc",
+        plateau=1,
         diagnostics=True,
     )
     assert mapped[0].mappings["applications"][0].item == "a"
@@ -306,6 +327,9 @@ async def test_map_set_writes_cache(monkeypatch, tmp_path) -> None:
         "applications",
         [_item()],
         [_feature()],
+        service_name="svc",
+        service_description="desc",
+        plateau=1,
         cache_mode="read",
     )
     cache_file = Path(".cache") / "unknown" / "mappings" / "applications" / "key.json"
@@ -339,6 +363,9 @@ async def test_map_set_reads_cache(monkeypatch, tmp_path) -> None:
         "applications",
         [_item()],
         [_feature()],
+        service_name="svc",
+        service_description="desc",
+        plateau=1,
         cache_mode="read",
     )
     assert session.prompts == []
@@ -365,6 +392,9 @@ async def test_map_set_bad_cache_renamed(monkeypatch, tmp_path) -> None:
         "applications",
         [_item()],
         [_feature()],
+        service_name="svc",
+        service_description="desc",
+        plateau=1,
         cache_mode="read",
     )
     assert mapped[0].mappings["applications"][0].item == "a"
@@ -403,6 +433,9 @@ async def test_map_set_cache_invalidation(monkeypatch, tmp_path, change) -> None
         "applications",
         [_item()],
         features1,
+        service_name="svc",
+        service_description="desc",
+        plateau=1,
         cache_mode="read",
         catalogue_hash=cat_hash1,
     )
@@ -411,6 +444,9 @@ async def test_map_set_cache_invalidation(monkeypatch, tmp_path, change) -> None
         "applications",
         [_item()],
         features2,
+        service_name="svc",
+        service_description="desc",
+        plateau=1,
         cache_mode="read",
         catalogue_hash=cat_hash2,
     )
@@ -453,6 +489,9 @@ async def test_map_set_logs_cache_status(
         "applications",
         [_item()],
         [_feature()],
+        service_name="svc",
+        service_description="desc",
+        plateau=1,
         cache_mode=mode,
     )
     assert logs[0][1]["cache"] == expected
@@ -491,6 +530,9 @@ async def test_map_set_cache_modes(
         "applications",
         [_item()],
         [_feature()],
+        service_name="svc",
+        service_description="desc",
+        plateau=1,
         cache_mode=mode,
     )
     assert len(session.prompts) == expected_prompts
@@ -527,6 +569,9 @@ async def test_map_set_prompt_logging_respects_flags(monkeypatch) -> None:
         "applications",
         [_item()],
         [_feature()],
+        service_name="svc",
+        service_description="desc",
+        plateau=1,
     )
     assert logs
     features_json = logs[0][1]["features"]
@@ -559,6 +604,9 @@ async def test_map_set_prompt_logging_skipped(monkeypatch) -> None:
         "applications",
         [_item()],
         [_feature()],
+        service_name="svc",
+        service_description="desc",
+        plateau=1,
     )
     assert logs == []
 

--- a/tests/test_mapping_prompt.py
+++ b/tests/test_mapping_prompt.py
@@ -58,7 +58,14 @@ def test_render_set_prompt_orders_content(shuffle: bool, monkeypatch) -> None:
         items = list(reversed(items))
         features = list(reversed(features))
 
-    prompt = render_set_prompt("test", items, features)
+    prompt = render_set_prompt(
+        "test",
+        items,
+        features,
+        service_name="svc",
+        service_description="desc",
+        plateau=1,
+    )
     blocks = re.findall(r"```json\n(.*?)\n```", prompt, re.DOTALL)
     items_json = json.loads(blocks[0])
     features_json = json.loads(blocks[1])
@@ -67,7 +74,12 @@ def test_render_set_prompt_orders_content(shuffle: bool, monkeypatch) -> None:
 
     if shuffle:
         prompt_again = render_set_prompt(
-            "test", list(reversed(items)), list(reversed(features))
+            "test",
+            list(reversed(items)),
+            list(reversed(features)),
+            service_name="svc",
+            service_description="desc",
+            plateau=1,
         )
         assert prompt_again == prompt
 
@@ -123,7 +135,14 @@ def test_render_set_prompt_normalizes_whitespace(monkeypatch) -> None:
         )
     ]
 
-    prompt = render_set_prompt("test", items, features)
+    prompt = render_set_prompt(
+        "test",
+        items,
+        features,
+        service_name="svc",
+        service_description="desc",
+        plateau=1,
+    )
     blocks = re.findall(r"```json\n(.*?)\n```", prompt, re.DOTALL)
     items_json = json.loads(blocks[0])
     features_json = json.loads(blocks[1])
@@ -143,7 +162,15 @@ def test_render_set_prompt_uses_diagnostics_template(monkeypatch) -> None:
         return "{schema}"
 
     monkeypatch.setattr("mapping_prompt.load_prompt_text", fake_load)
-    render_set_prompt("test", [], [], diagnostics=True)
+    render_set_prompt(
+        "test",
+        [],
+        [],
+        service_name="svc",
+        service_description="desc",
+        plateau=1,
+        diagnostics=True,
+    )
     assert called["name"] == "mapping_prompt_diagnostics"
 
 
@@ -157,5 +184,28 @@ def test_render_set_prompt_handles_literal_braces(monkeypatch) -> None:
     )
     monkeypatch.setattr("mapping_prompt.load_prompt_text", lambda _n: template)
 
-    result = render_set_prompt("test", [], [])
+    result = render_set_prompt(
+        "test",
+        [],
+        [],
+        service_name="svc",
+        service_description="desc",
+        plateau=1,
+    )
     assert '{ "item": <ID> }' in result
+
+
+def test_render_set_prompt_inserts_service_metadata(monkeypatch) -> None:
+    """Service placeholders are replaced in the rendered prompt."""
+
+    template = "{service_name}|{service_description}|{plateau}"
+    monkeypatch.setattr("mapping_prompt.load_prompt_text", lambda _n: template)
+    result = render_set_prompt(
+        "test",
+        [],
+        [],
+        service_name="svc",
+        service_description="desc",
+        plateau=2,
+    )
+    assert result == "svc|desc|2"

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -146,7 +146,13 @@ async def test_map_features_maps_all_sets_with_full_list(monkeypatch) -> None:
         ),
     ]
 
-    await gen._map_features(cast(ConversationSession, session), feats)
+    await gen._map_features(
+        cast(ConversationSession, session),
+        feats,
+        plateau=1,
+        service_name="svc",
+        service_description="desc",
+    )
 
     assert called == [s.field for s in mapping_sets]
     assert all(ids == ["f1", "f2"] for ids in received)
@@ -219,7 +225,7 @@ def test_generate_plateau_returns_results(monkeypatch) -> None:
 
     call = {"n": 0}
 
-    async def dummy_map_features(self, session, feats):
+    async def dummy_map_features(self, session, feats, **kwargs):
         call["n"] += 1
         refs = [
             FeatureMappingRef(feature_id=f.feature_id, description=f.description)
@@ -320,7 +326,7 @@ def test_generate_plateau_repairs_missing_features(monkeypatch) -> None:
     )
     session = DummySession([desc_payload, initial, repair])
 
-    async def dummy_map_features(self, session, feats):
+    async def dummy_map_features(self, session, feats, **kwargs):
         return {}
 
     monkeypatch.setattr(PlateauGenerator, "_map_features", dummy_map_features)
@@ -409,7 +415,7 @@ def test_generate_plateau_requests_missing_features_concurrently(
     )
     session = DummySession([desc_payload, initial])
 
-    async def dummy_map_features(self, session, feats):
+    async def dummy_map_features(self, session, feats, **kwargs):
         return {}
 
     monkeypatch.setattr(PlateauGenerator, "_map_features", dummy_map_features)
@@ -524,7 +530,7 @@ def test_generate_plateau_repairs_invalid_role(monkeypatch) -> None:
     )
     session = DummySession([desc_payload, initial, repair])
 
-    async def dummy_map_features(self, session, feats):
+    async def dummy_map_features(self, session, feats, **kwargs):
         return {}
 
     monkeypatch.setattr(PlateauGenerator, "_map_features", dummy_map_features)

--- a/tests/test_small_mapping.py
+++ b/tests/test_small_mapping.py
@@ -65,6 +65,9 @@ def test_mapping_run_matches_golden(tmp_path) -> None:
             "applications",
             items["applications"],
             features,
+            service_name="svc",
+            service_description="desc",
+            plateau=1,
             catalogue_hash=catalogue_hash,
         )
     )
@@ -86,6 +89,9 @@ def test_mapping_run_matches_golden(tmp_path) -> None:
             "technologies",
             items["technologies"],
             mapped,
+            service_name="svc",
+            service_description="desc",
+            plateau=1,
             catalogue_hash=catalogue_hash,
         )
     )
@@ -144,6 +150,9 @@ def test_default_mode_quarantines_unknown_ids(monkeypatch, tmp_path) -> None:
             "applications",
             items["applications"],
             features,
+            service_name="svc",
+            service_description="desc",
+            plateau=1,
             catalogue_hash=catalogue_hash,
         )
     )
@@ -185,6 +194,9 @@ def test_strict_mapping_raises_on_unknown_ids(monkeypatch, tmp_path) -> None:
                 "applications",
                 items["applications"],
                 features,
+                service_name="svc",
+                service_description="desc",
+                plateau=1,
                 strict=True,
                 catalogue_hash=catalogue_hash,
             )


### PR DESCRIPTION
## Summary
- extend mapping prompt renderer to replace service name, description, and plateau placeholders
- plumb service metadata through plateau generation and mapping
- expand tests for new prompt formatting parameters

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing --exclude "\.idea" .`
- `poetry run ruff check --fix --exclude .idea .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af89d0d3d8832bb8dba5a7c4b3cdaf