### PR TITLE
refactor: adopt logfire and simplify diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,9 @@ supports swapping sections to suit different industries.
 This project depends on the [Pydantic Logfire](https://logfire.pydantic.dev/)
 libraries for telemetry. The `LOGFIRE_TOKEN` environment variable is optional:
 without it, Logfire still records logs and metrics locally but nothing is sent
-to the cloud. Provide a token to stream traces to Logfire. The CLI only
-instruments Pydantic, Pydantic AI, OpenAI and system metrics when run with the
-`--diagnostics` flag, which enables verbose diagnostics. Use `--no-logs` to
-avoid writing local log files. Prompts are excluded from logs unless
-`--allow-prompt-logging` is specified.
+to the cloud. Provide a token to stream traces to Logfire. The CLI instruments
+Pydantic, Pydantic AI, OpenAI and system metrics by default. Prompts are
+excluded from logs unless `--allow-prompt-logging` is specified.
 
 See [Logging levels](docs/logging-levels.md) for guidance on TRACE through
 EXCEPTION and when to use each level.
@@ -134,19 +132,17 @@ Run the CLI through Poetry to ensure it uses the managed environment. Use
 subcommands to select the desired operation:
 
 ```bash
-poetry run service-ambitions run --input-file sample-services.jsonl --output-file evolutions.jsonl --no-logs
-poetry run service-ambitions diagnose --input-file sample-services.jsonl --output-file evolutions.jsonl --no-logs
-poetry run service-ambitions validate --input-file sample-services.jsonl --no-logs
-poetry run service-ambitions reverse --input-file evolutions.jsonl --output-file features.jsonl --no-logs
+poetry run service-ambitions run --input-file sample-services.jsonl --output-file evolutions.jsonl
+poetry run service-ambitions validate --input-file sample-services.jsonl
+poetry run service-ambitions reverse --input-file evolutions.jsonl --output-file features.jsonl
 ```
 
 Alternatively, use the provided shell script which forwards all arguments to the CLI:
 
 ```bash
-./run.sh run --input-file sample-services.jsonl --output-file evolutions.jsonl --no-logs
-./run.sh diagnose --input-file sample-services.jsonl --output-file evolutions.jsonl --no-logs
-./run.sh validate --input-file sample-services.jsonl --no-logs
-./run.sh reverse --input-file evolutions.jsonl --output-file features.jsonl --no-logs
+./run.sh run --input-file sample-services.jsonl --output-file evolutions.jsonl
+./run.sh validate --input-file sample-services.jsonl
+./run.sh reverse --input-file evolutions.jsonl --output-file features.jsonl
 ```
 
 ## Usage
@@ -278,8 +274,7 @@ Fields in the schema:
       - `score`: object with CMMI maturity `level`, `label` and `justification`.
       - `customer_type`: audience benefiting from the feature.
       - `mappings`: object with `information`, `applications` and
-        `technologies` lists of mapping items referencing supporting IDs. Use
-        `--diagnostics` to include a brief `rationale` for each mapping.
+        `technologies` lists of mapping items referencing supporting IDs.
 
 ## Reference Data
 
@@ -339,7 +334,7 @@ Map each feature to relevant Applications from the list below.
 - Do not include any text outside the JSON object.
 ```
 
-Repeat this structure for the `technologies` and `information` datasets. Run with `--diagnostics` to additionally request a one-line rationale for each mapping.
+Repeat this structure for the `technologies` and `information` datasets.
 
 ## IDE support
 

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -23,21 +23,19 @@ Example command:
 poetry run service-ambitions generate-evolution \
   --input-file sample-services.jsonl \
   --output-file evolution.jsonl \
-  --strict-mapping --diagnostics --no-logs
+  --strict-mapping
 ```
 
 `--mapping-data-dir` points to a directory of mapping reference data.
 `--strict-mapping/--no-strict-mapping` fails when feature mappings are missing or
 contain unknown identifiers.
-`--diagnostics/--no-diagnostics` enables verbose diagnostics output and
-telemetry instrumentation. Prompt text is hidden from logs unless
+Telemetry via Logfire is always enabled. Prompt text is hidden from logs unless
 `--allow-prompt-logging` is passed.
 Use `--roles-file` to supply an alternative roles definition file when needed.
 
 Logfire is required by the CLI but the `LOGFIRE_TOKEN` environment variable is
 optional for local runs. Set the token to stream traces to Logfire; without it,
-telemetry remains local. Instrumentation only runs when `--diagnostics` is
-supplied.
+telemetry remains local.
 
 Pass `--strict` to abort if any role lacks features or if generated features
 contain empty mapping lists. This turns on a fail-fast mode instead of the

--- a/docs/generate-mapping.md
+++ b/docs/generate-mapping.md
@@ -13,7 +13,7 @@ Example command:
 poetry run service-ambitions generate-mapping \
   --input evolution.jsonl \
   --output remapped.jsonl \
-  --strict-mapping --diagnostics --no-logs
+  --strict-mapping
 ```
 
 `--mapping-data-dir` points to the directory containing mapping reference data
@@ -23,9 +23,8 @@ files.
 produces an empty list or contains unknown identifiers. Disable with
 `--no-strict-mapping` to drop unknown mappings and continue.
 
-`--diagnostics` enables verbose logging and telemetry instrumentation useful for
-troubleshooting. Instrumentation runs only when this verbose mode is enabled.
-Prompt text is omitted unless `--allow-prompt-logging` is supplied.
+Telemetry via Logfire is always enabled. Prompt text is omitted unless
+`--allow-prompt-logging` is supplied.
 
 `--use-local-cache` reads mapping responses under `.cache/<service>/mappings` and
 optionally writes new entries to avoid repeated network requests during

--- a/docs/logging-levels.md
+++ b/docs/logging-levels.md
@@ -1,6 +1,6 @@
 # Logging levels
 
-This project uses structured logging to describe application behaviour and
+Logfire provides structured logging to describe application behaviour and
 troubleshooting information. Log entries are emitted at different levels to
 control verbosity. Each level builds on the ones before it, inheriting their
 messages while adding more detail.
@@ -50,5 +50,5 @@ messages while adding more detail.
 * **Use:** Generally produced automatically by the logging system when an
   exception propagates without being caught.
 
-For more on debugging practices, see the `--diagnostics` flag in the CLI which
-enables verbose logging and telemetry instrumentation.
+Use `-q` and `-v` flags on the CLI to adjust verbosity from `fatal` through
+`trace`.

--- a/src/engine/processing_engine.py
+++ b/src/engine/processing_engine.py
@@ -99,7 +99,7 @@ class ProcessingEngine:
         self.processed_ids, self.existing_lines = _load_resume_state(
             self.processed_path, self.output_path, args.resume
         )
-        if self.transcripts_dir is None and not args.no_logs:
+        if self.transcripts_dir is None:
             self.transcripts_dir = _ensure_transcripts_dir(
                 args.transcripts_dir, self.output_path
             )

--- a/src/monitoring.py
+++ b/src/monitoring.py
@@ -1,47 +1,42 @@
 # SPDX-License-Identifier: MIT
-"""Helpers for enabling Pydantic Logfire telemetry.
-
-Logfire operates locally without an API token; the token is only required for
-publishing telemetry to the cloud. These helpers configure the SDK and, when
-requested, instrument the application regardless of token availability so the
-rest of the application can remain oblivious to monitoring details.
-"""
+"""Helpers for enabling Pydantic Logfire telemetry."""
 
 from __future__ import annotations
 
 import os
+from typing import Literal
 
-# Default log file used across the application
-LOG_FILE_NAME = "service.log"
+import logfire
 
 
-def init_logfire(token: str | None = None, diagnostics: bool = False) -> None:
-    """Configure the Logfire SDK and optionally enable diagnostics.
+def init_logfire(
+    token: str | None = None,
+    min_log_level: Literal[
+        "fatal", "error", "warn", "notice", "info", "debug", "trace"
+    ] = "warn",
+) -> None:
+    """Configure Logfire and enable instrumentation.
 
     Args:
-        token: Optional Logfire API token. When omitted the ``LOGFIRE_TOKEN``
-            environment variable is used. A missing token means logs remain
-            local but the SDK still operates.
-        diagnostics: When ``True``, enable system metrics and available
-            instrumentation helpers to collect diagnostic telemetry.
+        token: Optional Logfire API token. If omitted, ``LOGFIRE_TOKEN`` from the
+            environment is used. Missing tokens keep telemetry local.
+        min_log_level: Minimum level for console and telemetry output.
     """
 
-    import logfire
-
     key = token or os.getenv("LOGFIRE_TOKEN")
-    logfire.configure(token=key, service_name="service-ambition-generator")
+    logfire.configure(
+        token=key,
+        service_name="service-ambition-generator",
+        console=logfire.ConsoleOptions(
+            min_log_level=min_log_level,
+            show_project_link=False,
+            verbose=True,
+        ),
+        min_level=min_log_level,
+    )
 
-    if diagnostics:  # Enable instrumentation only when diagnostics are requested
-        logfire.instrument_system_metrics(base="full")
-
-        # Dynamically enable available instrumentation helpers on the logfire module.
-        for name in (
-            "instrument_pydantic_ai",
-            "instrument_pydantic",
-            "instrument_openai",
-        ):
-            instrument = getattr(logfire, name, None)
-            if instrument:  # Skip helpers missing from the current Logfire build
-                instrument()
-
-        logfire.info("Logfire telemetry enabled")
+    logfire.instrument_system_metrics(base="full")
+    for name in ("instrument_pydantic_ai", "instrument_pydantic", "instrument_openai"):
+        instrument = getattr(logfire, name, None)
+        if instrument:
+            instrument()

--- a/tests/test_cli_modes.py
+++ b/tests/test_cli_modes.py
@@ -35,33 +35,12 @@ def test_run_invokes_generator(monkeypatch):
     monkeypatch.setattr(cli, "_cmd_generate_evolution", fake_generate)
     monkeypatch.setattr(cli, "load_settings", _prepare_settings)
     monkeypatch.setattr(cli, "_configure_logging", lambda *a, **k: None)
-    monkeypatch.setattr(sys, "argv", ["main", "run", "--dry-run", "--no-logs"])
+    monkeypatch.setattr(sys, "argv", ["main", "run", "--dry-run"])
 
     cli.main()
 
     assert called["args"].dry_run is True
     assert called["settings"].diagnostics is False
-
-
-def test_diagnose_enables_diagnostics(monkeypatch):
-    """Diagnose subcommand forces diagnostics and transcripts."""
-
-    called = {}
-
-    async def fake_generate(args, transcripts_dir):
-        called["args"] = args
-        called["settings"] = RuntimeEnv.instance().settings
-
-    monkeypatch.setattr(cli, "_cmd_generate_evolution", fake_generate)
-    monkeypatch.setattr(cli, "load_settings", _prepare_settings)
-    monkeypatch.setattr(cli, "_configure_logging", lambda *a, **k: None)
-    monkeypatch.setattr(sys, "argv", ["main", "diagnose", "--dry-run", "--no-logs"])
-
-    cli.main()
-
-    assert called["args"].dry_run is True
-    assert called["settings"].diagnostics is True
-    assert called["args"].no_logs is False
 
 
 def test_validate_sets_dry_run(monkeypatch):
@@ -76,7 +55,7 @@ def test_validate_sets_dry_run(monkeypatch):
     monkeypatch.setattr(cli, "_cmd_generate_evolution", fake_generate)
     monkeypatch.setattr(cli, "load_settings", _prepare_settings)
     monkeypatch.setattr(cli, "_configure_logging", lambda *a, **k: None)
-    monkeypatch.setattr(sys, "argv", ["main", "validate", "--no-logs"])
+    monkeypatch.setattr(sys, "argv", ["main", "validate"])
 
     cli.main()
 
@@ -97,7 +76,7 @@ def test_cache_args_defaults(monkeypatch):
     monkeypatch.setattr(cli, "_cmd_generate_evolution", fake_generate)
     monkeypatch.setattr(cli, "load_settings", _prepare_settings)
     monkeypatch.setattr(cli, "_configure_logging", lambda *a, **k: None)
-    monkeypatch.setattr(sys, "argv", ["main", "run", "--dry-run", "--no-logs"])
+    monkeypatch.setattr(sys, "argv", ["main", "run", "--dry-run"])
 
     cli.main()
 
@@ -129,7 +108,6 @@ def test_cache_args_custom(monkeypatch):
             "main",
             "run",
             "--dry-run",
-            "--no-logs",
             "--use-local-cache",
             "--cache-mode",
             "write",

--- a/tests/test_e2e_cli_generate.py
+++ b/tests/test_e2e_cli_generate.py
@@ -302,7 +302,6 @@ def test_cli_generate_matches_golden(monkeypatch, tmp_path, dummy_agent) -> None
             "sample-services.json",
             "--output-file",
             str(output_file),
-            "--no-logs",
         ],
     )
 

--- a/tests/test_e2e_cli_mapping.py
+++ b/tests/test_e2e_cli_mapping.py
@@ -79,7 +79,6 @@ def test_cli_map_matches_golden(monkeypatch, tmp_path) -> None:
             str(input_file),
             "--output-file",
             str(output_file),
-            "--no-logs",
         ],
     )
 

--- a/tests/test_e2e_cli_reverse.py
+++ b/tests/test_e2e_cli_reverse.py
@@ -125,7 +125,6 @@ def test_cli_reverse_generates_caches(monkeypatch, tmp_path) -> None:
             str(input_file),
             "--output-file",
             str(output_file),
-            "--no-logs",
         ],
     )
     cli.main()


### PR DESCRIPTION
## Summary
- switch CLI logging to Logfire with new verbose/quiet flags
- always instrument telemetry and drop diagnostics/no-logs options
- document Logfire usage and updated logging levels

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5440af3b0832bb0c2eff02910d137