### PR TITLE
chore: run e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,4 +19,18 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - run: echo "Running heavy E2E..."
+      - name: Install Poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.11'
+          cache: 'poetry'
+      - name: Install dependencies
+        run: poetry install --no-interaction
+      - name: Run E2E tests
+        run: |
+          if [ -d tests/e2e ]; then
+            poetry run pytest tests/e2e
+          else
+            echo "No E2E tests found, skipping."
+          fi


### PR DESCRIPTION
## Summary
- install dependencies and conditionally run end-to-end tests if present

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3da3c85e8832bbf48a43c037ee3d5