### PR TITLE
Use pydantic_core to parse service identifiers

### DIFF
--- a/src/service_loader.py
+++ b/src/service_loader.py
@@ -8,12 +8,12 @@ reading newline-delimited JSON service definitions and yielding validated
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Generator, Iterator
 
 import logfire
 from pydantic import TypeAdapter
+from pydantic_core import from_json
 
 from models import ServiceInput
 
@@ -29,9 +29,12 @@ def _extract_service_id(line: str) -> str | None:
     """Return service identifier from ``line`` when available."""
 
     try:
-        return json.loads(line).get("service_id")
+        data = from_json(line, allow_partial=True)
     except Exception:
         return None
+    if isinstance(data, dict):
+        return data.get("service_id")
+    return None
 
 
 def _process_line(

--- a/tests/test_service_loader_extract.py
+++ b/tests/test_service_loader_extract.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+"""Tests for `_extract_service_id`."""
+
+from service_loader import _extract_service_id
+
+
+def test_extract_service_id_from_partial_json() -> None:
+    """Service ID can be parsed from truncated JSON lines."""
+    line = '{"service_id": "svc1", "name": "Service"'
+    assert _extract_service_id(line) == "svc1"
+
+
+def test_extract_service_id_missing() -> None:
+    """Missing identifiers return ``None`` for partial lines."""
+    line = '{"name": "Service"'
+    assert _extract_service_id(line) is None


### PR DESCRIPTION
## Summary
- replace json.loads with pydantic_core.from_json and allow partial JSON
- test service id extraction from truncated JSON lines

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy --install-types --non-interactive .` (fails: Argument 2 to "setdefault" of "MutableMapping" has incompatible type "SimpleNamespace"; expected Module)
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` (fails: TypeError: type 'object' is not subscriptable)

------
https://chatgpt.com/codex/tasks/task_e_68b4e8ea864c832bbf10a7cd6ed1e031