### PR TITLE
Add pydantic JSON helpers

### DIFF
--- a/src/pydantic_code.py
+++ b/src/pydantic_code.py
@@ -1,0 +1,40 @@
+"""Utilities for JSON serialization using Pydantic."""
+
+from __future__ import annotations
+
+from typing import Any, TypeVar
+
+from pydantic import TypeAdapter
+from pydantic_core import to_json as _to_json
+
+T = TypeVar("T")
+
+
+def to_json(obj: Any) -> str:
+    """Convert a Python object to a JSON string.
+
+    Args:
+        obj: The Python object to serialise.
+
+    Returns:
+        The JSON representation of ``obj``.
+    """
+
+    return _to_json(obj).decode("utf-8")
+
+
+def from_json(data: str, schema: type[T]) -> T:
+    """Parse ``data`` into an instance of ``schema``.
+
+    Args:
+        data: The JSON string to deserialise.
+        schema: The Pydantic model or other schema type expected.
+
+    Returns:
+        An instance of ``schema`` derived from ``data``.
+    """
+
+    return TypeAdapter(schema).validate_json(data)
+
+
+__all__ = ["to_json", "from_json"]

--- a/tests/test_pydantic_code.py
+++ b/tests/test_pydantic_code.py
@@ -1,0 +1,23 @@
+"""Tests for pydantic_code utilities."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from pydantic_code import from_json, to_json
+
+
+class SampleModel(BaseModel):
+    """Simple model for round-trip tests."""
+
+    value: int
+    name: str
+
+
+def test_round_trip_json() -> None:
+    """Objects should round-trip to JSON and back."""
+
+    model = SampleModel(value=1, name="alpha")
+    data = to_json(model)
+    result = from_json(data, SampleModel)
+    assert result == model


### PR DESCRIPTION
## Summary
- provide helper functions for JSON serialization and deserialization backed by pydantic
- expose helpers for reuse across the codebase
- add unit test for round-tripping through JSON

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_pydantic_code.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4e343ec0c832ba5c6df0b22893e6b