### PR TITLE
Use pydantic_core from_json in tests

### DIFF
--- a/tests/test_async_processing.py
+++ b/tests/test_async_processing.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: MIT
 import asyncio
-import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from pydantic_core import from_json
 
 import generator
 from models import ServiceInput
@@ -38,7 +38,7 @@ def test_process_service_async(monkeypatch):
     gen._limiter = asyncio.Semaphore(1)
     gen._limiter = asyncio.Semaphore(1)
     result, tokens, retries = asyncio.run(gen.process_service(service, "prompt"))
-    assert json.loads(result["service"]) == service.model_dump()
+    assert from_json(result["service"]) == service.model_dump()
     assert tokens == 1
     assert retries == 0
 
@@ -74,7 +74,7 @@ def test_process_service_retries(monkeypatch):
     result, tokens, retries = asyncio.run(gen.process_service(service, "prompt"))
 
     assert attempts["count"] == 3
-    assert json.loads(result["service"]) == service.model_dump()
+    assert from_json(result["service"]) == service.model_dump()
     assert tokens == 1
     assert retries == 2
 
@@ -423,7 +423,7 @@ def test_temp_output_dir_writes_progress(tmp_path, monkeypatch):
                 None,
                 tmp_path,
             )
-            first = json.loads((tmp_path / f"{service.service_id}.json").read_text())
+            first = from_json((tmp_path / f"{service.service_id}.json").read_text())
             assert first == {"stage": 1}
             await gen._run_one(
                 service,
@@ -434,7 +434,7 @@ def test_temp_output_dir_writes_progress(tmp_path, monkeypatch):
                 None,
                 tmp_path,
             )
-            second = json.loads((tmp_path / f"{service.service_id}.json").read_text())
+            second = from_json((tmp_path / f"{service.service_id}.json").read_text())
             assert second == {"stage": 2}
         finally:
             await asyncio.to_thread(handle.close)

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from typing import cast
 
 from pydantic_ai import Agent, messages
+from pydantic_core import from_json
 
 import conversation
 from conversation import ConversationSession
@@ -54,7 +55,7 @@ def test_add_parent_materials_records_history() -> None:
     assert isinstance(part, messages.UserPromptPart)
     material = cast(str, part.content)
     assert material.startswith("SERVICE_CONTEXT:\n")
-    data = json.loads(material.split("SERVICE_CONTEXT:\n", 1)[1])
+    data = from_json(material.split("SERVICE_CONTEXT:\n", 1)[1])
     assert data["service_id"] == "svc-1"
     assert data["jobs_to_be_done"] == [
         {"name": "job1"},
@@ -88,7 +89,7 @@ def test_add_parent_materials_includes_features() -> None:
 
     part = cast(messages.UserPromptPart, session._history[0].parts[0])
     material = cast(str, part.content)
-    data = json.loads(material.split("SERVICE_CONTEXT:\n", 1)[1])
+    data = from_json(material.split("SERVICE_CONTEXT:\n", 1)[1])
     assert data["features"] == [
         {
             "feature_id": "F1",
@@ -188,7 +189,7 @@ def test_diagnostics_writes_transcript(tmp_path) -> None:
 
     path = tmp_path / "svc-1" / "stage.json"
     assert path.exists()
-    data = json.loads(path.read_text(encoding="utf-8"))
+    data = from_json(path.read_text(encoding="utf-8"))
     assert data == {"prompt": "ping", "response": "pong"}
 
 

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Sequence, cast
 
 import pytest
+from pydantic_core import from_json
 
 import mapping
 from conversation import ConversationSession
@@ -127,8 +128,8 @@ async def test_map_set_quarantines_unknown_ids(monkeypatch, tmp_path) -> None:
     assert [c.item for c in mapped[0].mappings["applications"]] == ["a"]
     qdir = tmp_path / "quarantine" / "svc" / "applications"
     qfile = qdir / "unknown_ids_1.json"
-    assert json.loads(qfile.read_text()) == ["x"]
-    manifest = json.loads((qdir / "manifest.json").read_text())
+    assert from_json(qfile.read_text()) == ["x"]
+    manifest = from_json((qdir / "manifest.json").read_text())
     assert manifest["unknown_ids"]["count"] == 1
     assert manifest["unknown_ids"]["examples"] == [["x"]]
     assert paths == [qfile.resolve()]
@@ -170,8 +171,8 @@ async def test_quarantine_separates_unknown_ids_by_service(
     )
     qfile1 = tmp_path / "quarantine" / "svc1" / "applications" / "unknown_ids_1.json"
     qfile2 = tmp_path / "quarantine" / "svc2" / "applications" / "unknown_ids_1.json"
-    assert json.loads(qfile1.read_text()) == ["x"]
-    assert json.loads(qfile2.read_text()) == ["x"]
+    assert from_json(qfile1.read_text()) == ["x"]
+    assert from_json(qfile2.read_text()) == ["x"]
 
 
 @pytest.mark.asyncio()
@@ -227,7 +228,7 @@ async def test_map_set_strict_unknown_ids(monkeypatch, tmp_path) -> None:
             strict=True,
         )
     qfile = tmp_path / "quarantine" / "svc" / "applications" / "unknown_ids_1.json"
-    assert json.loads(qfile.read_text()) == ["x"]
+    assert from_json(qfile.read_text()) == ["x"]
     assert paths == [qfile.resolve()]
 
 
@@ -352,7 +353,7 @@ async def test_map_set_writes_cache(monkeypatch, tmp_path) -> None:
     )
     assert cache_file.exists()
     content = cache_file.read_text()
-    assert json.loads(content) == response.model_dump()
+    assert from_json(content) == response.model_dump()
     assert ": " not in content and ", " not in content
 
 
@@ -508,7 +509,7 @@ async def test_map_set_logs_cache_status(
         )
         cache_dir.mkdir(parents=True, exist_ok=True)
         with (cache_dir / "key.json").open("w", encoding="utf-8") as fh:
-            json.dump(json.loads(response), fh)
+            json.dump(from_json(response), fh)
     session = DummySession([response])
     logs: list[tuple[str, dict[str, Any]]] = []
     monkeypatch.setattr(

--- a/tests/test_mapping_prompt.py
+++ b/tests/test_mapping_prompt.py
@@ -4,13 +4,13 @@
 from __future__ import annotations
 
 import importlib
-import json
 import re
 import sys
 import types
 from typing import Sequence
 
 import pytest
+from pydantic_core import from_json
 
 # Replace ``loader`` with a stub during ``mapping_prompt`` import to avoid
 # reading actual prompt files. The real module is restored immediately so other
@@ -67,8 +67,8 @@ def test_render_set_prompt_orders_content(shuffle: bool, monkeypatch) -> None:
         plateau=1,
     )
     blocks = re.findall(r"```json\n(.*?)\n```", prompt, re.DOTALL)
-    items_json = json.loads(blocks[0])
-    features_json = json.loads(blocks[1])
+    items_json = from_json(blocks[0])
+    features_json = from_json(blocks[1])
     assert [i["id"] for i in items_json] == ["A", "B"]
     assert [f["id"] for f in features_json] == ["1", "2"]
 
@@ -95,7 +95,7 @@ def test_render_items_normalizes_whitespace() -> None:
         )
     ]
     result = mapping_prompt._render_items(items)
