### PR TITLE
Ensure temporary output uses atomic writes safely

### DIFF
--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from persistence import atomic_write
+
+
+def test_atomic_write_creates_parent_dir(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "out.jsonl"
+    atomic_write(path, [json.dumps({"a": 1})])
+    assert path.read_text(encoding="utf-8") == '{"a": 1}\n'
+
+
+def test_atomic_write_flushes(tmp_path: Path) -> None:
+    path = tmp_path / "out.txt"
+    flush_called = False
+
+    real_open = open
+
+    def open_wrapper(*args, **kwargs):
+        handle = real_open(*args, **kwargs)
+        original_flush = handle.flush
+
+        def tracked_flush() -> None:
+            nonlocal flush_called
+            flush_called = True
+            original_flush()
+
+        handle.flush = tracked_flush
+        return handle
+
+    with (
+        patch("persistence.open", open_wrapper),
+        patch("persistence.os.fsync") as fsync,
+    ):
+        atomic_write(path, ["data"])
+
+    assert flush_called
+    fsync.assert_called()


### PR DESCRIPTION
## Summary
- ensure atomic writes flush and sync temporary files before replacement
- add regression test verifying flush and fsync

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .` *(fails: Cannot parse .idea templates)*
- `poetry run black --preview --enable-unstable-feature string_processing src tests`
- `poetry run ruff check --fix .` *(fails: invalid syntax in .idea templates)*
- `poetry run ruff check --fix src tests`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `pytest tests/test_persistence.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'logfire')*


------
https://chatgpt.com/codex/tasks/task_e_68af9064f248832ba2565e1e6bb0bee6