### PR TITLE
Use pydantic_core.to_json for record serialization

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import inspect
-import json
 import logging
 import os
 import random
@@ -19,6 +18,7 @@ from uuid import uuid4
 
 import logfire
 from pydantic_ai import Agent
+from pydantic_core import to_json
 from tqdm import tqdm
 
 import loader
@@ -271,18 +271,9 @@ async def _generate_evolution_for_service(
                 temp_output_dir.mkdir(parents=True, exist_ok=True)
                 atomic_write(
                     temp_output_dir / f"{service.service_id}.json",
-                    [
-                        json.dumps(
-                            record,
-                            separators=(",", ":"),
-                            ensure_ascii=False,
-                            sort_keys=True,
-                        )
-                    ],
+                    [to_json(record).decode()],
                 )
-            line = json.dumps(
-                record, separators=(",", ":"), ensure_ascii=False, sort_keys=True
-            )
+            line = to_json(record).decode()
             async with lock:
                 await asyncio.to_thread(output.write, f"{line}\n")
                 new_ids.add(service.service_id)
@@ -403,7 +394,7 @@ async def _cmd_map(
     with output_path.open("w", encoding="utf-8") as fh:
         for evo in evolutions:
             record = canonicalise_record(evo.model_dump(mode="json"))
-            fh.write(json.dumps(record, separators=(",", ":"), sort_keys=True) + "\n")
+            fh.write(to_json(record).decode() + "\n")
 
 
 async def _cmd_generate_evolution(


### PR DESCRIPTION
## Summary
- serialize CLI records using `pydantic_core.to_json`
- drop standard `json` usage in favour of `to_json`

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy src`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: TypeError: type 'object' is not subscriptable and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e6ce5aa8832b9a5b134be8817a50