### PR TITLE
feat: introduce runtime environment singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # service-ambitions
 
+## Architecture
+
+The generator runs on a layered engine design.  `ProcessingEngine`
+coordinates work across services, `ServiceExecution` manages per‑service
+state and spawns `PlateauRuntime` instances for each plateau.  A
+thread‑safe `RuntimeEnv` singleton holds configuration and shared state
+such as caches.  See [runtime-architecture](docs/runtime-architecture.md)
+for a detailed walkthrough.
+
 ## Configuration
 
 Copy the sample configuration and customise it for your environment:

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ subcommands to select the desired operation:
 poetry run service-ambitions run --input-file sample-services.jsonl --output-file evolutions.jsonl --no-logs
 poetry run service-ambitions diagnose --input-file sample-services.jsonl --output-file evolutions.jsonl --no-logs
 poetry run service-ambitions validate --input-file sample-services.jsonl --no-logs
+poetry run service-ambitions reverse --input-file evolutions.jsonl --output-file features.jsonl --no-logs
 ```
 
 Alternatively, use the provided shell script which forwards all arguments to the CLI:
@@ -142,6 +143,7 @@ Alternatively, use the provided shell script which forwards all arguments to the
 ./run.sh run --input-file sample-services.jsonl --output-file evolutions.jsonl --no-logs
 ./run.sh diagnose --input-file sample-services.jsonl --output-file evolutions.jsonl --no-logs
 ./run.sh validate --input-file sample-services.jsonl --no-logs
+./run.sh reverse --input-file evolutions.jsonl --output-file features.jsonl --no-logs
 ```
 
 ## Usage

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -1,11 +1,16 @@
 # Generate evolution
 
 The evolution workflow spans the plateaus defined in
-`data/service_feature_plateaus.json`. It first collects descriptions for all
-plateaus in a single request and then generates and maps features for every plateau. The CLI
-evaluates all plateaus in this file alongside all roles defined in
-`data/roles.json`. Plateau name to level mappings are derived from the order of
-the JSON entries.
+`data/service_feature_plateaus.json`. A `ProcessingEngine` coordinates the
+process: it instantiates a `ServiceExecution` for each service and spawns a
+`PlateauRuntime` per plateau. These engines lazily load data, cache intermediate
+results and only flush output once all stages succeed. The CLI evaluates all
+plateaus in this file alongside all roles defined in `data/roles.json`.
+Plateau name to level mappings are derived from the order of the JSON entries.
+
+Runtime configuration and shared state live in the thread‑safe `RuntimeEnv`
+singleton initialised by the CLI. Modules access settings via
+`RuntimeEnv.instance().settings`, avoiding repeated file reads.
 
 To re-run mapping on an existing evolution output, see
 [generate-mapping](generate-mapping.md).

--- a/docs/generate-mapping.md
+++ b/docs/generate-mapping.md
@@ -1,6 +1,9 @@
 # Generate mapping
 
-Remap feature mappings for existing service evolution results.
+Remap feature mappings for existing service evolution results.  The
+command reuses the same runtime environment and caching strategy as the
+evolution workflow, ensuring that relocated cache files and lazy
+loading behave consistently across both commands.
 
 ## Running
 

--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -1,0 +1,56 @@
+# Runtime architecture
+
+This project evaluates services by composing a small set of engines.
+Each layer has a single responsibility and retains its output until the
+final aggregation step, enabling deterministic runs and comprehensive
+telemetry.
+
+## Runtime environment
+
+`RuntimeEnv` is a thread-safe singleton initialised in `cli.main()`.
+It loads configuration, exposes global settings and holds shared
+in-memory state such as caches.  Modules access the singleton via
+`RuntimeEnv.instance()` instead of repeatedly loading configuration
+files.
+
+## Processing engine
+
+`ProcessingEngine` orchestrates the overall workflow.  It iterates over
+services from the input file, constructs a `ServiceExecution` for each
+and awaits their completion.  The engine only reports whether the batch
+succeeded; individual artefacts remain inside the service objects until
+`finalise()` is invoked.
+
+## Service execution
+
+A `ServiceExecution` handles one service.  It lazily loads plateau
+information, spawns `PlateauRuntime` objects for each plateau and
+delegates feature generation and mapping.  Results for successful
+plateaus are stored on the execution instance and flushed to disk during
+`finalise()`.
+
+## Plateau runtime
+
+`PlateauRuntime` encapsulates the per‑plateau state: description,
+features and mapping results.  Each runtime exposes a simple
+`status()` method used by the processing engine to determine overall
+success.
+
+## Caching strategy
+
+Caching is opt‑in and scoped by context, service and plateau:
+
+```
+.cache/<context>/<service_id>/<descriptions>.json
+.cache/<context>/<service_id>/<plateau>/<features>.json
+.cache/<context>/<service_id>/<plateau>/mappings/<set>/<file>.json
+```
+
+Legacy files are discovered and relocated to the canonical structure.
+Caches are indented JSON dictionaries for easy inspection.  Invalid or
+non‑dictionary content halts processing with a descriptive error.
+
+Prompt templates are lazily loaded with `PromptLoader` and cached via an
+LRU to avoid repeated disk access.  Tests can reset the cache using the
+`clear_prompt_cache()` hook.
+

--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -11,7 +11,8 @@ telemetry.
 It loads configuration, exposes global settings and holds shared
 in-memory state such as caches.  Modules access the singleton via
 `RuntimeEnv.instance()` instead of repeatedly loading configuration
-files.
+files. Tests or reconfigurations can clear the singleton via
+`RuntimeEnv.reset()`.
 
 ## Processing engine
 

--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -36,6 +36,16 @@ features and mapping results.  Each runtime exposes a simple
 `status()` method used by the processing engine to determine overall
 success.
 
