### PR TITLE
fix: enable packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,16 +51,20 @@ requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-package-mode = false
+# Enable package mode so `poetry build` can create a distributable.
+# Include all modules from the `src` directory.
+packages = [{include = "*", from = "src"}]
 
 [tool.black]
 line-length = 88
 target-version = ["py313"]
+extend-exclude = '\.idea'
 
 [tool.ruff]
 line-length = 88
 target-version = "py313"
 src = ["src", "tests"]
+extend-exclude = [".idea"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B"]


### PR DESCRIPTION
## Summary
- enable package mode so `poetry build` succeeds
- ignore IDE directories in Black and Ruff configs

## Testing
- `poetry build`
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3d6a5c704832bbaa95fbc0b1ff037