### PR TITLE
Refactor processing engine to use RuntimeEnv settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@
 ## Architecture
 
 The generator runs on a layered engine design.  `ProcessingEngine`
-coordinates work across services, `ServiceExecution` manages per‑service
-state and spawns `PlateauRuntime` instances for each plateau.  A
-thread‑safe `RuntimeEnv` singleton holds configuration and shared state
-such as caches.  See [runtime-architecture](docs/runtime-architecture.md)
-for a detailed walkthrough.
+coordinates work across services while `ServiceRuntime` holds
+per‑service artefacts.  `ServiceExecution` populates each runtime and
+spawns `PlateauRuntime` instances for every plateau.  A thread‑safe
+`RuntimeEnv` singleton holds configuration and shared state such as
+caches.  See [runtime-architecture](docs/runtime-architecture.md) for a
+detailed walkthrough.
 
 ## Configuration
 

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -2,10 +2,11 @@
 
 The evolution workflow spans the plateaus defined in
 `data/service_feature_plateaus.json`. A `ProcessingEngine` coordinates the
-process: it instantiates a `ServiceExecution` for each service and spawns a
-`PlateauRuntime` per plateau. These engines lazily load data, cache intermediate
-results and only flush output once all stages succeed. The CLI evaluates all
-plateaus in this file alongside all roles defined in `data/roles.json`.
+process: it creates a `ServiceRuntime` for each service, invokes a
+`ServiceExecution` to populate it and spawns a `PlateauRuntime` per plateau.
+These engines lazily load data, cache intermediate results and only flush output
+once all stages succeed. The CLI evaluates all plateaus in this file alongside
+all roles defined in `data/roles.json`.
 Plateau name to level mappings are derived from the order of the JSON entries.
 
 Runtime configuration and shared state live in the thread‑safe `RuntimeEnv`

--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -17,18 +17,18 @@ files. Tests or reconfigurations can clear the singleton via
 ## Processing engine
 
 `ProcessingEngine` orchestrates the overall workflow.  It iterates over
-services from the input file, constructs a `ServiceExecution` for each
-and awaits their completion.  The engine only reports whether the batch
-succeeded; individual artefacts remain inside the service objects until
-`finalise()` is invoked.
+services from the input file, builds a `ServiceRuntime` for each and
+invokes a `ServiceExecution` to populate it.  The engine reports whether
+the batch succeeded and later flushes successful runtime artefacts to
+disk.
 
 ## Service execution
 
-A `ServiceExecution` handles one service.  It lazily loads plateau
-information, spawns `PlateauRuntime` objects for each plateau and
-delegates feature generation and mapping.  Results for successful
-plateaus are stored on the execution instance and flushed to disk during
-`finalise()`.
+A `ServiceExecution` handles one service runtime.  It lazily loads
+plateau information, spawns `PlateauRuntime` objects for each plateau
+and delegates feature generation and mapping.  Results for successful
+plateaus are stored on the `ServiceRuntime` instance for later
+persistence.
 
 ## Plateau runtime
 

--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -14,28 +14,38 @@ in-memory state such as caches.  Modules access the singleton via
 files. Tests or reconfigurations can clear the singleton via
 `RuntimeEnv.reset()`.
 
+Settings also drive the lazy loaders for prompts, plateau definitions
+and role identifiers.  Each loader reads configuration paths from the
+current `RuntimeEnv` settings on first use and retains the parsed
+results in an in-memory cache for subsequent calls.
+
 ## Processing engine
 
 `ProcessingEngine` orchestrates the overall workflow.  It iterates over
 services from the input file, builds a `ServiceRuntime` for each and
 invokes a `ServiceExecution` to populate it.  The engine reports whether
 the batch succeeded and later flushes successful runtime artefacts to
-disk.
+disk.  Because per‑service state is confined to the runtime object,
+processing remains deterministic and easy to reason about.
 
-## Service execution
+## Service runtime and execution
 
-A `ServiceExecution` handles one service runtime.  It lazily loads
-plateau information, spawns `PlateauRuntime` objects for each plateau
-and delegates feature generation and mapping.  Results for successful
-plateaus are stored on the `ServiceRuntime` instance for later
+`ServiceRuntime` is a dataclass capturing the service input, associated
+plateau runtimes and output artefacts.  `ServiceExecution` is a thin
+executor that mutates a `ServiceRuntime` in place.  It lazily loads
+plateau information, spawns `PlateauRuntime` objects and delegates
+feature generation and mapping.  The executor returns a success flag
+while the populated runtime retains all artefacts for later
 persistence.
 
-## Plateau runtime
+## Plateau execution
 
-`PlateauRuntime` encapsulates the per‑plateau state: description,
-features and mapping results.  Each runtime exposes a simple
-`status()` method used by the processing engine to determine overall
-success.
+`PlateauGenerator` orchestrates a sequence of `PlateauRuntime` objects.
+Each runtime encapsulates the plateau description, features and mapping
+results and exposes `generate_features()` and `generate_mappings()`
+helpers.  These helpers call model sessions, update on‑disk caches and
+store results on the runtime.  A simple `status()` method communicates
+per‑plateau success back to the processing engine.
 
 ## Telemetry and logging
 