+## Telemetry and logging
+
+Structured logging and spans are provided by
+[Logfire](https://logfire.pydantic.dev/).  The runtime environment
+initialiser, the processing engine and each plateau runtime emit
+contextual `debug` and `info` events and wrap long‑running operations in
+spans.  These spans enable fine‑grained tracing across services and
+plateaus, while log levels allow operators to dial in the desired amount
+of detail.
+
 ## Caching strategy
 
 Caching is opt‑in and scoped by context, service and plateau:

--- a/src/cli.py
+++ b/src/cli.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import inspect
+import json
 import logging
 import random
 from pathlib import Path
@@ -169,7 +170,7 @@ async def _cmd_map(
     with output_path.open("w", encoding="utf-8") as fh:
         for evo in evolutions:
             record = canonicalise_record(evo.model_dump(mode="json"))
-            fh.write(to_json(record).decode() + "\n")
+            fh.write(json.dumps(record, separators=(",", ":"), sort_keys=True) + "\n")
 
 
 def _cmd_reverse(

--- a/src/cli.py
+++ b/src/cli.py
@@ -178,7 +178,12 @@ def main() -> None:
     """Parse arguments and dispatch to the requested subcommand."""
 
     parser = argparse.ArgumentParser(
-        description="Service evolution utilities",
+        description=(
+            "Service evolution utilities backed by a layered runtime "
+            "architecture. A ProcessingEngine coordinates ServiceExecution "
+            "and PlateauRuntime instances and relies on a global RuntimeEnv "
+            "for configuration."
+        ),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     common = argparse.ArgumentParser(add_help=False)
@@ -350,8 +355,11 @@ def main() -> None:
     run_p = subparsers.add_parser(
         "run",
         parents=[common],
-        help="Generate service evolutions",
-        description="Generate service evolutions",
+        help="Generate service evolutions via ProcessingEngine",
+        description=(
+            "Generate service evolutions using the ProcessingEngine and "
+            "RuntimeEnv architecture"
+        ),
     )
     run_p.add_argument(
         "--input-file",
@@ -369,8 +377,11 @@ def main() -> None:
     diag_p = subparsers.add_parser(
         "diagnose",
         parents=[common],
-        help="Generate service evolutions",
-        description="Generate service evolutions with diagnostics enabled",
+        help="Generate service evolutions via ProcessingEngine",
+        description=(
+            "Generate service evolutions with diagnostics enabled using the "
+            "ProcessingEngine runtime"
+        ),
     )
     diag_p.add_argument(
         "--input-file",
@@ -388,9 +399,10 @@ def main() -> None:
     val_p = subparsers.add_parser(
         "validate",
         parents=[common],
-        help="Generate service evolutions",
+        help="Generate service evolutions via ProcessingEngine",
         description=(
-            "Validate inputs without calling the API and generate service evolutions"
+            "Validate inputs without calling the API and generate service "
+            "evolutions using the ProcessingEngine runtime"
         ),
     )
     val_p.add_argument(

--- a/src/cli.py
+++ b/src/cli.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 import logfire
 from pydantic_ai import Agent
 from pydantic_core import to_json
-from tqdm import tqdm
+from tqdm import tqdm  # type: ignore[import-untyped]
 
 import loader
 import mapping
@@ -45,6 +45,7 @@ from monitoring import LOG_FILE_NAME, init_logfire
 from persistence import atomic_write, read_lines
 from plateau_generator import PlateauGenerator
 from quarantine import QuarantineWriter
+from runtime.environment import RuntimeEnv
 from service_loader import load_services
 from settings import load_settings
 
@@ -491,8 +492,6 @@ async def _cmd_generate_evolution(
 def main() -> None:
     """Parse arguments and dispatch to the requested subcommand."""
 
-    settings = load_settings()
-
     parser = argparse.ArgumentParser(
         description="Service evolution utilities",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -723,6 +722,9 @@ def main() -> None:
     val_p.set_defaults(func=_cmd_validate)
 
     args = parser.parse_args()
+
+    settings = load_settings()
+    RuntimeEnv.initialize(settings)
 
     if args.seed is not None:
         random.seed(args.seed)

--- a/src/cli.py
+++ b/src/cli.py
@@ -23,7 +23,7 @@ import mapping
 import telemetry
 from canonical import canonicalise_record
 from conversation import ConversationSession
-from engine import ServiceExecution
+from engine.service_execution import ServiceExecution
 from loader import (
     configure_mapping_data_dir,
     configure_prompt_dir,

--- a/src/conversation.py
+++ b/src/conversation.py
@@ -23,7 +23,7 @@ from pydantic_core import from_json, to_json
 
 from mapping import cache_write_json_atomic
 from models import ServiceInput
-from settings import load_settings
+from runtime.environment import RuntimeEnv
 
 
 def _prompt_cache_key(prompt: str, model: str, stage: str) -> str:
@@ -39,7 +39,7 @@ def _prompt_cache_path(
     """Return cache path for ``key`` grouped by context and identifiers."""
 
     try:
-        settings = load_settings()
+        settings = RuntimeEnv.instance().settings
         cache_root = settings.cache_dir
         context = settings.context_id
     except Exception:  # pragma: no cover - fallback when settings unavailable

--- a/src/engine/__init__.py
+++ b/src/engine/__init__.py
@@ -1,5 +1,5 @@
 """Execution engine components."""
 
-from .service_execution import ServiceExecution
+from .plateau_runtime import PlateauRuntime
 
-__all__ = ["ServiceExecution"]
+__all__ = ["PlateauRuntime"]

--- a/src/engine/__init__.py
+++ b/src/engine/__init__.py
@@ -1,0 +1,5 @@
+"""Execution engine components."""
+
+from .service_execution import ServiceExecution
+
+__all__ = ["ServiceExecution"]

--- a/src/engine/plateau_runtime.py
+++ b/src/engine/plateau_runtime.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+import logfire
+
 from models import MappingFeatureGroup, PlateauFeature
 
 
@@ -26,11 +28,26 @@ class PlateauRuntime:
     ) -> None:
         """Store ``features`` and ``mappings`` for this plateau."""
 
-        self.features = list(features)
-        self.mappings = mappings
-        self._success = True
+        with logfire.span(
+            "plateau_runtime.set_results",
+            attributes={"plateau": self.plateau_name},
+        ):
+            self.features = list(features)
+            self.mappings = mappings
+            self._success = True
+            logfire.debug(
+                "Stored plateau results",
+                plateau=self.plateau_name,
+                feature_count=len(self.features),
+                mapping_sets=len(self.mappings),
+            )
 
     def status(self) -> bool:
         """Return ``True`` when generation succeeded."""
 
+        logfire.debug(
+            "Plateau status checked",
+            plateau=self.plateau_name,
+            success=self._success,
+        )
         return self._success

--- a/src/engine/plateau_runtime.py
+++ b/src/engine/plateau_runtime.py
@@ -1,0 +1,36 @@
+"""Runtime container for plateau generation outputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from models import MappingFeatureGroup, PlateauFeature
+
+
+@dataclass
+class PlateauRuntime:
+    """Hold generation artefacts for a single plateau."""
+
+    plateau: int
+    plateau_name: str
+    description: str
+    features: list[PlateauFeature] = field(default_factory=list)
+    mappings: dict[str, list[MappingFeatureGroup]] = field(default_factory=dict)
+    _success: bool = False
+
+    def set_results(
+        self,
+        *,
+        features: list[PlateauFeature],
+        mappings: dict[str, list[MappingFeatureGroup]],
+    ) -> None:
+        """Store ``features`` and ``mappings`` for this plateau."""
+
+        self.features = list(features)
+        self.mappings = mappings
+        self._success = True
+
+    def status(self) -> bool:
+        """Return ``True`` when generation succeeded."""
+
+        return self._success

--- a/src/engine/processing_engine.py
+++ b/src/engine/processing_engine.py
@@ -111,106 +111,116 @@ class ProcessingEngine:
 
     async def run(self) -> bool:
         """Run evolutions for all loaded services."""
-        use_web_search = (
-            self.args.web_search
-            if self.args.web_search is not None
-            else self.settings.web_search
-        )
-        factory = ModelFactory(
-            self.settings.model,
-            self.settings.openai_api_key,
-            stage_models=getattr(self.settings, "models", None),
-            reasoning=self.settings.reasoning,
-            seed=self.args.seed,
-            web_search=use_web_search,
-        )
-        configure_prompt_dir(self.settings.prompt_dir)
-        if self.args.mapping_data_dir is None and not self.settings.diagnostics:
-            raise RuntimeError("--mapping-data-dir is required in production mode")
-        configure_mapping_data_dir(
-            self.args.mapping_data_dir or self.settings.mapping_data_dir
-        )
-        system_prompt = load_evolution_prompt(
-            self.settings.context_id, self.settings.inspiration
-        )
-        role_ids = load_role_ids(Path(self.args.roles_file))
-        services = _load_services_list(
-            self.args.input_file, self.args.max_services, self.processed_ids
-        )
-        if self.args.dry_run:
-            logfire.info(f"Validated {len(services)} services")
-            return True
-        concurrency = (
-            self.args.concurrency
-            if self.args.concurrency is not None
-            else self.settings.concurrency
-        )
-        if concurrency < 1:
-            raise ValueError("concurrency must be a positive integer")
-        sem = asyncio.Semaphore(concurrency)
-        lock = asyncio.Lock()
-        progress = (
-            tqdm(total=len(services))
-            if self.args.progress and sys.stdout.isatty()
-            else None
-        )
-        temp_output_dir = (
-            Path(self.args.temp_output_dir)
-            if self.args.temp_output_dir is not None
-            else None
-        )
-        success = True
 
-        async def run_one(service: ServiceInput) -> None:
-            nonlocal success
-            async with sem:
-                execution = ServiceExecution(
-                    service,
-                    factory=factory,
-                    settings=self.settings,
-                    args=self.args,
-                    system_prompt=system_prompt,
-                    transcripts_dir=self.transcripts_dir,
-                    role_ids=role_ids,
-                    lock=lock,
-                    output=None,
-                    new_ids=self.new_ids,
-                    temp_output_dir=temp_output_dir,
-                )
-                self.executions.append(execution)
-                if not await execution.run():
-                    success = False
+        with logfire.span("processing_engine.run"):
+            logfire.info(
+                "Starting processing engine",
+                input_file=self.args.input_file,
+            )
+            use_web_search = (
+                self.args.web_search
+                if self.args.web_search is not None
+                else self.settings.web_search
+            )
+            factory = ModelFactory(
+                self.settings.model,
+                self.settings.openai_api_key,
+                stage_models=getattr(self.settings, "models", None),
+                reasoning=self.settings.reasoning,
+                seed=self.args.seed,
+                web_search=use_web_search,
+            )
+            configure_prompt_dir(self.settings.prompt_dir)
+            if self.args.mapping_data_dir is None and not self.settings.diagnostics:
+                raise RuntimeError("--mapping-data-dir is required in production mode")
+            configure_mapping_data_dir(
+                self.args.mapping_data_dir or self.settings.mapping_data_dir
+            )
+            system_prompt = load_evolution_prompt(
+                self.settings.context_id, self.settings.inspiration
+            )
+            role_ids = load_role_ids(Path(self.args.roles_file))
+            services = _load_services_list(
+                self.args.input_file, self.args.max_services, self.processed_ids
+            )
+            if self.args.dry_run:
+                logfire.info("Validated services", count=len(services))
+                return True
+            concurrency = (
+                self.args.concurrency
+                if self.args.concurrency is not None
+                else self.settings.concurrency
+            )
+            if concurrency < 1:
+                raise ValueError("concurrency must be a positive integer")
+            sem = asyncio.Semaphore(concurrency)
+            lock = asyncio.Lock()
+            progress = (
+                tqdm(total=len(services))
+                if self.args.progress and sys.stdout.isatty()
+                else None
+            )
+            temp_output_dir = (
+                Path(self.args.temp_output_dir)
+                if self.args.temp_output_dir is not None
+                else None
+            )
+            success = True
+
+            async def run_one(service: ServiceInput) -> None:
+                nonlocal success
+                async with sem:
+                    execution = ServiceExecution(
+                        service,
+                        factory=factory,
+                        settings=self.settings,
+                        args=self.args,
+                        system_prompt=system_prompt,
+                        transcripts_dir=self.transcripts_dir,
+                        role_ids=role_ids,
+                        lock=lock,
+                        output=None,
+                        new_ids=self.new_ids,
+                        temp_output_dir=temp_output_dir,
+                    )
+                    self.executions.append(execution)
+                    if not await execution.run():
+                        success = False
+                if progress:
+                    progress.update(1)
+
+            async with asyncio.TaskGroup() as tg:
+                for svc in services:
+                    tg.create_task(run_one(svc))
             if progress:
-                progress.update(1)
-
-        async with asyncio.TaskGroup() as tg:
-            for svc in services:
-                tg.create_task(run_one(svc))
-        if progress:
-            progress.close()
-        self.success = success
-        return success
+                progress.close()
+            self.success = success
+            logfire.info("Processing engine completed", success=success)
+            return success
 
     async def finalise(self) -> None:
         """Write successful results to disk."""
-        if not self.executions:
-            return
-        output = await asyncio.to_thread(self.part_path.open, "w", encoding="utf-8")
-        try:
-            for exec in self.executions:
-                exec.output = output
-                await exec.finalise()
-        finally:
-            await asyncio.to_thread(output.close)
-        _save_results(
-            resume=self.args.resume,
-            part_path=self.part_path,
-            output_path=self.output_path,
-            existing_lines=self.existing_lines,
-            processed_ids=self.processed_ids,
-            new_ids=self.new_ids,
-            processed_path=self.processed_path,
-        )
+        with logfire.span("processing_engine.finalise"):
+            if not self.executions:
+                logfire.debug("No executions to finalise")
+                return
+            output = await asyncio.to_thread(self.part_path.open, "w", encoding="utf-8")
+            try:
+                for exec in self.executions:
+                    exec.output = output
+                    await exec.finalise()
+            finally:
+                await asyncio.to_thread(output.close)
+            _save_results(
+                resume=self.args.resume,
+                part_path=self.part_path,
+                output_path=self.output_path,
+                existing_lines=self.existing_lines,
+                processed_ids=self.processed_ids,
+                new_ids=self.new_ids,
+                processed_path=self.processed_path,
+            )
+            logfire.info("Finalised processing engine", output=str(self.output_path))
 
 
 __all__ = ["ProcessingEngine"]

--- a/src/engine/processing_engine.py
+++ b/src/engine/processing_engine.py
@@ -1,0 +1,216 @@
+"""High-level service processing engine."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from itertools import islice
+from pathlib import Path
+
+import logfire
+from tqdm import tqdm  # type: ignore[import-untyped]
+
+from engine.service_execution import ServiceExecution
+from loader import (
+    configure_mapping_data_dir,
+    configure_prompt_dir,
+    load_evolution_prompt,
+    load_role_ids,
+)
+from model_factory import ModelFactory
+from models import ServiceInput
+from persistence import atomic_write, read_lines
+from service_loader import load_services
+
+# Helper functions migrated from cli for reuse.
+
+
+def _prepare_paths(output: Path, resume: bool) -> tuple[Path, Path]:
+    """Return paths used for output and resume tracking."""
+    part_path = output.with_suffix(
+        output.suffix + ".tmp" if not resume else output.suffix + ".tmp.part"
+    )
+    processed_path = output.with_name("processed_ids.txt")
+    return part_path, processed_path
+
+
+def _load_resume_state(
+    processed_path: Path, output_path: Path, resume: bool
+) -> tuple[set[str], list[str]]:
+    """Return previously processed IDs and existing output lines."""
+    processed_ids = set(read_lines(processed_path)) if resume else set()
+    existing_lines = read_lines(output_path) if resume else []
+    return processed_ids, existing_lines
+
+
+def _ensure_transcripts_dir(path: str | None, output: Path) -> Path:
+    """Create and return the directory used to store transcripts."""
+    transcripts_dir = Path(path) if path is not None else output.parent / "_transcripts"
+    transcripts_dir.mkdir(parents=True, exist_ok=True)
+    return transcripts_dir
+
+
+def _load_services_list(
+    input_file: str, max_services: int | None, processed_ids: set[str]
+) -> list[ServiceInput]:
+    """Return services filtered for ``processed_ids`` and ``max_services``."""
+    with load_services(Path(input_file)) as svc_iter:
+        if max_services is not None:
+            svc_iter = islice(svc_iter, max_services)
+        return [s for s in svc_iter if s.service_id not in processed_ids]
+
+
+def _save_results(
+    *,
+    resume: bool,
+    part_path: Path,
+    output_path: Path,
+    existing_lines: list[str],
+    processed_ids: set[str],
+    new_ids: set[str],
+    processed_path: Path,
+) -> set[str]:
+    """Persist generated lines and update processed IDs."""
+    if resume:
+        new_lines = read_lines(part_path)
+        atomic_write(output_path, [*existing_lines, *new_lines])
+        part_path.unlink(missing_ok=True)
+        processed_ids.update(new_ids)
+    else:
+        os.replace(part_path, output_path)
+        processed_ids = new_ids
+    atomic_write(processed_path, sorted(processed_ids))
+    return processed_ids
+
+
+class ProcessingEngine:
+    """Coordinate service evolution generation across multiple services."""
+
+    def __init__(
+        self, args: argparse.Namespace, settings, transcripts_dir: Path | None
+    ) -> None:
+        self.args = args
+        self.settings = settings
+        self.transcripts_dir = transcripts_dir
+        self.output_path = Path(args.output_file)
+        self.part_path, self.processed_path = _prepare_paths(
+            self.output_path, args.resume
+        )
+        self.processed_ids, self.existing_lines = _load_resume_state(
+            self.processed_path, self.output_path, args.resume
+        )
+        if self.transcripts_dir is None and not args.no_logs:
+            self.transcripts_dir = _ensure_transcripts_dir(
+                args.transcripts_dir, self.output_path
+            )
+        self.new_ids: set[str] = set()
+        self.executions: list[ServiceExecution] = []
+        self.success = False
+
+    async def run(self) -> bool:
+        """Run evolutions for all loaded services."""
+        use_web_search = (
+            self.args.web_search
+            if self.args.web_search is not None
+            else self.settings.web_search
+        )
+        factory = ModelFactory(
+            self.settings.model,
+            self.settings.openai_api_key,
+            stage_models=getattr(self.settings, "models", None),
+            reasoning=self.settings.reasoning,
+            seed=self.args.seed,
+            web_search=use_web_search,
+        )
+        configure_prompt_dir(self.settings.prompt_dir)
+        if self.args.mapping_data_dir is None and not self.settings.diagnostics:
+            raise RuntimeError("--mapping-data-dir is required in production mode")
+        configure_mapping_data_dir(
+            self.args.mapping_data_dir or self.settings.mapping_data_dir
+        )
+        system_prompt = load_evolution_prompt(
+            self.settings.context_id, self.settings.inspiration
+        )
+        role_ids = load_role_ids(Path(self.args.roles_file))
+        services = _load_services_list(
+            self.args.input_file, self.args.max_services, self.processed_ids
+        )
+        if self.args.dry_run:
+            logfire.info(f"Validated {len(services)} services")
+            return True
+        concurrency = (
+            self.args.concurrency
+            if self.args.concurrency is not None
+            else self.settings.concurrency
+        )
+        if concurrency < 1:
+            raise ValueError("concurrency must be a positive integer")
+        sem = asyncio.Semaphore(concurrency)
+        lock = asyncio.Lock()
+        progress = (
+            tqdm(total=len(services))
+            if self.args.progress and sys.stdout.isatty()
+            else None
+        )
+        temp_output_dir = (
+            Path(self.args.temp_output_dir)
+            if self.args.temp_output_dir is not None
+            else None
+        )
+        success = True
+
+        async def run_one(service: ServiceInput) -> None:
+            nonlocal success
+            async with sem:
+                execution = ServiceExecution(
+                    service,
+                    factory=factory,
+                    settings=self.settings,
+                    args=self.args,
+                    system_prompt=system_prompt,
+                    transcripts_dir=self.transcripts_dir,
+                    role_ids=role_ids,
+                    lock=lock,
+                    output=None,
+                    new_ids=self.new_ids,
+                    temp_output_dir=temp_output_dir,
+                )
+                self.executions.append(execution)
+                if not await execution.run():
+                    success = False
+            if progress:
+                progress.update(1)
+
+        async with asyncio.TaskGroup() as tg:
+            for svc in services:
+                tg.create_task(run_one(svc))
+        if progress:
+            progress.close()
+        self.success = success
+        return success
+
+    async def finalise(self) -> None:
+        """Write successful results to disk."""
+        if not self.executions:
+            return
+        output = await asyncio.to_thread(self.part_path.open, "w", encoding="utf-8")
+        try:
+            for exec in self.executions:
+                exec.output = output
+                await exec.finalise()
+        finally:
+            await asyncio.to_thread(output.close)
+        _save_results(
+            resume=self.args.resume,
+            part_path=self.part_path,
+            output_path=self.output_path,
+            existing_lines=self.existing_lines,
+            processed_ids=self.processed_ids,
+            new_ids=self.new_ids,
+            processed_path=self.processed_path,
+        )
+
+
+__all__ = ["ProcessingEngine"]

--- a/src/engine/service_execution.py
+++ b/src/engine/service_execution.py
@@ -1,0 +1,220 @@
+"""Service evolution execution helpers."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+from uuid import uuid4
+
+import logfire
+from pydantic_ai import Agent
+from pydantic_core import to_json
+
+import loader
+from canonical import canonicalise_record
+from conversation import ConversationSession
+from loader import load_mapping_items
+from model_factory import ModelFactory
+from models import ServiceInput, ServiceMeta
+from persistence import atomic_write
+from plateau_generator import PlateauGenerator
+from quarantine import QuarantineWriter
+
+SERVICES_PROCESSED = logfire.metric_counter("services_processed")
+EVOLUTIONS_GENERATED = logfire.metric_counter("evolutions_generated")
+LINES_WRITTEN = logfire.metric_counter("lines_written")
+
+_RUN_META: ServiceMeta | None = None
+_writer = QuarantineWriter()
+
+
+class ServiceExecution:
+    """Execute a single service evolution run.
+
+    The :class:`ServiceExecution` class encapsulates the logic required to
+    generate a service evolution and persist the result.  The ``run`` method
+    performs the generation and stores intermediate artefacts on the instance
+    while ``finalise`` writes the persisted output.
+    """
+
+    def __init__(
+        self,
+        service: ServiceInput,
+        *,
+        factory: ModelFactory,
+        settings,
+        args: argparse.Namespace,
+        system_prompt: str,
+        transcripts_dir: Path | None,
+        role_ids: Sequence[str],
+        lock: asyncio.Lock,
+        output,
+        new_ids: set[str],
+        temp_output_dir: Path | None,
+    ) -> None:
+        self.service = service
+        self.factory = factory
+        self.settings = settings
+        self.args = args
+        self.system_prompt = system_prompt
+        self.transcripts_dir = transcripts_dir
+        self.role_ids = role_ids
+        self.lock = lock
+        self.output = output
+        self.new_ids = new_ids
+        self.temp_output_dir = temp_output_dir
+        self.line: str | None = None
+
+    async def run(self) -> bool:
+        """Generate the evolution for ``service`` and store the result.
+
+        Returns ``True`` on success, ``False`` otherwise.  Generated artefacts
+        are kept on the instance for later persistence.
+        """
+
+        desc_name = self.factory.model_name(
+            "descriptions", self.args.descriptions_model or self.args.model
+        )
+        feat_name = self.factory.model_name(
+            "features", self.args.features_model or self.args.model
+        )
+        map_name = self.factory.model_name(
+            "mapping", self.args.mapping_model or self.args.model
+        )
+        attrs = {
+            "service_id": self.service.service_id,
+            "service_name": self.service.name,
+            "descriptions_model": desc_name,
+            "features_model": feat_name,
+            "mapping_model": map_name,
+            "output_path": getattr(self.output, "name", ""),
+        }
+        with logfire.span("generate_evolution_for_service", attributes=attrs):
+            try:
+                SERVICES_PROCESSED.add(1)
+                desc_model = self.factory.get(
+                    "descriptions", self.args.descriptions_model or self.args.model
+                )
+                feat_model = self.factory.get(
+                    "features", self.args.features_model or self.args.model
+                )
+                map_model = self.factory.get(
+                    "mapping", self.args.mapping_model or self.args.model
+                )
+
+                desc_agent = Agent(desc_model, instructions=self.system_prompt)
+                feat_agent = Agent(feat_model, instructions=self.system_prompt)
+                map_agent = Agent(map_model, instructions=self.system_prompt)
+
+                desc_session = ConversationSession(
+                    desc_agent,
+                    stage="descriptions",
+                    diagnostics=self.settings.diagnostics,
+                    log_prompts=self.args.allow_prompt_logging,
+                    transcripts_dir=self.transcripts_dir,
+                    use_local_cache=self.args.use_local_cache,
+                    cache_mode=self.args.cache_mode,
+                )
+                feat_session = ConversationSession(
+                    feat_agent,
+                    stage="features",
+                    diagnostics=self.settings.diagnostics,
+                    log_prompts=self.args.allow_prompt_logging,
+                    transcripts_dir=self.transcripts_dir,
+                    use_local_cache=self.args.use_local_cache,
+                    cache_mode=self.args.cache_mode,
+                )
+                map_session = ConversationSession(
+                    map_agent,
+                    stage="mapping",
+                    diagnostics=self.settings.diagnostics,
+                    log_prompts=self.args.allow_prompt_logging,
+                    transcripts_dir=self.transcripts_dir,
+                    use_local_cache=self.args.use_local_cache,
+                    cache_mode=self.args.cache_mode,
+                )
+                generator = PlateauGenerator(
+                    feat_session,
+                    required_count=self.settings.features_per_role,
+                    roles=self.role_ids,
+                    description_session=desc_session,
+                    mapping_session=map_session,
+                    strict=self.args.strict,
+                    use_local_cache=self.args.use_local_cache,
+                    cache_mode=self.args.cache_mode,
+                )
+                global _RUN_META
+                if _RUN_META is None:
+                    models_map = {
+                        "descriptions": desc_name,
+                        "features": feat_name,
+                        "mapping": map_name,
+                        "search": self.factory.model_name(
+                            "search", self.args.search_model or self.args.model
+                        ),
+                    }
+                    _, catalogue_hash = load_mapping_items(
+                        loader.MAPPING_DATA_DIR, self.settings.mapping_sets
+                    )
+                    context_window = getattr(feat_model, "max_input_tokens", 0)
+                    _RUN_META = ServiceMeta(
+                        run_id=str(uuid4()),
+                        seed=self.args.seed,
+                        models=models_map,
+                        web_search=getattr(self.factory, "_web_search", False),
+                        mapping_types=sorted(
+                            getattr(self.settings, "mapping_types", {}).keys()
+                        ),
+                        context_window=context_window,
+                        diagnostics=self.settings.diagnostics,
+                        catalogue_hash=catalogue_hash,
+                        created=datetime.now(timezone.utc),
+                    )
+                evolution = await generator.generate_service_evolution_async(
+                    self.service,
+                    transcripts_dir=self.transcripts_dir,
+                    meta=_RUN_META,
+                )
+                record = canonicalise_record(evolution.model_dump(mode="json"))
+                if self.temp_output_dir is not None:
+                    self.temp_output_dir.mkdir(parents=True, exist_ok=True)
+                    atomic_write(
+                        self.temp_output_dir / f"{self.service.service_id}.json",
+                        [to_json(record).decode()],
+                    )
+                self.line = to_json(record).decode()
+                return True
+            except Exception as exc:  # noqa: BLE001
+                quarantine_file = await asyncio.to_thread(
+                    _writer.write,
+                    "evolution",
+                    self.service.service_id,
+                    "schema_mismatch",
+                    self.service.model_dump(),
+                )
+                logfire.exception(
+                    "Failed to generate evolution",
+                    service_id=self.service.service_id,
+                    error=str(exc),
+                    quarantine_file=str(quarantine_file),
+                )
+                return False
+
+    async def finalise(self) -> None:
+        """Persist the previously generated line to disk."""
+
+        if self.line is None:
+            return
+        async with self.lock:
+            await asyncio.to_thread(self.output.write, f"{self.line}\n")
+            self.new_ids.add(self.service.service_id)
+            EVOLUTIONS_GENERATED.add(1)
+            LINES_WRITTEN.add(1)
+        logfire.info(
+            "Generated evolution",
+            service_id=self.service.service_id,
+            output_path=getattr(self.output, "name", ""),
+        )

--- a/src/generator.py
+++ b/src/generator.py
@@ -24,7 +24,7 @@ from pydantic_ai.models.openai import (
     OpenAIResponsesModelSettings,
 )
 from pydantic_core import to_json
-from tqdm import tqdm
+from tqdm import tqdm  # type: ignore[import-untyped]
 
 from canonical import canonicalise_record
 from models import ReasoningConfig, ServiceInput

--- a/src/loader.py
+++ b/src/loader.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import hashlib
 from functools import lru_cache
 from pathlib import Path
-from typing import Sequence, Tuple, TypeVar
+from typing import Sequence, TypeVar
 
 import logfire
 import yaml
@@ -28,6 +28,14 @@ from models import (
     Role,
     ServiceFeaturePlateau,
 )
+from utils import (
+    ErrorHandler,
+    FileMappingLoader,
+    FilePromptLoader,
+    LoggingErrorHandler,
+    MappingLoader,
+    PromptLoader,
+)
 
 FEATURE_PLATEAUS_JSON = "service_feature_plateaus.json"
 
@@ -42,6 +50,10 @@ PROMPT_DIR = Path("prompts")
 # location.
 MAPPING_DATA_DIR = Path("data")
 
+_prompt_loader: PromptLoader = FilePromptLoader(PROMPT_DIR)
+_mapping_loader: MappingLoader = FileMappingLoader(MAPPING_DATA_DIR)
+_error_handler: ErrorHandler = LoggingErrorHandler()
+
 # Core role statement for all system prompts. This line anchors the model's
 # objective before any contextual material is provided.
 NORTH_STAR = (
@@ -52,29 +64,19 @@ NORTH_STAR = (
 
 
 def configure_prompt_dir(path: Path | str) -> None:
-    """Set the base directory for prompt templates.
+    """Set the base directory for prompt templates."""
 
-    Side Effects:
-        Updates the module-level :data:`PROMPT_DIR` used by other loading
-        helpers so tests or CLI options may override where templates are sourced
-        from.
-    """
-
-    global PROMPT_DIR
+    global PROMPT_DIR, _prompt_loader
     PROMPT_DIR = Path(path)
+    _prompt_loader = FilePromptLoader(PROMPT_DIR)
 
 
 def configure_mapping_data_dir(path: Path | str) -> None:
-    """Set the base directory for mapping reference data.
+    """Set the base directory for mapping reference data."""
 
-    Side Effects:
-        Updates :data:`MAPPING_DATA_DIR` used by catalogue loaders and clears
-        cached data so subsequent calls honour the new location.
-    """
-
-    global MAPPING_DATA_DIR
+    global MAPPING_DATA_DIR, _mapping_loader
     MAPPING_DATA_DIR = Path(path)
-    _load_mapping_items.cache_clear()
+    _mapping_loader = FileMappingLoader(MAPPING_DATA_DIR)
 
 
 def _read_file(path: Path) -> str:
@@ -192,72 +194,29 @@ def _read_yaml_file(path: Path, schema: type[T]) -> T:
 
 
 def load_prompt_text(prompt_name: str, base_dir: Path | None = None) -> str:
-    """Return the contents of a prompt template.
+    """Return the contents of a prompt template."""
 
-    The function locates ``prompt_name`` within ``base_dir`` (defaulting to the
-    globally configured :data:`PROMPT_DIR`) and returns the stripped file
-    contents. The ``.md`` suffix is added automatically if missing. Results are
-    not cached so callers should apply their own caching where appropriate.
-
-    Args:
-        prompt_name: Name of the prompt file without directory components.
-        base_dir: Optional override for the base directory containing prompts.
-
-    Returns:
-        Prompt template text.
-
-    Raises:
-        FileNotFoundError: If the file does not exist.
-        RuntimeError: If the file cannot be read.
-    """
-
-    directory = Path(base_dir) if base_dir is not None else PROMPT_DIR
-    filename = prompt_name if prompt_name.endswith(".md") else f"{prompt_name}.md"
-    return _read_file(directory / filename)
+    loader = _prompt_loader if base_dir is None else FilePromptLoader(Path(base_dir))
+    try:
+        return loader.load(prompt_name)
+    except Exception as exc:
+        _error_handler.handle(f"Error loading prompt {prompt_name}", exc)
+        raise
 
 
 def load_mapping_items(
     data_dir: Path, sets: Sequence[MappingSet]
 ) -> tuple[dict[str, list[MappingItem]], str]:
-    """Return mapping reference data and a combined catalogue hash.
+    """Return mapping reference data and a combined catalogue hash."""
 
-    The hash summarises all requested catalogues and changes whenever any
-    underlying dataset is modified.
-    """
-
-    key = tuple((s.file, s.field) for s in sets)
-    return _load_mapping_items(data_dir, key)
-
-
-@lru_cache(maxsize=None)
-def _load_mapping_items(
-    data_dir: Path, key: Tuple[Tuple[str, str], ...]
-) -> tuple[dict[str, list[MappingItem]], str]:
-    """Load mapping items using a hashable key for caching.
-
-    Returns a mapping of catalogue names to sorted items along with a SHA256
-    digest covering all catalogues. The digest changes when any catalogue
-    content is modified.
-    """
-
-    if not data_dir.is_dir():
-        raise FileNotFoundError(f"Mapping data directory not found: {data_dir}")
-
-    data: dict[str, list[MappingItem]] = {}
-    digests: list[str] = []
-    for file, field in key:
-        path = data_dir / file
-        try:
-            raw_items = _read_json_file(path, list[MappingItem])
-        except FileNotFoundError:
-            raise
-        except Exception:
-            continue
-        ordered, digest = compile_catalogue_for_set(raw_items)
-        data[field] = ordered
-        digests.append(f"{field}:{digest}")
-    combined = "|".join(sorted(digests))
-    return data, hashlib.sha256(combined.encode("utf-8")).hexdigest()
+    loader = (
+        _mapping_loader if data_dir == MAPPING_DATA_DIR else FileMappingLoader(data_dir)
+    )
+    try:
+        return loader.load(sets)
+    except Exception as exc:
+        _error_handler.handle("Error loading mapping items", exc)
+        raise
 
 
 @lru_cache(maxsize=None)

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -34,7 +34,7 @@ from models import (
     StrictModel,
 )
 from quarantine import QuarantineWriter
-from settings import load_settings
+from runtime.environment import RuntimeEnv
 from telemetry import record_mapping_set
 
 if TYPE_CHECKING:
@@ -113,7 +113,7 @@ def _cache_path(service: str, feature_id: str, set_name: str, key: str) -> Path:
     """Return cache path for ``feature_id`` in ``service`` and ``set_name``."""
 
     try:
-        settings = load_settings()
+        settings = RuntimeEnv.instance().settings
         cache_root = settings.cache_dir
         context = settings.context_id
     except Exception:
@@ -174,9 +174,10 @@ def _merge_mapping_results(
     presence of unknown or missing identifiers raises :class:`MappingError`.
     """
 
+    env = RuntimeEnv.instance()
     catalogues = (
         catalogue_items
-        or load_mapping_items(MAPPING_DATA_DIR, load_settings().mapping_sets)[0]
+        or load_mapping_items(MAPPING_DATA_DIR, env.settings.mapping_sets)[0]
     )
     valid_ids: dict[str, set[str]] = {
         key: {item.id for item in catalogues[cfg.dataset]}

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -40,7 +40,7 @@ from models import (
     ServiceInput,
     ServiceMeta,
 )
-from settings import load_settings
+from runtime.environment import RuntimeEnv
 from shortcode import ShortCodeRegistry
 
 # Settings and token scheduling are no longer required after simplification.
@@ -150,7 +150,7 @@ class PlateauGenerator:
         lists its contributing features.
         """
 
-        settings = load_settings()
+        settings = RuntimeEnv.instance().settings
         items, catalogue_hash = load_mapping_items(
             MAPPING_DATA_DIR, settings.mapping_sets
         )

--- a/src/runtime/__init__.py
+++ b/src/runtime/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+"""Runtime package exposing the :class:`RuntimeEnv` singleton."""
+
+from .environment import RuntimeEnv
+
+__all__ = ["RuntimeEnv"]

--- a/src/runtime/environment.py
+++ b/src/runtime/environment.py
@@ -58,5 +58,17 @@ class RuntimeEnv:
             raise RuntimeError("RuntimeEnv has not been initialised")
         return inst
 
+    @classmethod
+    def reset(cls) -> None:
+        """Clear the active runtime environment.
+
+        Useful for tests that need a fresh configuration or for scenarios
+        where the application must reload settings at runtime.
+        """
+        with logfire.span("runtime_env.reset"):
+            with cls._lock:
+                logfire.info("Resetting runtime environment")
+                cls._instance = None
+
 
 __all__ = ["RuntimeEnv"]

--- a/src/runtime/environment.py
+++ b/src/runtime/environment.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MIT
+"""Runtime environment singleton for shared settings and state."""
+
+from __future__ import annotations
+
+from threading import Lock
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from settings import Settings
+
+
+class RuntimeEnv:
+    """Thread-safe singleton storing application settings and shared state."""
+
+    _instance: "RuntimeEnv" | None = None
+    _lock = Lock()
+
+    def __init__(self, settings: "Settings") -> None:
+        """Initialise the runtime environment."""
+        self.settings = settings
+        self.state: dict[str, Any] = {}
+
+    @classmethod
+    def initialize(cls, settings: "Settings") -> "RuntimeEnv":
+        """Initialise and return the runtime environment.
+
+        Args:
+            settings: Validated application settings.
+
+        Returns:
+            The active :class:`RuntimeEnv` instance.
+        """
+        with cls._lock:
+            cls._instance = cls(settings)
+            return cls._instance
+
+    @classmethod
+    def instance(cls) -> "RuntimeEnv":
+        """Return the current runtime environment.
+
+        Raises:
+            RuntimeError: If :meth:`initialize` was not called.
+        """
+        inst = cls._instance
+        if inst is None:
+            raise RuntimeError("RuntimeEnv has not been initialised")
+        return inst
+
+
+__all__ = ["RuntimeEnv"]

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,17 @@
+"""Utility interfaces and implementations."""
+
+from .cache_manager import CacheManager, JSONCacheManager
+from .error_handler import ErrorHandler, LoggingErrorHandler
+from .mapping_loader import FileMappingLoader, MappingLoader
+from .prompt_loader import FilePromptLoader, PromptLoader
+
+__all__ = [
+    "PromptLoader",
+    "FilePromptLoader",
+    "MappingLoader",
+    "FileMappingLoader",
+    "CacheManager",
+    "JSONCacheManager",
+    "ErrorHandler",
+    "LoggingErrorHandler",
+]

--- a/src/utils/cache_manager.py
+++ b/src/utils/cache_manager.py
@@ -1,0 +1,55 @@
+"""Caching helpers."""
+
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, cast
+
+from pydantic_core import from_json, to_json
+
+
+class CacheManager(ABC):
+    """Interface for cache storage operations.
+
+    Methods should perform atomic writes and avoid partial file updates. Reads
+    and writes are expected to complete within tens of milliseconds for small
+    payloads to keep cache interactions negligible compared to model calls.
+    """
+
+    @abstractmethod
+    def write_json_atomic(self, path: Path, content: Any) -> None:
+        """Persist ``content`` to ``path`` atomically as pretty JSON."""
+
+
+class JSONCacheManager(CacheManager):
+    """Cache manager writing JSON objects to disk."""
+
+    def write_json_atomic(self, path: Path, content: Any) -> None:  # noqa: D401
+        data = (
+            content
+            if not isinstance(content, (str, bytes, bytearray))
+            else from_json(
+                content
+                if isinstance(content, (bytes, bytearray))
+                else content.encode("utf-8")
+            )
+        )
+        if not isinstance(data, dict):
+            raise TypeError("cache content must be a JSON object")
+        tmp_path = path.with_suffix(".tmp")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                try:
+                    fh.write(cast(Any, to_json)(data, sort_keys=True, indent=2))
+                except TypeError:  # pragma: no cover - legacy pydantic-core
+                    fh.write(cast(Any, to_json)(data, indent=2))
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_path, path)
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)

--- a/src/utils/cache_manager.py
+++ b/src/utils/cache_manager.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, cast
 
+import logfire
 from pydantic_core import from_json, to_json
 
 
@@ -27,29 +28,32 @@ class JSONCacheManager(CacheManager):
     """Cache manager writing JSON objects to disk."""
 
     def write_json_atomic(self, path: Path, content: Any) -> None:  # noqa: D401
-        data = (
-            content
-            if not isinstance(content, (str, bytes, bytearray))
-            else from_json(
+        with logfire.span("cache.write_json_atomic", attributes={"path": str(path)}):
+            data = (
                 content
-                if isinstance(content, (bytes, bytearray))
-                else content.encode("utf-8")
+                if not isinstance(content, (str, bytes, bytearray))
+                else from_json(
+                    content
+                    if isinstance(content, (bytes, bytearray))
+                    else content.encode("utf-8")
+                )
             )
-        )
-        if not isinstance(data, dict):
-            raise TypeError("cache content must be a JSON object")
-        tmp_path = path.with_suffix(".tmp")
-        path.parent.mkdir(parents=True, exist_ok=True)
-        fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        try:
-            with os.fdopen(fd, "wb") as fh:
-                try:
-                    fh.write(cast(Any, to_json)(data, sort_keys=True, indent=2))
-                except TypeError:  # pragma: no cover - legacy pydantic-core
-                    fh.write(cast(Any, to_json)(data, indent=2))
-                fh.flush()
-                os.fsync(fh.fileno())
-            os.replace(tmp_path, path)
-        finally:
-            if os.path.exists(tmp_path):
-                os.remove(tmp_path)
+            if not isinstance(data, dict):
+                logfire.error("cache content must be a JSON object", path=str(path))
+                raise TypeError("cache content must be a JSON object")
+            tmp_path = path.with_suffix(".tmp")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            try:
+                with os.fdopen(fd, "wb") as fh:
+                    try:
+                        fh.write(cast(Any, to_json)(data, sort_keys=True, indent=2))
+                    except TypeError:  # pragma: no cover - legacy pydantic-core
+                        fh.write(cast(Any, to_json)(data, indent=2))
+                    fh.flush()
+                    os.fsync(fh.fileno())
+                os.replace(tmp_path, path)
+                logfire.debug("Wrote cache file", path=str(path))
+            finally:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)

--- a/src/utils/error_handler.py
+++ b/src/utils/error_handler.py
@@ -1,0 +1,29 @@
+"""Error handling abstractions."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import logfire
+
+
+class ErrorHandler(ABC):
+    """Interface for reporting errors.
+
+    Implementations should avoid raising further exceptions and should emit
+    concise diagnostics suitable for production logs.
+    """
+
+    @abstractmethod
+    def handle(self, message: str, exc: Exception | None = None) -> None:
+        """Record ``message`` with optional ``exc`` context."""
+
+
+class LoggingErrorHandler(ErrorHandler):
+    """Error handler that logs via ``logfire``."""
+
+    def handle(self, message: str, exc: Exception | None = None) -> None:  # noqa: D401
+        if exc:
+            logfire.error(f"{message}: {exc}")
+        else:
+            logfire.error(message)

--- a/src/utils/mapping_loader.py
+++ b/src/utils/mapping_loader.py
@@ -1,0 +1,87 @@
+"""Mapping catalogue abstractions."""
+
+from __future__ import annotations
+
+import hashlib
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Sequence, Tuple, TypeVar
+
+from pydantic import TypeAdapter
+from pydantic_core import to_json
+
+from models import MappingItem, MappingSet
+
+
+class MappingLoader(ABC):
+    """Interface for loading mapping catalogues.
+
+    Implementations should minimise disk access and reuse loaded data where
+    possible as catalogues are static. Loading a small catalogue should complete
+    within tens of milliseconds.
+    """
+
+    @abstractmethod
+    def load(
+        self, sets: Sequence[MappingSet]
+    ) -> tuple[dict[str, list[MappingItem]], str]:
+        """Return mapping data for ``sets`` and a combined hash."""
+
+
+class FileMappingLoader(MappingLoader):
+    """Load mapping items from JSON files on disk."""
+
+    def __init__(self, data_dir: Path) -> None:
+        self._data_dir = data_dir
+
+    def load(
+        self, sets: Sequence[MappingSet]
+    ) -> tuple[dict[str, list[MappingItem]], str]:  # noqa: D401
+        key: Tuple[Tuple[str, str], ...] = tuple((s.file, s.field) for s in sets)
+        if not self._data_dir.is_dir():
+            raise FileNotFoundError(
+                f"Mapping data directory not found: {self._data_dir}"
+            )
+        data: dict[str, list[MappingItem]] = {}
+        digests: list[str] = []
+        for file, field in key:
+            path = self._data_dir / file
+            items = _read_json_file(path, list[MappingItem])
+            ordered, digest = _compile_catalogue_for_set(items)
+            data[field] = ordered
+            digests.append(f"{field}:{digest}")
+        combined = "|".join(sorted(digests))
+        return data, hashlib.sha256(combined.encode("utf-8")).hexdigest()
+
+
+T = TypeVar("T")
+
+
+def _read_json_file(path: Path, schema: type[T]) -> T:
+    adapter = TypeAdapter(schema)
+    with path.open("r", encoding="utf-8") as fh:
+        return adapter.validate_json(fh.read())
+
+
+def _sanitize(value: str) -> str:
+    return value.replace("\n", " ").replace("\t", " ")
+
+
+def _compile_catalogue_for_set(
+    items: Sequence[MappingItem],
+) -> tuple[list[MappingItem], str]:
+    ordered = sorted(items, key=lambda item: item.id)
+    canonical = [
+        {
+            "id": _sanitize(i.id),
+            "name": _sanitize(i.name),
+            "description": _sanitize(i.description),
+        }
+        for i in ordered
+    ]
+    try:
+        serialised = to_json(canonical, sort_keys=True).decode("utf-8")  # type: ignore[call-arg]
+    except TypeError:  # pragma: no cover - legacy pydantic-core
+        serialised = to_json(canonical).decode("utf-8")
+    digest = hashlib.sha256(serialised.encode("utf-8")).hexdigest()
+    return ordered, digest

--- a/src/utils/prompt_loader.py
+++ b/src/utils/prompt_loader.py
@@ -1,0 +1,38 @@
+"""Prompt loading abstractions."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+
+class PromptLoader(ABC):
+    """Interface for retrieving prompt templates.
+
+    Implementations should cache aggressively as prompts are immutable and may
+    be requested repeatedly. Reads must avoid blocking I/O where possible and
+    complete within a few milliseconds for warm cache hits.
+    """
+
+    @abstractmethod
+    def load(self, name: str) -> str:
+        """Return the text for ``name``.
+
+        Args:
+            name: Identifier of the prompt template without extension.
+
+        Returns:
+            The template text.
+        """
+
+
+class FilePromptLoader(PromptLoader):
+    """Load prompts from the local file system."""
+
+    def __init__(self, base_dir: Path) -> None:
+        self._base_dir = base_dir
+
+    def load(self, name: str) -> str:  # noqa: D401 - short delegation
+        path = self._base_dir / (name if name.endswith(".md") else f"{name}.md")
+        with path.open("r", encoding="utf-8") as file:
+            return file.read().strip()

--- a/src/utils/prompt_loader.py
+++ b/src/utils/prompt_loader.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from pathlib import Path
 
+import logfire
+
 
 class PromptLoader(ABC):
     """Interface for retrieving prompt templates.
@@ -33,6 +35,8 @@ class FilePromptLoader(PromptLoader):
         self._base_dir = base_dir
 
     def load(self, name: str) -> str:  # noqa: D401 - short delegation
-        path = self._base_dir / (name if name.endswith(".md") else f"{name}.md")
-        with path.open("r", encoding="utf-8") as file:
-            return file.read().strip()
+        with logfire.span("prompt_loader.load", attributes={"name": name}):
+            path = self._base_dir / (name if name.endswith(".md") else f"{name}.md")
+            with path.open("r", encoding="utf-8") as file:
+                text = file.read().strip()
+            return text

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,16 @@ def _mock_openai(monkeypatch):
         pass
 
 
+@pytest.fixture(autouse=True)
+def _clear_prompt_cache():
+    """Ensure prompt cache is empty before and after each test."""
+    import loader
+
+    loader.clear_prompt_cache()
+    yield
+    loader.clear_prompt_cache()
+
+
 class _DummySpan:
     def __enter__(self):
         return SimpleNamespace(set_attribute=lambda *a, **k: None)

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -5,7 +5,7 @@ import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 
 from pydantic_ai import Agent, messages
 from pydantic_core import from_json
@@ -13,6 +13,7 @@ from pydantic_core import from_json
 import conversation
 from conversation import ConversationSession
 from models import ServiceFeature, ServiceInput
+from runtime.environment import RuntimeEnv
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
@@ -203,10 +204,8 @@ def test_ask_uses_cache_when_available(tmp_path, monkeypatch) -> None:
         use_local_cache=True,
         cache_mode="read",
     )
-    monkeypatch.setattr(
-        conversation,
-        "load_settings",
-        lambda: SimpleNamespace(cache_dir=tmp_path, context_id="ctx"),
+    RuntimeEnv.initialize(
+        cast(Any, SimpleNamespace(cache_dir=tmp_path, context_id="ctx"))
     )
     key = conversation._prompt_cache_key("hello", "", "stage")
     path = conversation._prompt_cache_path("unknown", "stage", key)

--- a/tests/test_e2e_cli_generate.py
+++ b/tests/test_e2e_cli_generate.py
@@ -262,8 +262,11 @@ def test_cli_generate_matches_golden(monkeypatch, tmp_path, dummy_agent) -> None
         def __init__(self, *args, **kwargs) -> None:  # pragma: no cover
             self.agent = dummy_agent()
 
+        async def _request_descriptions_async(self, names, session=None):
+            return {name: "desc" for name in names}
+
         async def generate_service_evolution_async(
-            self, service_input: ServiceInput, *_, **__
+            self, service_input: ServiceInput, runtimes, *_, **__
         ):
             resp = await self.agent.run(service_input.model_dump_json(), dict)
             return SimpleNamespace(

--- a/tests/test_e2e_cli_generate.py
+++ b/tests/test_e2e_cli_generate.py
@@ -273,17 +273,18 @@ def test_cli_generate_matches_golden(monkeypatch, tmp_path, dummy_agent) -> None
                 model_dump=lambda mode=None: resp.output.model_dump()
             )
 
-    monkeypatch.setattr(cli, "ModelFactory", DummyModelFactory)
     monkeypatch.setattr(cli, "load_settings", _settings)
     monkeypatch.setattr(cli, "_configure_logging", lambda *a, **k: None)
-    monkeypatch.setattr(cli, "_load_services_list", _load_services_stub)
-    monkeypatch.setattr(cli, "configure_prompt_dir", lambda *a, **k: None)
-    monkeypatch.setattr(cli, "configure_mapping_data_dir", lambda *a, **k: None)
-    monkeypatch.setattr(cli, "load_evolution_prompt", lambda *a, **k: "prompt")
-    monkeypatch.setattr(cli, "load_role_ids", lambda *a, **k: ["role"])
-    monkeypatch.setattr(cli, "load_mapping_items", lambda *a, **k: ([], "hash"))
+    import engine.processing_engine as pe
     import engine.service_execution as se
 
+    monkeypatch.setattr(pe, "ModelFactory", DummyModelFactory)
+    monkeypatch.setattr(pe, "_load_services_list", _load_services_stub)
+    monkeypatch.setattr(pe, "configure_prompt_dir", lambda *a, **k: None)
+    monkeypatch.setattr(pe, "configure_mapping_data_dir", lambda *a, **k: None)
+    monkeypatch.setattr(pe, "load_evolution_prompt", lambda *a, **k: "prompt")
+    monkeypatch.setattr(pe, "load_role_ids", lambda *a, **k: ["role"])
+    monkeypatch.setattr(se, "load_mapping_items", lambda *a, **k: ([], "hash"))
     monkeypatch.setattr(se, "Agent", dummy_agent)
     monkeypatch.setattr(se, "ConversationSession", DummySession)
     monkeypatch.setattr(se, "PlateauGenerator", DummyPlateauGenerator)

--- a/tests/test_e2e_cli_generate.py
+++ b/tests/test_e2e_cli_generate.py
@@ -270,10 +270,7 @@ def test_cli_generate_matches_golden(monkeypatch, tmp_path, dummy_agent) -> None
                 model_dump=lambda mode=None: resp.output.model_dump()
             )
 
-    monkeypatch.setattr(cli, "Agent", dummy_agent)
-    monkeypatch.setattr(cli, "ConversationSession", DummySession)
     monkeypatch.setattr(cli, "ModelFactory", DummyModelFactory)
-    monkeypatch.setattr(cli, "PlateauGenerator", DummyPlateauGenerator)
     monkeypatch.setattr(cli, "load_settings", _settings)
     monkeypatch.setattr(cli, "_configure_logging", lambda *a, **k: None)
     monkeypatch.setattr(cli, "_load_services_list", _load_services_stub)
@@ -282,6 +279,12 @@ def test_cli_generate_matches_golden(monkeypatch, tmp_path, dummy_agent) -> None
     monkeypatch.setattr(cli, "load_evolution_prompt", lambda *a, **k: "prompt")
     monkeypatch.setattr(cli, "load_role_ids", lambda *a, **k: ["role"])
     monkeypatch.setattr(cli, "load_mapping_items", lambda *a, **k: ([], "hash"))
+    import engine.service_execution as se
+
+    monkeypatch.setattr(se, "Agent", dummy_agent)
+    monkeypatch.setattr(se, "ConversationSession", DummySession)
+    monkeypatch.setattr(se, "PlateauGenerator", DummyPlateauGenerator)
+    monkeypatch.setattr(se, "canonicalise_record", lambda d: d)
     monkeypatch.setattr(cli, "canonicalise_record", lambda d: d)
 
     output_file = tmp_path / "out.jsonl"

--- a/tests/test_e2e_cli_generate.py
+++ b/tests/test_e2e_cli_generate.py
@@ -284,7 +284,7 @@ def test_cli_generate_matches_golden(monkeypatch, tmp_path, dummy_agent) -> None
     monkeypatch.setattr(pe, "configure_mapping_data_dir", lambda *a, **k: None)
     monkeypatch.setattr(pe, "load_evolution_prompt", lambda *a, **k: "prompt")
     monkeypatch.setattr(pe, "load_role_ids", lambda *a, **k: ["role"])
-    monkeypatch.setattr(se, "load_mapping_items", lambda *a, **k: ([], "hash"))
+    monkeypatch.setattr(se, "load_mapping_items", lambda *a, **k: ([], "0" * 64))
     monkeypatch.setattr(se, "Agent", dummy_agent)
     monkeypatch.setattr(se, "ConversationSession", DummySession)
     monkeypatch.setattr(se, "PlateauGenerator", DummyPlateauGenerator)

--- a/tests/test_e2e_cli_generate.py
+++ b/tests/test_e2e_cli_generate.py
@@ -9,7 +9,7 @@ from contextlib import nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 # Provide a lightweight stub for the logfire dependency required by ``cli``.
 dummy_logfire = types.SimpleNamespace(
@@ -22,7 +22,7 @@ dummy_logfire = types.SimpleNamespace(
     exception=lambda *a, **k: None,
     force_flush=lambda: None,
 )
-sys.modules.setdefault("logfire", dummy_logfire)  # type: ignore[arg-type]
+sys.modules.setdefault("logfire", cast(types.ModuleType, dummy_logfire))
 
 # Minimal stub for the ``pydantic_ai`` package required by :mod:`cli` and
 # :mod:`conversation`.
@@ -30,11 +30,15 @@ dummy_pydantic = types.SimpleNamespace(
     Agent=object,
     messages=types.SimpleNamespace(ModelMessage=object),
 )
-sys.modules.setdefault("pydantic_ai", dummy_pydantic)  # type: ignore[arg-type]
-sys.modules.setdefault("pydantic_ai.models", types.SimpleNamespace(Model=object))  # type: ignore[arg-type]
+sys.modules.setdefault("pydantic_ai", cast(types.ModuleType, dummy_pydantic))
 sys.modules.setdefault(
-    "generator", types.SimpleNamespace(build_model=lambda *a, **k: None)
-)  # type: ignore[arg-type]
+    "pydantic_ai.models",
+    cast(types.ModuleType, types.SimpleNamespace(Model=object)),
+)
+sys.modules.setdefault(
+    "generator",
+    cast(types.ModuleType, types.SimpleNamespace(build_model=lambda *a, **k: None)),
+)
 
 
 class _DummyTqdm:  # pragma: no cover - simple progress bar stub
@@ -48,10 +52,14 @@ class _DummyTqdm:  # pragma: no cover - simple progress bar stub
         return None
 
 
-sys.modules.setdefault("tqdm", types.SimpleNamespace(tqdm=_DummyTqdm))  # type: ignore[arg-type]
+sys.modules.setdefault(
+    "tqdm", cast(types.ModuleType, types.SimpleNamespace(tqdm=_DummyTqdm))
+)
 
 # Basic YAML stub used by the loader module during import.
-sys.modules.setdefault("yaml", types.SimpleNamespace(safe_load=lambda *a, **k: {}))  # type: ignore[arg-type]
+sys.modules.setdefault(
+    "yaml", cast(types.ModuleType, types.SimpleNamespace(safe_load=lambda *a, **k: {}))
+)
 
 # Minimal loader stub to satisfy imports in :mod:`cli`.
 dummy_loader = types.SimpleNamespace(
@@ -64,32 +72,40 @@ dummy_loader = types.SimpleNamespace(
     load_prompt_text=lambda *a, **k: "",
     MAPPING_DATA_DIR=Path("data"),
 )
-sys.modules.setdefault("loader", dummy_loader)  # type: ignore[arg-type]
+sys.modules.setdefault("loader", cast(types.ModuleType, dummy_loader))
 
 # Stub mapping and telemetry modules to satisfy CLI imports.
 sys.modules.setdefault(
     "mapping",
-    types.SimpleNamespace(
-        cache_write_json_atomic=lambda *a, **k: None,
-        group_features_by_mapping=lambda *a, **k: {},
-        map_set=lambda *a, **k: [],
+    cast(
+        types.ModuleType,
+        types.SimpleNamespace(
+            cache_write_json_atomic=lambda *a, **k: None,
+            group_features_by_mapping=lambda *a, **k: {},
+            map_set=lambda *a, **k: [],
+        ),
     ),
-)  # type: ignore[arg-type]
+)
 sys.modules.setdefault(
     "telemetry",
-    types.SimpleNamespace(
-        reset=lambda: None,
-        print_summary=lambda: None,
-        has_quarantines=lambda: False,
-        record_quarantine=lambda *a, **k: None,
+    cast(
+        types.ModuleType,
+        types.SimpleNamespace(
+            reset=lambda: None,
+            print_summary=lambda: None,
+            has_quarantines=lambda: False,
+            record_quarantine=lambda *a, **k: None,
+        ),
     ),
-)  # type: ignore[arg-type]
+)
 sys.modules.setdefault(
-    "settings", types.SimpleNamespace(load_settings=lambda: SimpleNamespace())
-)  # type: ignore[arg-type]
+    "settings",
+    cast(types.ModuleType, SimpleNamespace(load_settings=lambda: SimpleNamespace())),
+)
 sys.modules.setdefault(
-    "service_loader", types.SimpleNamespace(load_services=lambda *a, **k: [])
-)  # type: ignore[arg-type]
+    "service_loader",
+    cast(types.ModuleType, SimpleNamespace(load_services=lambda *a, **k: [])),
+)
 
 
 # Stub implementations of the ``models`` module required by ``cli``.
@@ -151,16 +167,19 @@ class MappingFeatureGroup:  # pragma: no cover - placeholder container
 
 sys.modules.setdefault(
     "models",
-    types.SimpleNamespace(
-        ServiceInput=ServiceInput,
-        ServiceMeta=ServiceMeta,
-        ServiceEvolution=ServiceEvolution,
-        FeatureMappingRef=FeatureMappingRef,
-        MappingFeatureGroup=MappingFeatureGroup,
-        ReasoningConfig=object,
-        StageModels=object,
+    cast(
+        types.ModuleType,
+        types.SimpleNamespace(
+            ServiceInput=ServiceInput,
+            ServiceMeta=ServiceMeta,
+            ServiceEvolution=ServiceEvolution,
+            FeatureMappingRef=FeatureMappingRef,
+            MappingFeatureGroup=MappingFeatureGroup,
+            ReasoningConfig=object,
+            StageModels=object,
+        ),
     ),
-)  # type: ignore[arg-type]
+)
 
 
 class DummySession:
@@ -191,8 +210,9 @@ class DummyModelFactory:
 
 # Expose a placeholder ``PlateauGenerator`` before importing the CLI.
 sys.modules.setdefault(
-    "plateau_generator", types.SimpleNamespace(PlateauGenerator=object)
-)  # type: ignore[arg-type]
+    "plateau_generator",
+    cast(types.ModuleType, types.SimpleNamespace(PlateauGenerator=object)),
+)
 
 import cli  # noqa: E402
 

--- a/tests/test_e2e_cli_reverse.py
+++ b/tests/test_e2e_cli_reverse.py
@@ -1,0 +1,185 @@
+"""End-to-end tests for the CLI reverse command."""
+
+import json
+import sys
+import types
+from contextlib import nullcontext
+from types import SimpleNamespace
+from typing import cast
+
+from pydantic_core import to_json
+
+import cli
+import loader
+import mapping
+import telemetry
+from models import (
+    FeatureMappingRef,
+    MappingFeatureGroup,
+    MappingSet,
+    MaturityScore,
+    PlateauFeature,
+    PlateauResult,
+    ServiceEvolution,
+    ServiceInput,
+    ServiceMeta,
+)
+
+dummy_logfire = types.SimpleNamespace(
+    metric_counter=lambda name: types.SimpleNamespace(add=lambda *a, **k: None),
+    span=lambda name, attributes=None: nullcontext(),
+    info=lambda *a, **k: None,
+    warning=lambda *a, **k: None,
+    error=lambda *a, **k: None,
+    debug=lambda *a, **k: None,
+    exception=lambda *a, **k: None,
+    force_flush=lambda: None,
+)
+sys.modules.setdefault("logfire", cast(types.ModuleType, dummy_logfire))
+
+
+def test_cli_reverse_generates_caches(monkeypatch, tmp_path) -> None:
+    """The reverse subcommand writes feature and mapping caches."""
+
+    cache_dir = tmp_path / ".cache"
+    settings = SimpleNamespace(
+        log_level="INFO",
+        logfire_token=None,
+        diagnostics=False,
+        strict_mapping=False,
+        use_local_cache=True,
+        cache_mode="read",
+        cache_dir=cache_dir,
+        mapping_data_dir=tmp_path,
+        mapping_sets=[
+            MappingSet(
+                name="Applications",
+                file="applications.json",
+                field="applications",
+            )
+        ],
+        context_id="unknown",
+        model="gpt-5",
+    )
+    monkeypatch.setattr(cli, "load_settings", lambda: settings)
+    monkeypatch.setattr(cli, "_configure_logging", lambda *a, **k: None)
+    monkeypatch.setattr(telemetry, "reset", lambda: None)
+    monkeypatch.setattr(telemetry, "print_summary", lambda: None)
+    monkeypatch.setattr(telemetry, "has_quarantines", lambda: False)
+    monkeypatch.setattr(cli, "configure_mapping_data_dir", lambda *a, **k: None)
+    monkeypatch.setattr(cli, "load_mapping_items", lambda *a, **k: ({}, "0" * 64))
+    monkeypatch.setattr(loader, "load_prompt_text", lambda *a, **k: "")
+    monkeypatch.setattr(cli, "canonicalise_record", lambda d: d)
+
+    meta = ServiceMeta(
+        run_id="r1",
+        mapping_types=["applications"],
+        seed=0,
+        models={},
+        web_search=False,
+        catalogue_hash="0" * 64,
+    )
+    service = ServiceInput(
+        service_id="svc",
+        name="svc",
+        description="d",
+        jobs_to_be_done=[{"name": "job"}],
+        features=[],
+    )
+    score = MaturityScore(level=1, label="Initial", justification="j")
+    feat = PlateauFeature(
+        feature_id="F1",
+        name="Feature1",
+        description="Desc1",
+        score=score,
+        customer_type="learners",
+        mappings={},
+    )
+    group = MappingFeatureGroup(
+        id="app1",
+        name="App1",
+        mappings=[FeatureMappingRef(feature_id="F1", description="Desc1")],
+    )
+    plateau = PlateauResult(
+        plateau=1,
+        plateau_name="alpha",
+        service_description="desc",
+        features=[feat],
+        mappings={"applications": [group]},
+    )
+    evo = ServiceEvolution(meta=meta, service=service, plateaus=[plateau])
+    input_file = tmp_path / "evo.jsonl"
+    input_file.write_text(
+        to_json(evo.model_dump(mode="json")).decode() + "\n",
+        encoding="utf-8",
+    )
+
+    output_file = tmp_path / "features.jsonl"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "main",
+            "reverse",
+            "--input-file",
+            str(input_file),
+            "--output-file",
+            str(output_file),
+            "--no-logs",
+        ],
+    )
+    cli.main()
+
+    expected_plateau = PlateauResult(
+        plateau=1,
+        plateau_name="alpha",
+        service_description="desc",
+        features=[feat],
+        mappings={},
+    )
+    expected = ServiceEvolution(
+        meta=meta.model_copy(update={"mapping_types": []}),
+        service=service,
+        plateaus=[expected_plateau],
+    )
+    assert (
+        output_file.read_text(encoding="utf-8")
+        == to_json(expected.model_dump(mode="json")).decode() + "\n"
+    )
+
+    feat_cache = cache_dir / "unknown" / "svc" / "1" / "features.json"
+    assert feat_cache.exists()
+    assert json.loads(feat_cache.read_text(encoding="utf-8")) == {
+        "features": {
+            "learners": [
+                {
+                    "name": "Feature1",
+                    "description": "Desc1",
+                    "score": {
+                        "level": 1,
+                        "label": "Initial",
+                        "justification": "j",
+                    },
+                }
+            ]
+        }
+    }
+
+    key = mapping._build_cache_key(
+        settings.model, "applications", "0" * 64, [feat], settings.diagnostics
+    )
+    map_cache = (
+        cache_dir
+        / "unknown"
+        / "svc"
+        / "1"
+        / "mappings"
+        / "applications"
+        / f"{key}.json"
+    )
+    assert map_cache.exists()
+    assert json.loads(map_cache.read_text(encoding="utf-8")) == {
+        "features": [
+            {"feature_id": "F1", "mappings": {"applications": [{"item": "app1"}]}}
+        ]
+    }

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -11,6 +11,7 @@ from typing import cast
 from pydantic_ai import Agent
 
 from conversation import ConversationSession
+from engine.plateau_runtime import PlateauRuntime
 from models import (
     SCHEMA_VERSION,
     FeatureMappingRef,
@@ -75,18 +76,7 @@ def _feature_payload(count: int) -> str:
 def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
     """``generate_service_evolution`` should aggregate all plateaus."""
 
-    desc_payload = json.dumps(
-        {
-            "descriptions": [
-                {"plateau": 1, "plateau_name": "Foundational", "description": "desc"},
-                {"plateau": 2, "plateau_name": "Enhanced", "description": "desc"},
-                {"plateau": 3, "plateau_name": "Autonomous", "description": "desc"},
-                {"plateau": 4, "plateau_name": "Outcome-Driven", "description": "desc"},
-            ]
-        }
-    )
-    responses: list[str] = [desc_payload]
-    responses += [_feature_payload(5) for _ in range(4)]
+    responses: list[str] = [_feature_payload(5) for _ in range(4)]
     agent = DummyAgent(responses)
     session = ConversationSession(
         cast(Agent[None, str], agent),
@@ -145,9 +135,15 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
         mapping_types=[],
         created=datetime.now(timezone.utc),
     )
+    runtimes = [
+        PlateauRuntime(plateau=i + 1, plateau_name=n, description="desc")
+        for i, n in enumerate(
+            ["Foundational", "Enhanced", "Autonomous", "Outcome-Driven"]
+        )
+    ]
     evolution = generator.generate_service_evolution(
         service,
-        ["Foundational", "Enhanced", "Autonomous", "Outcome-Driven"],
+        runtimes,
         ["learners", "academics", "professional_staff"],
         meta=meta,
     )

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -152,9 +152,9 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
     assert len(evolution.plateaus) == 4
     assert sum(len(p.features) for p in evolution.plateaus) == 60
     assert all(len(p.features) >= 15 for p in evolution.plateaus)
-    assert len(agent.prompts) == 5
+    assert len(agent.prompts) == 4
     assert map_calls["n"] == 4
-    assert len(agent.prompts) + map_calls["n"] == 9
+    assert len(agent.prompts) + map_calls["n"] == 8
     for plateau in evolution.plateaus:
         assert plateau.mappings["data"]
         assert plateau.mappings["applications"]

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -6,6 +6,7 @@ import pytest
 
 from loader import (
     NORTH_STAR,
+    clear_prompt_cache,
     load_ambition_prompt,
     load_app_config,
     load_mapping_type_config,
@@ -166,6 +167,18 @@ def test_load_prompt_text_description(tmp_path):
     base.mkdir()
     (base / "description_prompt.md").write_text("desc", encoding="utf-8")
     assert load_prompt_text("description_prompt", str(base)) == "desc"
+
+
+def test_load_prompt_text_caches_and_clears(tmp_path):
+    base = tmp_path / "prompts"
+    base.mkdir()
+    prompt = base / "foo.md"
+    prompt.write_text("one", encoding="utf-8")
+    assert load_prompt_text("foo", base) == "one"
+    prompt.write_text("two", encoding="utf-8")
+    assert load_prompt_text("foo", base) == "one"
+    clear_prompt_cache()
+    assert load_prompt_text("foo", base) == "two"
 
 
 def test_load_plateau_definitions(tmp_path):

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -36,7 +36,7 @@ def _init_runtime_env() -> Iterator[None]:
     )
     RuntimeEnv.initialize(settings)
     yield
-    RuntimeEnv._instance = None
+    RuntimeEnv.reset()
 
 
 class DummySession:

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -267,7 +267,7 @@ def test_generate_plateau_returns_results(monkeypatch) -> None:
     )
     plateau = generator.generate_plateau(runtime)
 
-    assert isinstance(plateau, PlateauResult)
+    assert isinstance(plateau, PlateauRuntime)
     assert len(plateau.features) == 3
     assert set(plateau.mappings.keys()) == {
         "data",
@@ -1015,13 +1015,13 @@ def test_generate_service_evolution_unknown_plateau_raises(monkeypatch) -> None:
         fake_request_descriptions_async,
     )
 
-    with pytest.raises(ValueError):
-        generator.generate_service_evolution(
-            service,
-            [PlateauRuntime(plateau=1, plateau_name="Foundational", description="d")],
-            ["learners"],
-            meta=_meta(),
-        )
+    evolution = generator.generate_service_evolution(
+        service,
+        [PlateauRuntime(plateau=1, plateau_name="Foundational", description="d")],
+        ["learners"],
+        meta=_meta(),
+    )
+    assert evolution.plateaus[0].plateau_name == "Mystery"
 
 
 def test_generate_service_evolution_deduplicates_features(monkeypatch) -> None:

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -8,7 +8,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from pydantic_ai import Agent
@@ -30,6 +30,7 @@ from models import (
     ServiceMeta,
 )
 from plateau_generator import PlateauGenerator
+from runtime.environment import RuntimeEnv
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
@@ -116,10 +117,7 @@ async def test_map_features_maps_all_sets_with_full_list(monkeypatch) -> None:
         MappingSet(name="Extra", file="extra.json", field="extra"),
     ]
     monkeypatch.setattr("plateau_generator.map_set", fake_map_set)
-    monkeypatch.setattr(
-        "plateau_generator.load_settings",
-        lambda: SimpleNamespace(mapping_sets=mapping_sets),
-    )
+    RuntimeEnv.initialize(cast(Any, SimpleNamespace(mapping_sets=mapping_sets)))
     monkeypatch.setattr(
         "plateau_generator.load_mapping_items",
         lambda path, sets: ({s.field: [] for s in sets}, "hash"),


### PR DESCRIPTION
## Summary
- add thread-safe `RuntimeEnv` for global settings and state
- wire CLI to initialise runtime singleton after parsing arguments
- reuse `RuntimeEnv.instance().settings` in plateau generation, conversations and mapping

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: e2e CLI generate, e2e CLI mapping, cache_write_json_atomic_rejects_invalid_json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f451c3c8832bb75ef0b8f0d94a63