### PR TITLE
Bind output schemas to agents and streamline mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Generate service features for the {service_name} service at plateau {plateau}.
 ## Instructions
 
 - Use the service description: {service_description}.
-- Return a single JSON object with keys for each role: {roles}.
+- Provide keys for each role: {roles}.
 - Each key must map to an array containing at least {required_count} feature
   objects.
 - Every feature must provide:
@@ -314,7 +314,6 @@ Generate service features for the {service_name} service at plateau {plateau}.
     - "level": integer 1–5.
     - "label": matching CMMI maturity name.
     - "justification": brief rationale for the level.
-- Do not include any text outside the JSON object.
 ```
 
 ### Mapping prompts
@@ -328,10 +327,9 @@ Map each feature to relevant Applications from the list below.
 
 ## Instructions
 
-- Return a JSON object with a top-level "features" array.
+- Include a top-level "features" array.
 - Each element must include "feature_id" and an "applications" array of objects with an "item" field only.
 - Do not invent IDs; only use those provided.
-- Do not include any text outside the JSON object.
 ```
 
 Repeat this structure for the `technologies` and `information` datasets.

--- a/docs/sd01-flow-of-evolution-prompts.md
+++ b/docs/sd01-flow-of-evolution-prompts.md
@@ -105,9 +105,7 @@ Provide a description of the service at plateau 1 (Foundational).
 #### Instructions
 
 - Base wording on the situational context, definitions and inspirations.
-- Return a JSON object containing only a `description` field.
-- `description` must be a non-empty string explaining the service at plateau 1.
-- Do not include any text outside the JSON object.
+- Provide a non-empty `description` string explaining the service at plateau 1.
 - The response must adhere to the JSON schema provided below.
 
 #### Response structure
@@ -130,13 +128,12 @@ Generate service features for the Learning & Teaching service at plateau 1.
 
 - Use the service description: <Foundational description>.
 - Reference the situational context, definitions and inspirations to maintain consistent terminology.
-- Return a single JSON object with three keys: "learners", "staff" and "community".
+- Provide keys for "learners", "staff" and "community".
 - Each key must map to an array containing at least 5 feature objects.
 - Every feature must provide:
   - "name": short feature title.
   - "description": explanation of the feature.
   - "score": object describing CMMI maturity with "level", "label" and "justification".
-- Do not include any text outside the JSON object.
 - The response must adhere to the JSON schema provided below.
 
 #### Response structure
@@ -187,12 +184,10 @@ Map each feature to relevant Information, Applications and Technologies from the
 
 #### Instructions
 
-- Return a JSON object with a top-level "features" array.
 - Each element must include a 6 character `feature_id` and a "mappings" object containing "information", "applications" and "technologies" arrays.
 - Each mapping entry must include an "item" field. When diagnostics are enabled, also return a single-line "rationale" for the match.
 - Do not invent IDs; only use those provided.
 - Maintain terminology consistent with the situational context, definitions and inspirations.
-- Do not include any text outside the JSON object.
 - The response must adhere to the JSON schema provided below.
 
 #### Response structure

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -315,9 +315,9 @@ async def map_set(
         cache_mode: Local cache behaviour.
         catalogue_hash: SHA256 digest representing the loaded mapping catalogues.
 
-    The agent is queried twice to obtain a valid :class:`MappingResponse`. The
-    second attempt appends a hint instructing the model to return JSON only. If
-    both attempts fail, the raw response is written to
+    The agent is queried up to twice to obtain a valid :class:`MappingResponse`.
+    The second attempt appends a hint directing the model to stick to the
+    defined fields. If both attempts fail, the raw response is written to
     ``quarantine/mapping/<service>/<set>.txt`` and an empty mapping list is
     returned. When ``strict`` is ``True`` a :class:`MappingError`` is raised
     instead of returning partial results. ``cache_mode`` controls local caching
@@ -424,7 +424,7 @@ async def map_set(
         try:
             payload = await session.ask_async(prompt)
             tokens += getattr(session, "last_tokens", 0)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             svc = service or "unknown"
             _writer.write(set_name, svc, "json_parse_error", str(exc))
             _error_handler.handle("Invalid mapping response", exc)

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -233,6 +233,8 @@ async def test_map_set_strict_raises(monkeypatch, tmp_path) -> None:
             service="svc",
             strict=True,
         )
+    # Only a single attempt is made when validation fails.
+    assert session.prompts == ["PROMPT"]
     qfile = tmp_path / "quarantine" / "svc" / "applications" / "json_parse_error_1.json"
     assert qfile.exists()
     assert paths == [qfile.resolve()]


### PR DESCRIPTION
## Summary
- bind output schemas to agents and stop passing output types to ask/ask_async
- remove JSON-only instructions from docs and prompts
- simplify mapping error handling by dropping structured retry logic

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5831ddb00832ba7a359e725296471