### PR TITLE
ci: add e2e test step

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Install dependencies
         run: poetry install --no-interaction
       - name: Run E2E tests
-        run: |
-          if [ -d tests/e2e ]; then
-            poetry run pytest tests/e2e
-          else
-            echo "No E2E tests found, skipping."
-          fi
+        env:
+          OPENAI_API_KEY: dummy
+        run: poetry run pytest tests/test_e2e_*.py


### PR DESCRIPTION
## Summary
- run pytest tests/test_e2e_*.py in the e2e workflow using a dummy OPENAI_API_KEY
- remove e2e test execution from main, quick and nightly workflows

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Argument 2 to "setdefault" of "MutableMapping" has incompatible type "SimpleNamespace"; expected Module)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `OPENAI_API_KEY=dummy poetry run pytest tests/test_e2e_cli_generate.py tests/test_e2e_cli_mapping.py` *(fails: ImportError: cannot import name 'Contribution' from '<unknown module name>')*
- `OPENAI_API_KEY=dummy poetry run pytest tests/test_e2e_cli_generate.py`
- `OPENAI_API_KEY=dummy poetry run pytest tests/test_e2e_cli_mapping.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3ffea88c8832bb280037baa290ace