### PR TITLE
refactor: use runtime env property for run metadata

### DIFF
--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -5,6 +5,22 @@ Each layer has a single responsibility and retains its output until the
 final aggregation step, enabling deterministic runs and comprehensive
 telemetry.
 
+## Design principles
+
+- **Central runtime state** – the CLI initialises a singleton
+  `RuntimeEnv` which stores configuration, caches and run metadata. All
+  modules fetch this instance via `RuntimeEnv.instance()` instead of
+  passing settings through call chains.
+- **Isolated execution engines** – `ProcessingEngine` creates a
+  `ServiceRuntime` for each service and drives a `ServiceExecution` that
+  mutates it. Plateau-specific work occurs inside `PlateauRuntime`
+  instances spawned by the service executor.
+- **Success signalling** – engines return only a boolean outcome while
+  storing generated artefacts on their runtime objects.
+- **Lazy loading with caching** – prompts, plateau definitions and other
+  artefacts are loaded on first access and memoised for reuse. The
+  runtime reset clears these caches to force fresh loads when needed.
+
 ## Runtime environment
 
 `RuntimeEnv` is a thread-safe singleton initialised in `cli.main()`.

--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -8,16 +8,19 @@ telemetry.
 ## Runtime environment
 
 `RuntimeEnv` is a thread-safe singleton initialised in `cli.main()`.
-It loads configuration, exposes global settings and holds shared
-in-memory state such as caches.  Modules access the singleton via
-`RuntimeEnv.instance()` instead of repeatedly loading configuration
-files. Tests or reconfigurations can clear the singleton via
-`RuntimeEnv.reset()`.
+It loads configuration, exposes global settings and run metadata, and
+holds shared in-memory state such as caches. Modules access the
+singleton via `RuntimeEnv.instance()` instead of repeatedly loading
+configuration files. Execution metadata is read and written through the
+`run_meta` property, while `RuntimeEnv.reset()` clears both the metadata
+and any cached loaders.
 
 Settings also drive the lazy loaders for prompts, plateau definitions
-and role identifiers.  Each loader reads configuration paths from the
+and role identifiers. Each loader reads configuration paths from the
 current `RuntimeEnv` settings on first use and retains the parsed
-results in an in-memory cache for subsequent calls.
+results in an in-memory cache for subsequent calls. Run metadata is
+stored alongside these caches and exposed through
+`RuntimeEnv.instance().run_meta`.
 
 ## Processing engine
 
@@ -31,21 +34,22 @@ processing remains deterministic and easy to reason about.
 ## Service runtime and execution
 
 `ServiceRuntime` is a dataclass capturing the service input, associated
-plateau runtimes and output artefacts.  `ServiceExecution` is a thin
-executor that mutates a `ServiceRuntime` in place.  It lazily loads
+plateau runtimes and output artefacts. `ServiceExecution` is a thin
+executor that mutates a `ServiceRuntime` in place. It lazily loads
 plateau information, spawns `PlateauRuntime` objects and delegates
-feature generation and mapping.  The executor returns a success flag
-while the populated runtime retains all artefacts for later
-persistence.
+feature generation and mapping. The runtime tracks completion via a
+public `success` flag, and the executor returns a boolean while the
+populated runtime retains all artefacts for later persistence.
 
 ## Plateau execution
 
 `PlateauGenerator` orchestrates a sequence of `PlateauRuntime` objects.
 Each runtime encapsulates the plateau description, features and mapping
 results and exposes `generate_features()` and `generate_mappings()`
-helpers.  These helpers call model sessions, update on‑disk caches and
-store results on the runtime.  A simple `status()` method communicates
-per‑plateau success back to the processing engine.
+helpers. These helpers call model sessions, update on‑disk caches and
+store results on the runtime. Execution status is tracked with a public
+`success` flag, and a simple `status()` method forwards that flag back to
+the processing engine.
 
 ## Telemetry and logging
 
@@ -94,8 +98,8 @@ sequenceDiagram
         PE->>SE: execute(serviceRuntime)
         SE->>PR: generate_features()
         SE->>PR: generate_mappings()
