### PR TITLE
refactor: scope caches by context and feature

### DIFF
--- a/scripts/migrate_cache.py
+++ b/scripts/migrate_cache.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Migrate legacy cache layout to context-aware structure."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def migrate(root: Path, context: str) -> None:
+    """Rewrite caches under ``root`` into context/service hierarchy."""
+
+    for service_dir in root.iterdir():
+        if not service_dir.is_dir():
+            continue
+        service = service_dir.name
+        for file in service_dir.rglob("*.json"):
+            try:
+                data = json.load(file.open("r", encoding="utf-8"))
+            except json.JSONDecodeError:
+                continue
+            rel = file.relative_to(service_dir)
+            parts = rel.parts
+            if parts and parts[0] in {"features", "mappings"}:
+                rel = Path(parts[0]) / "unknown" / Path(*parts[1:])
+            new_path = root / context / service / rel
+            new_path.parent.mkdir(parents=True, exist_ok=True)
+            with new_path.open("w", encoding="utf-8") as fh:
+                json.dump(data, fh, ensure_ascii=False, separators=(",", ":"))
+            file.unlink()
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: migrate_cache.py <context> [cache_dir]", file=sys.stderr)
+        raise SystemExit(1)
+    context = sys.argv[1]
+    root = Path(sys.argv[2]) if len(sys.argv) > 2 else Path(".cache")
+    migrate(root, context)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -203,7 +203,9 @@ def test_ask_uses_cache_when_available(tmp_path, monkeypatch) -> None:
         cache_mode="read",
     )
     monkeypatch.setattr(
-        conversation, "load_settings", lambda: SimpleNamespace(cache_dir=tmp_path)
+        conversation,
+        "load_settings",
+        lambda: SimpleNamespace(cache_dir=tmp_path, context_id="ctx"),
     )
     key = conversation._prompt_cache_key("hello", "", "stage")
     path = conversation._prompt_cache_path("unknown", "stage", key)

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -341,10 +341,18 @@ async def test_map_set_writes_cache(monkeypatch, tmp_path) -> None:
         plateau=1,
         cache_mode="read",
     )
-    cache_file = Path(".cache") / "unknown" / "mappings" / "applications" / "key.json"
+    cache_file = (
+        Path(".cache")
+        / "unknown"
+        / "unknown"
+        / "mappings"
+        / "f1"
+        / "applications"
+        / "key.json"
+    )
     assert cache_file.exists()
     content = cache_file.read_text()
-    assert content == response.model_dump_json()
+    assert json.loads(content) == response.model_dump()
     assert ": " not in content and ", " not in content
 
 
@@ -355,12 +363,13 @@ async def test_map_set_reads_cache(monkeypatch, tmp_path) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr("mapping.render_set_prompt", lambda *a, **k: "PROMPT")
     monkeypatch.setattr(mapping, "_build_cache_key", lambda *a, **k: "key")
-    cached = json.dumps(
-        {"features": [{"feature_id": "f1", "applications": [{"item": "a"}]}]}
+    cached = {"features": [{"feature_id": "f1", "applications": [{"item": "a"}]}]}
+    cache_dir = (
+        Path(".cache") / "unknown" / "unknown" / "mappings" / "f1" / "applications"
     )
-    cache_dir = Path(".cache") / "unknown" / "mappings" / "applications"
     cache_dir.mkdir(parents=True, exist_ok=True)
-    (cache_dir / "key.json").write_text(cached)
+    with (cache_dir / "key.json").open("w", encoding="utf-8") as fh:
+        json.dump(cached, fh)
 
     class NoCallSession(DummySession):
         async def ask_async(self, prompt: str, output_type=None) -> str:
@@ -388,7 +397,9 @@ async def test_map_set_bad_cache_renamed(monkeypatch, tmp_path) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr("mapping.render_set_prompt", lambda *a, **k: "PROMPT")
     monkeypatch.setattr(mapping, "_build_cache_key", lambda *a, **k: "key")
-    cache_dir = Path(".cache") / "unknown" / "mappings" / "applications"
+    cache_dir = (
+        Path(".cache") / "unknown" / "unknown" / "mappings" / "f1" / "applications"
+    )
     cache_dir.mkdir(parents=True, exist_ok=True)
     bad_file = cache_dir / "key.json"
     bad_file.write_text("not json", encoding="utf-8")
@@ -459,8 +470,14 @@ async def test_map_set_cache_invalidation(monkeypatch, tmp_path, change) -> None
         cache_mode="read",
         catalogue_hash=cat_hash2,
     )
-    cache_dir = Path(".cache") / "unknown" / "mappings" / "applications"
-    assert len(list(cache_dir.glob("*.json"))) == 2
+    cache_dir1 = (
+        Path(".cache") / "unknown" / "unknown" / "mappings" / "f1" / "applications"
+    )
+    cache_dir2 = (
+        Path(".cache") / "unknown" / "unknown" / "mappings" / "f2" / "applications"
+    )
+    assert (cache_dir1 / "key.json").exists()
+    assert (cache_dir2 / "key.json").exists()
     assert len(session.prompts) == 2
 
 
@@ -485,9 +502,12 @@ async def test_map_set_logs_cache_status(
         {"features": [{"feature_id": "f1", "applications": [{"item": "a"}]}]}
     )
     if prepopulate:
-        cache_dir = Path(".cache") / "unknown" / "mappings" / "applications"
+        cache_dir = (
+            Path(".cache") / "unknown" / "unknown" / "mappings" / "f1" / "applications"
+        )
         cache_dir.mkdir(parents=True, exist_ok=True)
-        (cache_dir / "key.json").write_text(response)
+        with (cache_dir / "key.json").open("w", encoding="utf-8") as fh:
+            json.dump(json.loads(response), fh)
     session = DummySession([response])
     logs: list[tuple[str, dict[str, Any]]] = []
     monkeypatch.setattr(
@@ -529,7 +549,15 @@ async def test_map_set_cache_modes(
     response = json.dumps(
         {"features": [{"feature_id": "f1", "applications": [{"item": "a"}]}]}
     )
-    cache_file = Path(".cache") / "unknown" / "mappings" / "applications" / "key.json"
+    cache_file = (
+        Path(".cache")
+        / "unknown"
+        / "unknown"
+        / "mappings"
+        / "f1"
+        / "applications"
+        / "key.json"
+    )
     if prepopulate:  # Seed cache file when required
         cache_file.parent.mkdir(parents=True, exist_ok=True)
         cache_file.write_text("cached")


### PR DESCRIPTION
## Summary
- nest cache files by context and feature identifiers
- persist cached responses as native JSON data
- add migration helper for existing cache layout

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing src tests scripts`
- `poetry run ruff check --fix src tests scripts`
- `poetry run mypy .` *(fails: No module named 'pydantic')*
- `poetry run bandit -r src -ll` *(fails: Command not found)*
- `poetry run pip-audit` *(fails: Command not found)*
- `pytest` *(fails: 21 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b38137c840832ba58ef8031a2dc01c