### PR TITLE
Search plateau cache directories

### DIFF
--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -467,7 +467,7 @@ class PlateauGenerator:
                 raise ValueError(f"Unknown plateau name: {name}")
             plateau_session = ConversationSession(
                 self.session.client,
-                stage=self.session.stage,
+                stage=f"features_{level}",
                 use_local_cache=self.use_local_cache,
                 cache_mode=self.cache_mode,
             )


### PR DESCRIPTION
## Summary
- restructure cache hierarchy under `.cache/<context>/<service>` for descriptions, features, and mappings
- search service trees for legacy cache files and migrate them to plateau-specific locations
- cover cache migration and error scenarios with updated tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: Library stubs not installed for "tqdm"; incompatible types in tests/test_e2e_cli_generate.py)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_conversation.py tests/test_mapping.py`


------
https://chatgpt.com/codex/tasks/task_e_68b501365bac832b88e86ee4af3c1c07