### PR TITLE
docs: clarify engine success semantics

### DIFF
--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -21,6 +21,12 @@ telemetry.
   artefacts are loaded on first access and memoised for reuse. The
   runtime reset clears these caches to force fresh loads when needed.
 
+The command‑line interface wires these pieces together. It parses user
+flags, constructs application settings and initialises the global
+``RuntimeEnv``. After configuration, the CLI launches a
+``ProcessingEngine`` which loads service data, spawns per‑service and
+per‑plateau runtimes and finally writes the aggregated output.
+
 ## Runtime environment
 
 `RuntimeEnv` is a thread-safe singleton initialised in `cli.main()`.

--- a/src/engine/processing_engine.py
+++ b/src/engine/processing_engine.py
@@ -387,7 +387,12 @@ class ProcessingEngine:
         return all(t.result() for t in tasks)
 
     async def run(self) -> bool:
-        """Orchestrate the evolution workflow."""
+        """Execute the full processing pipeline.
+
+        Returns:
+            ``True`` when all service executions succeed. Results are stored on
+            per-service runtimes and written out by :meth:`finalise`.
+        """
 
         with logfire.span("processing_engine.run"):
             logfire.info(

--- a/src/engine/service_execution.py
+++ b/src/engine/service_execution.py
@@ -211,7 +211,12 @@ class ServiceExecution:
         )
 
     async def run(self) -> bool:
-        """Populate ``runtime`` with generated evolution data."""
+        """Populate ``runtime`` and report success.
+
+        Returns:
+            ``True`` when evolution generation succeeds. Generated artefacts
+            are stored on :attr:`runtime` and are not returned to callers.
+        """
 
         service = self.runtime.service
         desc_name = self.factory.model_name("descriptions")


### PR DESCRIPTION
## Summary
- document CLI orchestration of runtime environment
- detail that processing and service engines return simple success flags while storing results on their runtimes

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`


------
https://chatgpt.com/codex/tasks/task_e_68b6b1d1a460832bade297c04c1a471c