-    data = json.loads(result)
+    data = from_json(result)
     assert data == [{"id": "A B", "name": "Item Name", "description": "desc more"}]
 
 
@@ -112,7 +112,7 @@ def test_render_features_normalizes_whitespace() -> None:
         )
     ]
     result = mapping_prompt._render_features(features)
-    data = json.loads(result)
+    data = from_json(result)
     assert data == [{"id": "1 2", "name": "First Feature", "description": "desc more"}]
 
 
@@ -144,8 +144,8 @@ def test_render_set_prompt_normalizes_whitespace(monkeypatch) -> None:
         plateau=1,
     )
     blocks = re.findall(r"```json\n(.*?)\n```", prompt, re.DOTALL)
-    items_json = json.loads(blocks[0])
-    features_json = json.loads(blocks[1])
+    items_json = from_json(blocks[0])
+    features_json = from_json(blocks[1])
     assert items_json == [{"id": "A B", "name": "Item Name", "description": "desc"}]
     assert features_json == [
         {"id": "1 2", "name": "First Feature", "description": "desc more"}

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -12,6 +12,7 @@ from typing import cast
 
 import pytest
 from pydantic_ai import Agent
+from pydantic_core import from_json
 
 from conversation import (
     ConversationSession,
@@ -1159,5 +1160,5 @@ def test_write_transcript_writes_payload(tmp_path) -> None:
     asyncio.run(generator._write_transcript(tmp_path, service, evolution))
 
     path = tmp_path / f"{service.service_id}.json"
-    data = json.loads(path.read_text(encoding="utf-8"))
+    data = from_json(path.read_text(encoding="utf-8"))
     assert data["request"]["service_id"] == "s1"

--- a/tests/test_sample_services.py
+++ b/tests/test_sample_services.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: MIT
-import json
 from pathlib import Path
+
+from pydantic_core import from_json
 
 
 def test_sample_services_jsonl_is_valid() -> None:
     """All lines in sample-services.jsonl should be valid JSON."""
     lines = Path("sample-services.jsonl").read_text(encoding="utf-8").splitlines()
     for line in lines:
-        assert json.loads(line) is not None
+        assert from_json(line) is not None

--- a/tests/test_small_mapping.py
+++ b/tests/test_small_mapping.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import cast
 
 import pytest
+from pydantic_core import from_json
 
 import loader
 import mapping
@@ -159,7 +160,7 @@ def test_default_mode_quarantines_unknown_ids(monkeypatch, tmp_path) -> None:
     assert mapped[0].mappings["applications"][0].item == "app1"
     assert mapped[1].mappings["applications"] == []
     qfile = Path("quarantine/unknown/applications/unknown_ids_1.json")
-    assert json.loads(qfile.read_text()) == ["appX"]
+    assert from_json(qfile.read_text()) == ["appX"]
     assert paths == [qfile.resolve()]
 
 
@@ -202,4 +203,4 @@ def test_strict_mapping_raises_on_unknown_ids(monkeypatch, tmp_path) -> None:
             )
         )
     qfile = Path("quarantine/unknown/applications/unknown_ids_1.json")
-    assert json.loads(qfile.read_text()) == ["appX"]
+    assert from_json(qfile.read_text()) == ["appX"]


### PR DESCRIPTION
## Summary
- replace json.loads with pydantic_core.from_json in test modules
- drop json imports where no longer needed

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Missing stubs for tqdm and incompatible setdefault types)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `pytest tests/test_sample_services.py tests/test_async_processing.py -q` *(fails: ImportError: cannot import name 'ConfigDict')*


------
https://chatgpt.com/codex/tasks/task_e_68b4e9303084832baf5b6f46d8cd646c