### PR TITLE
feat: migrate caches into plateau-specific folders

### DIFF
--- a/scripts/migrate_plateau_cache.py
+++ b/scripts/migrate_plateau_cache.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Migrate cache entries into plateau-specific directories."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Iterable
+
+from pydantic_core import from_json
+
+
+def _load_feature_plateaus(files: Iterable[Path]) -> dict[str, dict[str, str]]:
+    """Return mapping of service to feature plateau levels."""
+
+    service_map: dict[str, dict[str, str]] = {}
+    for file in files:
+        try:
+            lines = file.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            try:
+                data = from_json(line)
+            except ValueError:
+                # Skip invalid JSON lines
+                continue
+            service = data.get("service", {}).get("service_id")
+            if not service:
+                continue
+            feature_map = service_map.setdefault(service, {})
+            for plateau in data.get("plateaus", []):
+                level = plateau.get("plateau")
+                if level is None:
+                    continue
+                for feat in plateau.get("features", []):
+                    fid = feat.get("feature_id")
+                    if fid:
+                        feature_map[fid] = str(level)
+    return service_map
+
+
+def _move_entries(
+    cache_root: Path, context: str, service: str, feature_map: dict[str, str]
+) -> None:
+    """Relocate feature and mapping caches using ``feature_map``."""
+
+    base = cache_root / context / service
+    for fid, plateau in feature_map.items():
+        for kind in ("features", "mappings"):
+            src = base / kind / "unknown" / fid
+            if src.exists():
+                dest = base / kind / plateau / fid
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                src.rename(dest)
+    for kind in ("features", "mappings"):
+        unknown_dir = base / kind / "unknown"
+        if unknown_dir.exists() and not any(unknown_dir.iterdir()):
+            unknown_dir.rmdir()
+
+
+def migrate(output_root: Path, cache_root: Path) -> None:
+    """Migrate cache directories based on evolution output."""
+
+    for context_dir in output_root.iterdir():
+        if not context_dir.is_dir():
+            continue
+        context = context_dir.name
+        outputs = list(context_dir.glob("*.jsonl"))
+        if not outputs:
+            continue
+        service_map = _load_feature_plateaus(outputs)
+        for service, feature_map in service_map.items():
+            _move_entries(cache_root, context, service, feature_map)
+
+
+def main() -> None:
+    """CLI entrypoint."""
+
+    out = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("output")
+    cache = Path(sys.argv[2]) if len(sys.argv) > 2 else Path(".cache")
+    migrate(out, cache)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_migrate_plateau_cache.py
+++ b/tests/test_migrate_plateau_cache.py
@@ -1,0 +1,41 @@
+"""Tests for migrate_plateau_cache script."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_module() -> object:
+    spec = importlib.util.spec_from_file_location(
+        "migrate_plateau_cache", Path("scripts/migrate_plateau_cache.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore[reportAttributeAccessIssue]
+    return module
+
+
+def test_migrate_moves_feature_and_mapping(tmp_path: Path) -> None:
+    module = _load_module()
+    output = tmp_path / "output" / "ctx"
+    cache = tmp_path / ".cache" / "ctx" / "svc"
+    output.mkdir(parents=True)
+    cache_feat = cache / "features" / "unknown" / "f1"
+    cache_feat.mkdir(parents=True)
+    (cache_feat / "data.json").write_text("{}", encoding="utf-8")
+    cache_map = cache / "mappings" / "unknown" / "f1" / "apps"
+    cache_map.mkdir(parents=True)
+    (cache_map / "x.json").write_text("{}", encoding="utf-8")
+    record = {
+        "service": {"service_id": "svc"},
+        "plateaus": [{"plateau": 1, "features": [{"feature_id": "f1"}]}],
+    }
+    with (output / "svc.jsonl").open("w", encoding="utf-8") as fh:
+        fh.write(json.dumps(record))
+    module.migrate(tmp_path / "output", tmp_path / ".cache")
+    assert (cache / "features" / "1" / "f1" / "data.json").exists()
+    assert not (cache / "features" / "unknown").exists()
+    assert (cache / "mappings" / "1" / "f1" / "apps" / "x.json").exists()
+    assert not (cache / "mappings" / "unknown").exists()


### PR DESCRIPTION
## Summary
- add migrate_plateau_cache script to position feature and mapping caches by plateau
- test cache migration for feature and mapping entries

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: AttributeError 'types.SimpleNamespace' object has no attribute 'ModelRequest', TypeError object is not subscriptable, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b4faa8fae4832b9c1cee70ac280fec