-        PR-->>SE: status
-        SE-->>PE: success flag
+        PR-->>SE: success
+        SE-->>PE: success
     end
     PE->>PE: flush outputs
 ```

--- a/src/engine/plateau_runtime.py
+++ b/src/engine/plateau_runtime.py
@@ -34,7 +34,7 @@ class PlateauRuntime:
     description: str
     features: list[PlateauFeature] = field(default_factory=list)
     mappings: dict[str, list[MappingFeatureGroup]] = field(default_factory=dict)
-    _success: bool = False
+    success: bool = False
 
     def _feature_cache_path(self, service: str) -> Path:
         """Return canonical cache path for features."""
@@ -382,7 +382,7 @@ class PlateauRuntime:
             )
 
         self.mappings = groups
-        self._success = True
+        self.success = True
 
     def set_results(
         self,
@@ -398,7 +398,7 @@ class PlateauRuntime:
         ):
             self.features = list(features)
             self.mappings = mappings
-            self._success = True
+            self.success = True
             logfire.debug(
                 "Stored plateau results",
                 plateau=self.plateau_name,
@@ -412,6 +412,6 @@ class PlateauRuntime:
         logfire.debug(
             "Plateau status checked",
             plateau=self.plateau_name,
-            success=self._success,
+            success=self.success,
         )
-        return self._success
+        return self.success

--- a/src/engine/service_execution.py
+++ b/src/engine/service_execution.py
@@ -34,6 +34,7 @@ from plateau_generator import (
 )
 from quarantine import QuarantineWriter
 from runtime.environment import RuntimeEnv
+from settings import Settings
 from utils import ErrorHandler
 
 SERVICES_PROCESSED = logfire.metric_counter("services_processed")
@@ -66,7 +67,9 @@ class ServiceExecution:
         self.allow_prompt_logging = allow_prompt_logging
         self.error_handler = error_handler
 
-    def _build_generator(self, settings) -> tuple[PlateauGenerator, str, str, str]:
+    def _build_generator(
+        self, settings: Settings
+    ) -> tuple[PlateauGenerator, str, str, str]:
         """Construct plateau generator and return model names.
 
         Args:
@@ -144,7 +147,7 @@ class ServiceExecution:
 
     def _ensure_run_meta(
         self,
-        settings,
+        settings: Settings,
         desc_name: str,
         feat_name: str,
         map_name: str,

--- a/src/runtime/environment.py
+++ b/src/runtime/environment.py
@@ -115,14 +115,26 @@ class RuntimeEnv:
 
     @classmethod
     def reset(cls) -> None:
-        """Clear the active runtime environment.
+        """Clear the active runtime environment and cached state.
 
-        Useful for tests that need a fresh configuration or for scenarios
-        where the application must reload settings at runtime.
+        Useful for tests needing a fresh configuration or for scenarios where
+        the application must reload settings at runtime. Loader caches and run
+        metadata are cleared to avoid stale data in subsequent initialisations.
         """
         with logfire.span("runtime_env.reset"):
             with cls._lock:
                 logfire.info("Resetting runtime environment")
+                inst = cls._instance
+                if inst is not None:
+                    inst.run_meta = None  # remove any persisted run metadata
+                    prompt = inst.state.get("prompt_loader")
+                    if prompt is not None:
+                        # Discard memoised prompts to force reloads.
+                        prompt.clear_cache()
+                    mapping = inst.state.get("mapping_loader")
+                    if mapping is not None:
+                        # Discard cached mapping data to force reloads.
+                        mapping.clear_cache()
                 cls._instance = None
 
 

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -111,7 +111,7 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
                 MappingFeatureGroup(id="t", name="t", mappings=refs.copy())
             ],
         }
-        self._success = True
+        self.success = True
 
     monkeypatch.setattr(PlateauRuntime, "generate_mappings", _fake_generate_mappings)
     template = "{required_count} {service_name} {service_description} {plateau} {roles}"

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -263,7 +263,7 @@ def test_generate_plateau_returns_results(monkeypatch) -> None:
                 MappingFeatureGroup(id="t", name="t", mappings=refs.copy())
             ],
         }
-        self._success = True
+        self.success = True
 
     monkeypatch.setattr(PlateauRuntime, "generate_mappings", dummy_generate_mappings)
 
@@ -363,7 +363,7 @@ def test_generate_plateau_repairs_missing_features(monkeypatch) -> None:
 
     async def dummy_generate_mappings(self, session, **kwargs):
         self.mappings = {}
-        self._success = True
+        self.success = True
 
     monkeypatch.setattr(PlateauRuntime, "generate_mappings", dummy_generate_mappings)
 
@@ -456,7 +456,7 @@ def test_generate_plateau_requests_missing_features_concurrently(
 
     async def dummy_generate_mappings(self, session, **kwargs):
         self.mappings = {}
-        self._success = True
+        self.success = True
 
     monkeypatch.setattr(PlateauRuntime, "generate_mappings", dummy_generate_mappings)
 
@@ -668,7 +668,7 @@ async def test_generate_plateau_supports_custom_roles(monkeypatch) -> None:
 
     async def dummy_generate_mappings(self, session, **kwargs):
         self.mappings = {}
-        self._success = True
+        self.success = True
 
     monkeypatch.setattr(PlateauRuntime, "generate_mappings", dummy_generate_mappings)
 
@@ -1165,7 +1165,7 @@ async def test_generate_plateau_reads_feature_cache(monkeypatch, tmp_path) -> No
 
     async def fake_generate_mappings(self, session, **kwargs):
         self.mappings = {}
-        self._success = True
+        self.success = True
 
     monkeypatch.setattr(PlateauRuntime, "generate_mappings", fake_generate_mappings)
 

--- a/tests/test_runtime_environment.py
+++ b/tests/test_runtime_environment.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+
+from runtime.environment import RuntimeEnv
+from utils import MappingLoader, PromptLoader
+
+
+class DummyPromptLoader(PromptLoader):
+    """Prompt loader stub tracking cache clears."""
+
+    def __init__(self) -> None:
+        self.cleared = False
+
+    def load(self, name: str) -> str:  # pragma: no cover - simple stub
+        return ""
+
+    def clear_cache(self) -> None:
+        self.cleared = True
+
+
+class DummyMappingLoader(MappingLoader):
+    """Mapping loader stub tracking cache clears."""
+
+    def __init__(self) -> None:
+        self.cleared = False
+
+    def load(self, sets):  # pragma: no cover - simple stub
+        return {}, ""
+
+    def clear_cache(self) -> None:
+        self.cleared = True
+
+
+def test_reset_clears_run_meta_and_caches():
+    RuntimeEnv.reset()
+    RuntimeEnv.initialize(SimpleNamespace())
+    env = RuntimeEnv.instance()
+    prompt = DummyPromptLoader()
+    mapping = DummyMappingLoader()
+    env.prompt_loader = prompt
+    env.mapping_loader = mapping
+    env.run_meta = SimpleNamespace()
+    RuntimeEnv.reset()
+    assert prompt.cleared
+    assert mapping.cleared
+    assert env.run_meta is None

--- a/tests/test_service_execution_helpers.py
+++ b/tests/test_service_execution_helpers.py
@@ -67,7 +67,7 @@ def test_ensure_run_meta_initialises_once(monkeypatch):
     exec_obj = _execution()
     monkeypatch.setattr(se, "load_mapping_items", lambda *a, **k: ({}, "0" * 64))
     env = RuntimeEnv.instance()
-    env.state.pop("run_meta", None)
+    env.run_meta = None
     settings = env.settings
     exec_obj._ensure_run_meta(
         settings,
@@ -76,7 +76,7 @@ def test_ensure_run_meta_initialises_once(monkeypatch):
         "map-model",
         SimpleNamespace(max_input_tokens=0),
     )
-    meta = env.state.get("run_meta")
+    meta = RuntimeEnv.instance().run_meta
     assert meta is not None
     assert meta.models["descriptions"] == "desc-model"
     exec_obj._ensure_run_meta(
@@ -86,5 +86,5 @@ def test_ensure_run_meta_initialises_once(monkeypatch):
         "other-map",
         SimpleNamespace(max_input_tokens=0),
     )
-    assert env.state.get("run_meta") is meta
-    env.state.pop("run_meta", None)
+    assert RuntimeEnv.instance().run_meta is meta
+    env.run_meta = None

--- a/tests/test_service_execution_helpers.py
+++ b/tests/test_service_execution_helpers.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from types import SimpleNamespace
 
 import engine.service_execution as se
@@ -5,16 +6,19 @@ from engine.service_execution import ServiceExecution
 from engine.service_runtime import ServiceRuntime
 from models import ServiceInput
 from runtime.environment import RuntimeEnv
+from settings import Settings
 from utils import ErrorHandler
 
 
-def _settings():
-    return SimpleNamespace(
-        diagnostics=False,
-        mapping_sets=[],
-        use_local_cache=True,
-        cache_mode="read",
-        mapping_types={},
+def _settings() -> Settings:
+    return Settings(
+        model="dummy:model",
+        log_level="INFO",
+        prompt_dir=Path("."),
+        context_id="ctx",
+        inspiration="insp",
+        concurrency=1,
+        openai_api_key="key",
     )
 
 


### PR DESCRIPTION
## Summary
- remove `RUN_META_KEY` in service execution
- use `RuntimeEnv.run_meta` for run metadata
- adapt tests to access `RuntimeEnv.instance().run_meta`

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6348dd454832bbbef469f678faec3