### PR TITLE
refactor: centralize feature cache path helper

### DIFF
--- a/src/engine/plateau_runtime.py
+++ b/src/engine/plateau_runtime.py
@@ -23,6 +23,7 @@ from models import (
 )
 from runtime.environment import RuntimeEnv
 from shortcode import ShortCodeRegistry
+from utils.cache_paths import feature_cache
 
 
 @dataclass
@@ -39,17 +40,7 @@ class PlateauRuntime:
     def _feature_cache_path(self, service: str) -> Path:
         """Return canonical cache path for features."""
 
-        try:
-            settings = RuntimeEnv.instance().settings
-            cache_root = settings.cache_dir
-            context = settings.context_id
-        except Exception:  # pragma: no cover - settings unavailable
-            cache_root = Path(".cache")
-            context = "unknown"
-
-        path = cache_root / context / service / str(self.plateau) / "features.json"
-        path.parent.mkdir(parents=True, exist_ok=True)
-        return path
+        return feature_cache(service, self.plateau)
 
     def _discover_feature_cache(self, service: str) -> tuple[Path, Path]:
         """Return existing feature cache and canonical destination."""

--- a/src/plateau_generator.py
+++ b/src/plateau_generator.py
@@ -38,6 +38,7 @@ from models import (
 )
 from runtime.environment import RuntimeEnv
 from shortcode import ShortCodeRegistry
+from utils.cache_paths import feature_cache
 
 # Settings and token scheduling are no longer required after simplification.
 
@@ -80,17 +81,7 @@ def default_role_ids() -> list[str]:
 def _feature_cache_path(service: str, plateau: int) -> Path:
     """Return canonical cache path for features at ``plateau``."""
 
-    try:
-        settings = RuntimeEnv.instance().settings
-        cache_root = settings.cache_dir
-        context = settings.context_id
-    except Exception:  # pragma: no cover - settings unavailable
-        cache_root = Path(".cache")
-        context = "unknown"
-
-    path = cache_root / context / service / str(plateau) / "features.json"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    return path
+    return feature_cache(service, plateau)
 
 
 def _discover_feature_cache(service: str, plateau: int) -> tuple[Path, Path]:

--- a/src/utils/cache_paths.py
+++ b/src/utils/cache_paths.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+"""Cache path helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from runtime.environment import RuntimeEnv
+
+
+def feature_cache(service_id: str, plateau: int) -> Path:
+    """Return canonical cache path for features for ``service_id`` at ``plateau``.
+
+    Ensures the parent directory exists before returning the final path.
+    """
+
+    try:
+        settings = RuntimeEnv.instance().settings
+        cache_root = settings.cache_dir
+        context = settings.context_id
+    except Exception:  # pragma: no cover - settings unavailable
+        cache_root = Path(".cache")
+        context = "unknown"
+
+    path = cache_root / context / service_id / str(plateau) / "features.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+__all__ = ["feature_cache"]

--- a/tests/test_cache_paths.py
+++ b/tests/test_cache_paths.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT
+"""Verify cache path helper consistency."""
+
+from __future__ import annotations
+
+from engine.plateau_runtime import PlateauRuntime
+from plateau_generator import _feature_cache_path
+from runtime.environment import RuntimeEnv
+from utils.cache_paths import feature_cache
+
+
+def test_feature_cache_paths_consistent(tmp_path) -> None:
+    env = RuntimeEnv.instance()
+    env.settings.cache_dir = tmp_path
+    env.settings.context_id = "ctx"
+
+    service_id = "svc"
+    plateau = 1
+
+    path_helper = feature_cache(service_id, plateau)
+    path_runtime = PlateauRuntime(
+        plateau=plateau, plateau_name="p", description="d"
+    )._feature_cache_path(service_id)
+    path_generator = _feature_cache_path(service_id, plateau)
+
+    assert path_helper == path_runtime == path_generator
+    assert path_helper.parent.is_dir()


### PR DESCRIPTION
## Summary
- add `utils.cache_paths.feature_cache` to build and create cache directories
- refactor `PlateauRuntime` and `plateau_generator` to use shared cache path helper
- test consistent cache path usage across modules

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6ab2b7c64832b9c7508a180052a46