### PR TITLE
Handle cached dict responses in plateau generation

### DIFF
--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -689,7 +689,10 @@ class PlateauGenerator:
 
             try:
                 raw = await session.ask_async(prompt)
-                data = from_json(raw)
+                if isinstance(raw, (bytes, bytearray, str)):
+                    data = from_json(raw)
+                else:
+                    data = raw
             except Exception as exc:
                 logfire.error(f"Invalid JSON from feature response: {exc}")
                 raise ValueError("Agent returned invalid JSON") from exc


### PR DESCRIPTION
## Summary
- avoid double JSON parsing when cached plateau responses return dicts
- add regression test covering cached dict scenario

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .` *(fails: missing tqdm stubs and unused ignores)*
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `pytest` *(fails: 21 errors during collection)*
- `poetry run pytest tests/test_plateau_generator.py::test_generate_plateau_accepts_dict_response` *(fails: AttributeError in ConversationSession)*

------
https://chatgpt.com/codex/tasks/task_e_68b51a83231c832b954fa34dd06572f7