@@ -47,9 +57,15 @@ spans.  These spans enable fine‑grained tracing across services and
 plateaus, while log levels allow operators to dial in the desired amount
 of detail.
 
-## Caching strategy
+## Lazy loading and caching
 
-Caching is opt‑in and scoped by context, service and plateau:
+Prompt templates are lazily loaded with `FilePromptLoader`, which
+retains an in-memory cache.  Plateau definitions, default plateau maps
+and role identifiers use similar loaders that cache results on first
+use.
+
+Feature and mapping outputs are cached on disk.  The cache layout is
+scoped by context, service and plateau:
 
 ```
 .cache/<context>/<service_id>/<descriptions>.json
@@ -61,7 +77,26 @@ Legacy files are discovered and relocated to the canonical structure.
 Caches are indented JSON dictionaries for easy inspection.  Invalid or
 non‑dictionary content halts processing with a descriptive error.
 
-Prompt templates are lazily loaded with `FilePromptLoader`, which retains an
-in-memory cache to avoid repeated disk access.  Tests can reset the cache via
-the `clear_prompt_cache()` hook.
+## Flow overview
+
+The following sequence summarises a typical run:
+
+```mermaid
+sequenceDiagram
+    participant CLI
+    participant PE as ProcessingEngine
+    participant SE as ServiceExecution
+    participant PR as PlateauRuntime
+
+    CLI->>RuntimeEnv: initialise settings
+    CLI->>PE: run()
+    loop services
+        PE->>SE: execute(serviceRuntime)
+        SE->>PR: generate_features()
+        SE->>PR: generate_mappings()
+        PR-->>SE: status
+        SE-->>PE: success flag
+    end
+    PE->>PE: flush outputs
+```
 

--- a/src/engine/plateau_runtime.py
+++ b/src/engine/plateau_runtime.py
@@ -2,11 +2,31 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, Sequence
 
 import logfire
+from pydantic import ValidationError
+from pydantic_core import from_json
 
-from models import MappingFeatureGroup, PlateauFeature
+from conversation import ConversationSession
+from loader import (
+    MAPPING_DATA_DIR,
+    load_mapping_items,
+    load_prompt_text,
+)
+from mapping import cache_write_json_atomic, group_features_by_mapping, map_set
+from models import (
+    FeatureItem,
+    MappingFeatureGroup,
+    PlateauFeature,
+    PlateauFeaturesResponse,
+    RoleFeaturesResponse,
+)
+from runtime.environment import RuntimeEnv
+from shortcode import ShortCodeRegistry
 
 
 @dataclass
@@ -19,6 +39,306 @@ class PlateauRuntime:
     features: list[PlateauFeature] = field(default_factory=list)
     mappings: dict[str, list[MappingFeatureGroup]] = field(default_factory=dict)
     _success: bool = False
+
+    def _feature_cache_path(self, service: str) -> Path:
+        """Return canonical cache path for features."""
+
+        try:
+            settings = RuntimeEnv.instance().settings
+            cache_root = settings.cache_dir
+            context = settings.context_id
+        except Exception:  # pragma: no cover - settings unavailable
+            cache_root = Path(".cache")
+            context = "unknown"
+
+        path = cache_root / context / service / str(self.plateau) / "features.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def _discover_feature_cache(self, service: str) -> tuple[Path, Path]:
+        """Return existing feature cache and canonical destination."""
+
+        canonical = self._feature_cache_path(service)
+        if canonical.exists():
+            return canonical, canonical
+
+        service_root = canonical.parents[1]
+        for candidate in service_root.glob("**/features.json"):
+            return candidate, canonical
+
+        return canonical, canonical
+
+    def _to_feature(
+        self, item: FeatureItem, role: str, code_registry: ShortCodeRegistry
+    ) -> PlateauFeature:
+        """Return a :class:`PlateauFeature` built from ``item``."""
+
+        canonical = f"{item.name}|{role}|{self.plateau_name}"
+        feature_id = code_registry.generate(canonical)
+        return PlateauFeature(
+            feature_id=feature_id,
+            name=item.name,
+            description=item.description,
+            score=item.score,
+            customer_type=role,
+        )
+
+    def _build_plateau_prompt(
+        self,
+        *,
+        service_name: str,
+        description: str,
+        roles: Sequence[str],
+        required_count: int,
+    ) -> str:
+        """Return a prompt requesting features for this plateau."""
+
+        template = load_prompt_text("plateau_prompt")
+        roles_str = ", ".join(f'"{r}"' for r in roles)
+        return template.format(
+            required_count=required_count,
+            service_name=service_name,
+            service_description=description,
+            plateau=str(self.plateau),
+            roles=str(roles_str),
+        )
+
+    def _collect_features(
+        self,
+        payload: PlateauFeaturesResponse,
+        *,
+        roles: Sequence[str],
+        code_registry: ShortCodeRegistry,
+    ) -> list[PlateauFeature]:
+        """Return PlateauFeature records extracted from ``payload``."""
+
+        features: list[PlateauFeature] = []
+        for role in roles:
+            raw_features = payload.features.get(role, [])
+            for item in raw_features:
+                features.append(self._to_feature(item, role, code_registry))
+        return features
+
+    def _validate_roles(
+        self,
+        role_data: dict[str, Any],
+        *,
+        roles: Sequence[str],
+        required_count: int,
+    ) -> tuple[dict[str, list[FeatureItem]], list[str], dict[str, int]]:
+        """Return valid roles, invalid role names and missing counts."""
+
+        valid: dict[str, list[FeatureItem]] = {}
+        invalid: list[str] = []
+        missing: dict[str, int] = {}
+        for role in roles:
+            items = role_data.get(role, [])
+            try:
+                role_block = RoleFeaturesResponse(features=items)
+            except Exception:  # noqa: BLE001
+                invalid.append(role)
+                valid[role] = []
+                continue
+            valid[role] = list(role_block.features)
+            if len(role_block.features) < required_count:
+                missing[role] = required_count - len(role_block.features)
+        return valid, invalid, missing
+
+    async def _request_role_features_async(
+        self,
+        level: int,
+        role: str,
+        description: str,
+        count: int,
+        session: ConversationSession,
+    ) -> list[FeatureItem]:
+        """Return ``count`` features for ``role`` when initial parsing fails."""
+
+        prompt = (
+            f"Previous output returned invalid features for role '{role}'.\nProvide"
+            f" exactly {count} unique features for this role at plateau"
+            f" {level}.\n\nService description:\n{description}"
+        )
+        payload = await session.ask_async(prompt)
+        return payload.features
+
+    async def _recover_invalid_roles(
+        self,
+        invalid: list[str],
+        *,
+        level: int,
+        description: str,
+        session: ConversationSession,
+        required_count: int,
+    ) -> dict[str, list[FeatureItem]]:
+        """Return features for roles that failed validation."""
+
+        fixes: dict[str, list[FeatureItem]] = {}
+        for role in invalid:
+            fixes[role] = await self._request_role_features_async(
+                level, role, description, required_count, session
+            )
+        return fixes
+
+    def _enforce_min_features(
+        self,
+        valid: dict[str, list[FeatureItem]],
+        *,
+        roles: Sequence[str],
+        required: int,
+    ) -> None:
+        """Ensure each role has at least ``required`` features."""
+
+        for role in roles:
+            items = valid.get(role, [])
+            if len(items) < required:
+                raise ValueError(
+                    f"Expected at least {required} features for '{role}', got"
+                    f" {len(items)} after retry"
+                )
+
+    async def _request_missing_features_async(
+        self,
+        level: int,
+        role: str,
+        description: str,
+        missing: int,
+        session: ConversationSession,
+    ) -> list[FeatureItem]:
+        """Return additional features for ``role`` to meet the required count."""
+
+        prompt = (
+            "Previous output returned insufficient features for role"
+            f" '{role}'.\nProvide exactly {missing} additional unique features for this"
+            f" role at plateau {level}.\n\nService description:\n{description}"
+        )
+        payload = await session.ask_async(prompt)
+        return payload.features
+
+    async def generate_features(
+        self,
+        session: ConversationSession,
+        *,
+        service_id: str,
+        service_name: str,
+        roles: Sequence[str],
+        required_count: int,
+        code_registry: ShortCodeRegistry,
+        use_local_cache: bool,
+        cache_mode: Literal["off", "read", "refresh", "write"],
+    ) -> None:
+        """Populate ``self.features`` using ``session``."""
+
+        payload: PlateauFeaturesResponse | None = None
+        cache_file: Path | None = None
+        if use_local_cache and cache_mode != "off":
+            candidate, cache_file = self._discover_feature_cache(service_id)
+            if cache_mode == "read" and candidate.exists():
+                try:
+                    with candidate.open("rb") as fh:
+                        data = from_json(fh.read())
+                    payload = PlateauFeaturesResponse.model_validate(data)
+                    if candidate != cache_file:
+                        cache_write_json_atomic(cache_file, payload.model_dump())
+                        candidate.unlink()
+                except (ValidationError, ValueError) as exc:
+                    raise RuntimeError(f"Invalid feature cache: {candidate}") from exc
+
+        if payload is None:
+            prompt = self._build_plateau_prompt(
+                service_name=service_name,
+                description=self.description,
+                roles=roles,
+                required_count=required_count,
+            )
+            logfire.info(
+                "Requesting features", plateau=self.plateau, service=service_id
+            )
+            payload = await session.ask_async(prompt)
+            role_data = payload.features
+            valid, invalid_roles, missing = self._validate_roles(
+                role_data, roles=roles, required_count=required_count
+            )
+            fixes = await self._recover_invalid_roles(
+                invalid_roles,
+                level=self.plateau,
+                description=self.description,
+                session=session,
+                required_count=required_count,
+            )
+            valid.update(fixes)
+            tasks = {
+                role: asyncio.create_task(
+                    self._request_missing_features_async(
+                        self.plateau,
+                        role,
+                        self.description,
+                        need,
+                        session,
+                    )
+                )
+                for role, need in missing.items()
+            }
+            if tasks:
+                results = await asyncio.gather(*tasks.values())
+                for role, extras in zip(tasks.keys(), results, strict=False):
+                    valid[role].extend(extras)
+            self._enforce_min_features(valid, roles=roles, required=required_count)
+            block: dict[str, list[FeatureItem]] = {
+                role: list(valid.get(role, [])) for role in roles
+            }
+            payload = PlateauFeaturesResponse(features=block)
+            if use_local_cache and cache_mode != "off":
+                cache_write_json_atomic(
+                    cache_file or self._feature_cache_path(service_id),
+                    payload.model_dump(),
+                )
+
+        self.features = self._collect_features(
+            payload, roles=roles, code_registry=code_registry
+        )
+
+    async def generate_mappings(
+        self,
+        session: ConversationSession,
+        *,
+        service_name: str,
+        service_id: str,
+        service_description: str,
+        strict: bool,
+        use_local_cache: bool,
+        cache_mode: Literal["off", "read", "refresh", "write"],
+    ) -> None:
+        """Populate ``self.mappings`` for ``self.features``."""
+
+        settings = RuntimeEnv.instance().settings
+        items, catalogue_hash = load_mapping_items(
+            MAPPING_DATA_DIR, settings.mapping_sets
+        )
+
+        groups: dict[str, list[MappingFeatureGroup]] = {}
+        for cfg in settings.mapping_sets:
+            set_session = session.derive()
+            set_session.stage = f"mapping_{cfg.field}"
+            result = await map_set(
+                set_session,
+                cfg.field,
+                items[cfg.field],
+                list(self.features),
+                service_name=service_name,
+                service_description=service_description,
+                plateau=self.plateau,
+                service=service_id,
+                strict=strict,
+                cache_mode=(cache_mode if use_local_cache else "off"),
+                catalogue_hash=catalogue_hash,
+            )
+            groups[cfg.field] = group_features_by_mapping(
+                result, cfg.field, items[cfg.field]
+            )
+
+        self.mappings = groups
+        self._success = True
 
     def set_results(
         self,

--- a/src/engine/service_execution.py
+++ b/src/engine/service_execution.py
@@ -24,6 +24,7 @@ from models import (
     MappingResponse,
     PlateauDescriptionsResponse,
     PlateauFeaturesResponse,
+    ServiceInput,
     ServiceMeta,
 )
 from persistence import atomic_write
@@ -68,6 +69,149 @@ class ServiceExecution:
         self.allow_prompt_logging = allow_prompt_logging
         self.error_handler = error_handler
 
+    def _build_generator(self, settings) -> tuple[PlateauGenerator, str, str, str]:
+        """Construct plateau generator and return model names.
+
+        Args:
+            settings: Runtime configuration.
+
+        Returns:
+            Tuple of the generator and stage model names.
+        """
+
+        desc_model = self.factory.get("descriptions")
+        feat_model = self.factory.get("features")
+        map_model = self.factory.get("mapping")
+
+        desc_name = self.factory.model_name("descriptions")
+        feat_name = self.factory.model_name("features")
+        map_name = self.factory.model_name("mapping")
+
+        desc_agent = Agent(
+            desc_model,
+            instructions=self.system_prompt,
+            output_type=PlateauDescriptionsResponse,
+        )
+        feat_agent = Agent(
+            feat_model,
+            instructions=self.system_prompt,
+            output_type=PlateauFeaturesResponse,
+        )
+        map_agent = Agent(
+            map_model,
+            instructions=self.system_prompt,
+            output_type=(
+                MappingDiagnosticsResponse if settings.diagnostics else MappingResponse
+            ),
+        )
+
+        desc_session = ConversationSession(
+            desc_agent,
+            stage="descriptions",
+            diagnostics=settings.diagnostics,
+            log_prompts=self.allow_prompt_logging,
+            transcripts_dir=self.transcripts_dir,
+            use_local_cache=settings.use_local_cache,
+            cache_mode=settings.cache_mode,
+        )
+        feat_session = ConversationSession(
+            feat_agent,
+            stage="features",
+            diagnostics=settings.diagnostics,
+            log_prompts=self.allow_prompt_logging,
+            transcripts_dir=self.transcripts_dir,
+            use_local_cache=settings.use_local_cache,
+            cache_mode=settings.cache_mode,
+        )
+        map_session = ConversationSession(
+            map_agent,
+            stage="mapping",
+            diagnostics=settings.diagnostics,
+            log_prompts=self.allow_prompt_logging,
+            transcripts_dir=self.transcripts_dir,
+            use_local_cache=settings.use_local_cache,
+            cache_mode=settings.cache_mode,
+        )
+
+        generator = PlateauGenerator(
+            feat_session,
+            required_count=settings.features_per_role,
+            roles=self.role_ids,
+            description_session=desc_session,
+            mapping_session=map_session,
+            strict=settings.strict,
+            use_local_cache=settings.use_local_cache,
+            cache_mode=settings.cache_mode,
+        )
+        return generator, desc_name, feat_name, map_name
+
+    def _ensure_run_meta(
+        self,
+        settings,
+        desc_name: str,
+        feat_name: str,
+        map_name: str,
+        feat_model,
+    ) -> None:
+        """Initialise global run metadata once."""
+
+        global _RUN_META
+        if _RUN_META is not None:
+            return
+        models_map = {
+            "descriptions": desc_name,
+            "features": feat_name,
+            "mapping": map_name,
+            "search": self.factory.model_name("search"),
+        }
+        _, catalogue_hash = load_mapping_items(
+            loader.MAPPING_DATA_DIR, settings.mapping_sets
+        )
+        context_window = getattr(feat_model, "max_input_tokens", 0)
+        _RUN_META = ServiceMeta(
+            run_id=str(uuid4()),
+            seed=self.factory.seed,
+            models=models_map,
+            web_search=getattr(self.factory, "_web_search", False),
+            mapping_types=sorted(getattr(settings, "mapping_types", {}).keys()),
+            context_window=context_window,
+            diagnostics=settings.diagnostics,
+            catalogue_hash=catalogue_hash,
+            created=datetime.now(timezone.utc),
+        )
+
+    async def _prepare_runtimes(
+        self, generator: PlateauGenerator
+    ) -> list[PlateauRuntime]:
+        """Return plateau runtimes with descriptions."""
+
+        names = list(default_plateau_names())
+        desc_map = await generator._request_descriptions_async(
+            names, session=generator.description_session
+        )
+        pmap = default_plateau_map()
+        return [
+            PlateauRuntime(
+                plateau=pmap[name],
+                plateau_name=name,
+                description=desc_map[name],
+            )
+            for name in names
+        ]
+
+    def _write_temp_output(
+        self, service: ServiceInput, record: dict[str, object]
+    ) -> None:
+        """Persist intermediate JSON record when enabled."""
+
+        if self.temp_output_dir is None:
+            return
+        self.temp_output_dir.mkdir(parents=True, exist_ok=True)
+        atomic_write(
+            self.temp_output_dir / f"{service.service_id}.json",
+            [to_json(record).decode()],
+        )
+
     async def run(self) -> bool:
         """Populate ``runtime`` with generated evolution data."""
 
@@ -85,105 +229,16 @@ class ServiceExecution:
         with logfire.span("generate_evolution_for_service", attributes=attrs):
             try:
                 SERVICES_PROCESSED.add(1)
-                desc_model = self.factory.get("descriptions")
-                feat_model = self.factory.get("features")
-                map_model = self.factory.get("mapping")
-
                 settings = RuntimeEnv.instance().settings
-
-                desc_agent = Agent(
-                    desc_model,
-                    instructions=self.system_prompt,
-                    output_type=PlateauDescriptionsResponse,
+                generator, desc_name, feat_name, map_name = self._build_generator(
+                    settings
                 )
-                feat_agent = Agent(
-                    feat_model,
-                    instructions=self.system_prompt,
-                    output_type=PlateauFeaturesResponse,
+                feat_model = self.factory.get("features")
+                self._ensure_run_meta(
+                    settings, desc_name, feat_name, map_name, feat_model
                 )
-                map_agent = Agent(
-                    map_model,
-                    instructions=self.system_prompt,
-                    output_type=(
-                        MappingDiagnosticsResponse
-                        if settings.diagnostics
-                        else MappingResponse
-                    ),
-                )
-                desc_session = ConversationSession(
-                    desc_agent,
-                    stage="descriptions",
-                    diagnostics=settings.diagnostics,
-                    log_prompts=self.allow_prompt_logging,
-                    transcripts_dir=self.transcripts_dir,
-                    use_local_cache=settings.use_local_cache,
-                    cache_mode=settings.cache_mode,
-                )
-                feat_session = ConversationSession(
-                    feat_agent,
-                    stage="features",
-                    diagnostics=settings.diagnostics,
-                    log_prompts=self.allow_prompt_logging,
-                    transcripts_dir=self.transcripts_dir,
-                    use_local_cache=settings.use_local_cache,
-                    cache_mode=settings.cache_mode,
-                )
-                map_session = ConversationSession(
-                    map_agent,
-                    stage="mapping",
-                    diagnostics=settings.diagnostics,
-                    log_prompts=self.allow_prompt_logging,
-                    transcripts_dir=self.transcripts_dir,
-                    use_local_cache=settings.use_local_cache,
-                    cache_mode=settings.cache_mode,
-                )
-                generator = PlateauGenerator(
-                    feat_session,
-                    required_count=settings.features_per_role,
-                    roles=self.role_ids,
-                    description_session=desc_session,
-                    mapping_session=map_session,
-                    strict=settings.strict,
-                    use_local_cache=settings.use_local_cache,
-                    cache_mode=settings.cache_mode,
-                )
-                global _RUN_META
-                if _RUN_META is None:
-                    models_map = {
-                        "descriptions": desc_name,
-                        "features": feat_name,
-                        "mapping": map_name,
-                        "search": self.factory.model_name("search"),
-                    }
-                    _, catalogue_hash = load_mapping_items(
-                        loader.MAPPING_DATA_DIR, settings.mapping_sets
-                    )
-                    context_window = getattr(feat_model, "max_input_tokens", 0)
-                    _RUN_META = ServiceMeta(
-                        run_id=str(uuid4()),
-                        seed=self.factory.seed,
-                        models=models_map,
-                        web_search=getattr(self.factory, "_web_search", False),
-                        mapping_types=sorted(
-                            getattr(settings, "mapping_types", {}).keys()
-                        ),
-                        context_window=context_window,
-                        diagnostics=settings.diagnostics,
-                        catalogue_hash=catalogue_hash,
-                        created=datetime.now(timezone.utc),
-                    )
-                plateau_names = list(default_plateau_names())
-                desc_map = await generator._request_descriptions_async(
-                    plateau_names, session=desc_session
-                )
-                runtimes = [
-                    PlateauRuntime(
-                        plateau=default_plateau_map()[name],
-                        plateau_name=name,
-                        description=desc_map[name],
-                    )
-                    for name in plateau_names
-                ]
+                runtimes = await self._prepare_runtimes(generator)
+                assert _RUN_META is not None  # mypy safeguard
                 evolution = await generator.generate_service_evolution_async(
                     service,
                     runtimes,
@@ -191,12 +246,7 @@ class ServiceExecution:
                     meta=_RUN_META,
                 )
                 record = canonicalise_record(evolution.model_dump(mode="json"))
-                if self.temp_output_dir is not None:
-                    self.temp_output_dir.mkdir(parents=True, exist_ok=True)
-                    atomic_write(
-                        self.temp_output_dir / f"{service.service_id}.json",
-                        [to_json(record).decode()],
-                    )
+                self._write_temp_output(service, record)
                 self.runtime.plateaus = runtimes
                 self.runtime.line = to_json(record).decode()
                 return True

--- a/src/engine/service_execution.py
+++ b/src/engine/service_execution.py
@@ -28,9 +28,9 @@ from models import (
 )
 from persistence import atomic_write
 from plateau_generator import (
-    DEFAULT_PLATEAU_MAP,
-    DEFAULT_PLATEAU_NAMES,
     PlateauGenerator,
+    default_plateau_map,
+    default_plateau_names,
 )
 from quarantine import QuarantineWriter
 from runtime.environment import RuntimeEnv
@@ -193,13 +193,13 @@ class ServiceExecution:
                         catalogue_hash=catalogue_hash,
                         created=datetime.now(timezone.utc),
                     )
-                plateau_names = list(DEFAULT_PLATEAU_NAMES)
+                plateau_names = list(default_plateau_names())
                 desc_map = await generator._request_descriptions_async(
                     plateau_names, session=desc_session
                 )
                 runtimes = [
                     PlateauRuntime(
-                        plateau=DEFAULT_PLATEAU_MAP[name],
+                        plateau=default_plateau_map()[name],
                         plateau_name=name,
                         description=desc_map[name],
                     )

--- a/src/engine/service_runtime.py
+++ b/src/engine/service_runtime.py
@@ -1,0 +1,27 @@
+"""Per-service runtime container."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+from engine.plateau_runtime import PlateauRuntime
+from models import ServiceInput
+
+
+@dataclass
+class ServiceRuntime:
+    """Hold execution artefacts for a single service.
+
+    Attributes:
+        service: The service definition being processed.
+        plateaus: Runtimes for each plateau.
+        line: JSONL output line produced after successful execution.
+    """
+
+    service: ServiceInput
+    plateaus: List[PlateauRuntime] = field(default_factory=list)
+    line: str | None = None
+
+
+__all__ = ["ServiceRuntime"]

--- a/tests/test_cli_modes.py
+++ b/tests/test_cli_modes.py
@@ -130,3 +130,32 @@ def test_cache_args_custom(monkeypatch):
     assert settings.use_local_cache is True
     assert settings.cache_mode == "write"
     assert settings.cache_dir == Path("/tmp/cache")
+
+
+def test_apply_args_to_settings_updates_settings():
+    args = SimpleNamespace(
+        model="m",
+        descriptions_model=None,
+        features_model=None,
+        mapping_model=None,
+        search_model=None,
+        concurrency=3,
+        strict_mapping=True,
+        mapping_data_dir="/tmp/map",
+        web_search=True,
+        use_local_cache=False,
+        cache_mode="off",
+        cache_dir="/tmp/cache",
+        strict=True,
+    )
+    settings = _prepare_settings()
+    cli._apply_args_to_settings(args, settings)
+    assert settings.model == "m"
+    assert settings.concurrency == 3
+    assert settings.strict_mapping is True
+    assert settings.mapping_data_dir == Path("/tmp/map")
+    assert settings.web_search is True
+    assert settings.use_local_cache is False
+    assert settings.cache_mode == "off"
+    assert settings.cache_dir == Path("/tmp/cache")
+    assert settings.strict is True

--- a/tests/test_e2e_cli_generate.py
+++ b/tests/test_e2e_cli_generate.py
@@ -263,6 +263,7 @@ def test_cli_generate_matches_golden(monkeypatch, tmp_path, dummy_agent) -> None
 
         def __init__(self, *args, **kwargs) -> None:  # pragma: no cover
             self.agent = dummy_agent()
+            self.description_session = DummySession([])
 
         async def _request_descriptions_async(self, names, session=None):
             return {name: "desc" for name in names}

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -6,7 +6,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 
 from pydantic_ai import Agent
 
@@ -22,6 +22,7 @@ from models import (
     ServiceMeta,
 )
 from plateau_generator import PlateauGenerator
+from runtime.environment import RuntimeEnv
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
@@ -80,6 +81,7 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
         use_local_cache=False,
         cache_mode="off",
     )
+    RuntimeEnv.initialize(cast(Any, SimpleNamespace(mapping_data_dir=Path("data"))))
     generator = PlateauGenerator(
         session,
         required_count=5,

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -91,13 +91,13 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
 
     map_calls = {"n": 0}
 
-    async def _fake_map_features(self, session, features, **kwargs):
+    async def _fake_generate_mappings(self, session, **kwargs):
         map_calls["n"] += 1
         refs = [
             FeatureMappingRef(feature_id=f.feature_id, description=f.description)
-            for f in features
+            for f in self.features
         ]
-        return {
+        self.mappings = {
             "data": [MappingFeatureGroup(id="d", name="d", mappings=refs.copy())],
             "applications": [
                 MappingFeatureGroup(id="a", name="a", mappings=refs.copy())
@@ -106,8 +106,9 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
                 MappingFeatureGroup(id="t", name="t", mappings=refs.copy())
             ],
         }
+        self._success = True
 
-    monkeypatch.setattr(PlateauGenerator, "_map_features", _fake_map_features)
+    monkeypatch.setattr(PlateauRuntime, "generate_mappings", _fake_generate_mappings)
     template = "{required_count} {service_name} {service_description} {plateau} {roles}"
 
     def fake_loader(name, *_, **__):

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -131,7 +131,12 @@ async def test_map_features_maps_all_sets_with_full_list(monkeypatch) -> None:
         MappingSet(name="Extra", file="extra.json", field="extra"),
     ]
     monkeypatch.setattr("plateau_generator.map_set", fake_map_set)
-    RuntimeEnv.initialize(cast(Any, SimpleNamespace(mapping_sets=mapping_sets)))
+    RuntimeEnv.initialize(
+        cast(
+            Any,
+            SimpleNamespace(mapping_sets=mapping_sets, mapping_data_dir=Path("data")),
+        )
+    )
     monkeypatch.setattr(
         "plateau_generator.load_mapping_items",
         lambda path, sets: ({s.field: [] for s in sets}, "hash"),

--- a/tests/test_plateau_metadata_cache.py
+++ b/tests/test_plateau_metadata_cache.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import plateau_generator
+from runtime.environment import RuntimeEnv
+
+
+def test_plateau_metadata_cached(monkeypatch) -> None:
+    RuntimeEnv.reset()
+    RuntimeEnv.initialize(cast(Any, SimpleNamespace(mapping_data_dir=Path("data"))))
+
+    defs_calls = 0
+    roles_calls = 0
+
+    def fake_load_defs(base_dir, filename=...):
+        nonlocal defs_calls
+        defs_calls += 1
+        return [SimpleNamespace(name="one"), SimpleNamespace(name="two")]
+
+    def fake_load_roles(base_dir, filename=...):
+        nonlocal roles_calls
+        roles_calls += 1
+        return ["alpha", "beta"]
+
+    monkeypatch.setattr(plateau_generator, "load_plateau_definitions", fake_load_defs)
+    monkeypatch.setattr(plateau_generator, "load_role_ids", fake_load_roles)
+
+    plateau_generator.plateau_definitions.cache_clear()
+    plateau_generator.default_plateau_map.cache_clear()
+    plateau_generator.default_plateau_names.cache_clear()
+    plateau_generator.default_role_ids.cache_clear()
+
+    plateau_generator.default_plateau_map()
+    plateau_generator.default_plateau_names()
+    plateau_generator.default_plateau_map()
+    plateau_generator.default_role_ids()
+    plateau_generator.default_role_ids()
+
+    assert defs_calls == 1
+    assert roles_calls == 1

--- a/tests/test_processing_engine_methods.py
+++ b/tests/test_processing_engine_methods.py
@@ -1,0 +1,100 @@
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+from engine.processing_engine import ProcessingEngine
+from models import ServiceInput
+from runtime.environment import RuntimeEnv
+
+
+def _make_args(tmp_path: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        output_file=str(tmp_path / "out.jsonl"),
+        resume=False,
+        transcripts_dir=None,
+        seed=0,
+        roles_file=str(tmp_path / "roles.json"),
+        input_file="services.json",
+        max_services=None,
+        progress=False,
+        temp_output_dir=None,
+        dry_run=False,
+        allow_prompt_logging=False,
+    )
+
+
+def _make_settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        model="gpt",
+        openai_api_key="key",
+        models=None,
+        reasoning=None,
+        prompt_dir=Path("prompts"),
+        mapping_data_dir=Path("mapping"),
+        context_id="ctx",
+        inspiration="insp",
+        concurrency=2,
+        web_search=False,
+    )
+
+
+def test_prepare_models_uses_runtimeenv(monkeypatch, tmp_path):
+    settings = _make_settings()
+    RuntimeEnv.reset()
+    RuntimeEnv.initialize(settings)
+    args = _make_args(tmp_path)
+    engine = ProcessingEngine(args, None)
+
+    captured = {}
+
+    def fake_create_model_factory(s):
+        captured["factory"] = s
+        return "factory"
+
+    def fake_load_services(s):
+        captured["services"] = s
+        svc = ServiceInput(
+            service_id="svc",
+            name="alpha",
+            description="desc",
+            jobs_to_be_done=[],
+        )
+        return "prompt", ["role"], [svc]
+
+    monkeypatch.setattr(engine, "_create_model_factory", fake_create_model_factory)
+    monkeypatch.setattr(engine, "_load_services", fake_load_services)
+
+    factory, system_prompt, role_ids, services = engine._prepare_models()
+
+    assert captured["factory"] is settings
+    assert captured["services"] is settings
+    assert factory == "factory"
+    assert system_prompt == "prompt"
+    assert role_ids == ["role"]
+    assert services[0].service_id == "svc"
+
+
+def test_init_sessions_uses_runtimeenv(monkeypatch, tmp_path):
+    settings = _make_settings()
+    RuntimeEnv.reset()
+    RuntimeEnv.initialize(settings)
+    args = _make_args(tmp_path)
+    engine = ProcessingEngine(args, None)
+
+    captured = {}
+
+    def fake_setup_concurrency(s):
+        captured["settings"] = s
+        return asyncio.Semaphore(1), asyncio.Lock()
+
+    monkeypatch.setattr(engine, "_setup_concurrency", fake_setup_concurrency)
+    monkeypatch.setattr(engine, "_create_progress", lambda total: "progress")
+
+    sem, lock, progress, temp_dir, handler = engine._init_sessions(5)
+
+    assert captured["settings"] is settings
+    assert isinstance(sem, asyncio.Semaphore)
+    assert isinstance(lock, asyncio.Lock)
+    assert progress == "progress"
+    assert temp_dir is None
+    assert handler is not None

--- a/tests/test_service_execution_helpers.py
+++ b/tests/test_service_execution_helpers.py
@@ -1,0 +1,80 @@
+from types import SimpleNamespace
+
+import engine.service_execution as se
+from engine.service_execution import ServiceExecution
+from engine.service_runtime import ServiceRuntime
+from models import ServiceInput
+from runtime.environment import RuntimeEnv
+from utils import ErrorHandler
+
+
+def _settings():
+    return SimpleNamespace(
+        diagnostics=False,
+        mapping_sets=[],
+        use_local_cache=True,
+        cache_mode="read",
+        mapping_types={},
+    )
+
+
+def _factory():
+    class Dummy:
+        seed = 1
+
+        def get(self, stage: str) -> object:  # pragma: no cover - simple stub
+            return object()
+
+        def model_name(self, stage: str) -> str:  # pragma: no cover - simple stub
+            return f"{stage}-model"
+
+    return Dummy()
+
+
+def _runtime() -> ServiceRuntime:
+    svc = ServiceInput(
+        service_id="svc",
+        name="alpha",
+        description="d",
+        jobs_to_be_done=[],
+    )
+    return ServiceRuntime(svc)
+
+
+def _execution() -> ServiceExecution:
+    RuntimeEnv.reset()
+    RuntimeEnv.initialize(_settings())
+
+    class DummyHandler(ErrorHandler):
+        def handle(
+            self, message: str, exc: Exception | None = None
+        ) -> None:  # pragma: no cover
+            pass
+
+    return ServiceExecution(
+        _runtime(),
+        factory=_factory(),
+        system_prompt="",
+        transcripts_dir=None,
+        role_ids=[],
+        temp_output_dir=None,
+        allow_prompt_logging=False,
+        error_handler=DummyHandler(),
+    )
+
+
+def test_ensure_run_meta_initialises_once(monkeypatch):
+    exec_obj = _execution()
+    monkeypatch.setattr(se, "load_mapping_items", lambda *a, **k: ({}, "0" * 64))
+    se._RUN_META = None
+    settings = RuntimeEnv.instance().settings
+    exec_obj._ensure_run_meta(
+        settings,
+        "desc-model",
+        "feat-model",
+        "map-model",
+        SimpleNamespace(max_input_tokens=0),
+    )
+    assert se._RUN_META is not None
+    assert se._RUN_META.models["descriptions"] == "desc-model"
+    se._RUN_META = None


### PR DESCRIPTION
## Summary
- obtain configuration from `RuntimeEnv` inside `ProcessingEngine` helpers
- streamline `run` to use updated helpers without passing settings
- add unit tests covering runtime environment integration

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b597948dec832ba3b67c2a031fa07a