### PR TITLE
Add debug logging for cache operations and document log levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ instruments Pydantic, Pydantic AI, OpenAI and system metrics when run with the
 avoid writing local log files. Prompts are excluded from logs unless
 `--allow-prompt-logging` is specified.
 
+See [Logging levels](docs/logging-levels.md) for guidance on TRACE through
+EXCEPTION and when to use each level.
+
 ## Installation
 
 Dependencies are managed with [Poetry](https://python-poetry.org/). Install the

--- a/docs/logging-levels.md
+++ b/docs/logging-levels.md
@@ -1,0 +1,54 @@
+# Logging levels
+
+This project uses structured logging to describe application behaviour and
+troubleshooting information. Log entries are emitted at different levels to
+control verbosity. Each level builds on the ones before it, inheriting their
+messages while adding more detail.
+
+## TRACE
+* **Purpose:** Lowest level used for extremely fine‑grained events such as
+  variable assignments or internal library calls.
+* **Use:** Enable only when diagnosing elusive issues where every step matters.
+
+## DEBUG
+* **Purpose:** Provide detailed, contextual information about the application's
+  internal state. Debug logs capture variable values, decision paths and
+  interactions with external systems.
+* **Use:** Primarily during development and testing or when troubleshooting
+  specific production problems. Verbose output can impact performance and
+  storage.
+
+## INFO
+* **Purpose:** Record high‑level application progress and key state changes.
+* **Use:** Enabled in most environments to show normal operation without
+  excessive detail.
+
+## NOTICE
+* **Purpose:** Highlight significant events that are not errors but may require
+  attention, such as configuration fallbacks.
+* **Use:** Useful for operations teams monitoring long‑running processes.
+
+## WARNING
+* **Purpose:** Indicate potential problems or unexpected situations that do not
+  stop execution.
+* **Use:** Trigger investigation when observed; often precedes an error if left
+  unaddressed.
+
+## ERROR
+* **Purpose:** Report failures that prevent an operation from completing.
+* **Use:** Should be logged whenever an exception is caught and handled or when
+  user action is required to resolve an issue.
+
+## FATAL
+* **Purpose:** Capture irrecoverable conditions that lead to application
+  termination.
+* **Use:** Log immediately before exiting the process to preserve diagnostic
+  data.
+
+## EXCEPTION
+* **Purpose:** Emit stack traces for unhandled errors.
+* **Use:** Generally produced automatically by the logging system when an
+  exception propagates without being caught.
+
+For more on debugging practices, see the `--diagnostics` flag in the CLI which
+enables verbose logging and telemetry instrumentation.

--- a/scripts/migrate_cache.py
+++ b/scripts/migrate_cache.py
@@ -5,34 +5,44 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import logfire
 from pydantic_core import from_json, to_json
 
 
 def migrate(root: Path, context: str) -> None:
     """Rewrite caches under ``root`` into context/service hierarchy."""
 
-    for service_dir in root.iterdir():
-        if not service_dir.is_dir():
-            # Skip non-directory entries in the cache root
-            continue
-        service = service_dir.name
-        for file in service_dir.rglob("*.json"):
-            try:
-                with file.open("r", encoding="utf-8") as fh:
-                    data = from_json(fh.read())
-            except ValueError:
-                # Ignore files containing invalid JSON
+    with logfire.span(
+        "cache.migrate_legacy", attributes={"root": str(root), "context": context}
+    ):
+        logfire.debug("Starting cache migration", root=str(root), context=context)
+        for service_dir in root.iterdir():
+            if not service_dir.is_dir():
+                # Skip non-directory entries in the cache root
                 continue
-            rel = file.relative_to(service_dir)
-            parts = rel.parts
-            if parts and parts[0] in {"features", "mappings"}:
-                # Insert "unknown" placeholder for feature/mapping caches
-                rel = Path(parts[0]) / "unknown" / Path(*parts[1:])
-            new_path = root / context / service / rel
-            new_path.parent.mkdir(parents=True, exist_ok=True)
-            with new_path.open("w", encoding="utf-8") as fh:
-                fh.write(to_json(data).decode("utf-8"))
-            file.unlink()
+            service = service_dir.name
+            logfire.debug("Processing service directory", service=service)
+            for file in service_dir.rglob("*.json"):
+                logfire.debug("Migrating file", file=str(file))
+                try:
+                    with file.open("r", encoding="utf-8") as fh:
+                        data = from_json(fh.read())
+                except ValueError:
+                    # Ignore files containing invalid JSON
+                    logfire.warning("Invalid JSON, skipping", file=str(file))
+                    continue
+                rel = file.relative_to(service_dir)
+                parts = rel.parts
+                if parts and parts[0] in {"features", "mappings"}:
+                    # Insert "unknown" placeholder for feature/mapping caches
+                    rel = Path(parts[0]) / "unknown" / Path(*parts[1:])
+                new_path = root / context / service / rel
+                new_path.parent.mkdir(parents=True, exist_ok=True)
+                with new_path.open("w", encoding="utf-8") as fh:
+                    fh.write(to_json(data).decode("utf-8"))
+                file.unlink()
+                logfire.debug("Wrote migrated file", path=str(new_path))
+        logfire.debug("Cache migration complete", root=str(root), context=context)
 
 
 def main() -> None:

--- a/src/utils/cache_manager.py
+++ b/src/utils/cache_manager.py
@@ -41,6 +41,13 @@ class JSONCacheManager(CacheManager):
             if not isinstance(data, dict):
                 logfire.error("cache content must be a JSON object", path=str(path))
                 raise TypeError("cache content must be a JSON object")
+
+            logfire.debug(
+                "Preparing cache file write",
+                path=str(path),
+                keys=len(data),
+            )
+
             tmp_path = path.with_suffix(".tmp")
             path.parent.mkdir(parents=True, exist_ok=True)
             fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
@@ -53,7 +60,12 @@ class JSONCacheManager(CacheManager):
                     fh.flush()
                     os.fsync(fh.fileno())
                 os.replace(tmp_path, path)
-                logfire.debug("Wrote cache file", path=str(path))
+                size = path.stat().st_size
+                logfire.debug(
+                    "Wrote cache file",
+                    path=str(path),
+                    bytes=size,
+                )
             finally:
                 if os.path.exists(tmp_path):
                     os.remove(tmp_path)

--- a/tests/test_migrate_plateau_cache.py
+++ b/tests/test_migrate_plateau_cache.py
@@ -5,20 +5,22 @@ from __future__ import annotations
 import importlib.util
 import json
 from pathlib import Path
+from types import ModuleType
+from typing import Any, cast
 
 
-def _load_module() -> object:
+def _load_module() -> ModuleType:
     spec = importlib.util.spec_from_file_location(
         "migrate_plateau_cache", Path("scripts/migrate_plateau_cache.py")
     )
+    assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    assert spec.loader is not None
-    spec.loader.exec_module(module)  # type: ignore[reportAttributeAccessIssue]
+    spec.loader.exec_module(module)
     return module
 
 
 def test_migrate_moves_feature_and_mapping(tmp_path: Path) -> None:
-    module = _load_module()
+    module = cast(Any, _load_module())
     output = tmp_path / "output" / "ctx"
     cache = tmp_path / ".cache" / "ctx" / "svc"
     output.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- add detailed debug logging to cache manager and migration scripts
- document TRACE through EXCEPTION levels and link from README

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b53dbe0c90832b96d1d7d4f428d379