### PR TITLE
fix: install poetry before Python setup

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -19,14 +19,14 @@ jobs:
     permissions: read-all
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Install Poetry
+        run: pipx install poetry
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'poetry'
       - name: Install dependencies
-        run: |
-          pipx install poetry
-          poetry install --no-interaction
+        run: poetry install --no-interaction
       - name: Pytest
         run: poetry run pytest -q
 
@@ -36,14 +36,14 @@ jobs:
     permissions: read-all
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Install Poetry
+        run: pipx install poetry
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'poetry'
       - name: Install build tools
-        run: |
-          pipx install poetry
-          poetry install --no-interaction --no-root
+        run: poetry install --no-interaction --no-root
       - name: Build wheel
         run: poetry build
       - name: Upload artefacts

--- a/.github/workflows/ci-quick.yml
+++ b/.github/workflows/ci-quick.yml
@@ -23,14 +23,14 @@ jobs:
     permissions: read-all
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Install Poetry
+        run: pipx install poetry
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'poetry'
       - name: Install dependencies
-        run: |
-          pipx install poetry
-          poetry install --no-interaction
+        run: poetry install --no-interaction
       - name: Ruff
         run: poetry run ruff check .
       - name: Mypy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,13 +22,13 @@ jobs:
     permissions: read-all
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Install Poetry
+        run: pipx install poetry
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
           cache: 'poetry'
       - name: Install dependencies
-        run: |
-          pipx install poetry
-          poetry install --no-interaction --no-root --with docs
+        run: poetry install --no-interaction --no-root --with docs
       - name: Build documentation site
         run: poetry run mkdocs build --strict


### PR DESCRIPTION
## Summary
- install Poetry before running `actions/setup-python` so cache configuration can find the executable
- apply the fix to main, quick and docs workflows to prevent `poetry` not found errors

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .` *(fails: cannot parse .idea templates)*
- `poetry run ruff check --fix .` *(fails: invalid syntax in .idea templates)*
- `poetry run mypy -v src`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3c47068e8832ba00fad6f0b768969