### PR TITLE
Clear residual state when resetting RuntimeEnv

### DIFF
--- a/src/runtime/environment.py
+++ b/src/runtime/environment.py
@@ -118,8 +118,9 @@ class RuntimeEnv:
         """Clear the active runtime environment and cached state.
 
         Useful for tests needing a fresh configuration or for scenarios where
-        the application must reload settings at runtime. Loader caches and run
-        metadata are cleared to avoid stale data in subsequent initialisations.
+        the application must reload settings at runtime. Loader caches, run
+        metadata, and state are cleared to avoid stale data in subsequent
+        initialisations.
         """
         with logfire.span("runtime_env.reset"):
             with cls._lock:
@@ -135,6 +136,8 @@ class RuntimeEnv:
                     if mapping is not None:
                         # Discard cached mapping data to force reloads.
                         mapping.clear_cache()
+                    # Remove any remaining state to ensure a clean instance.
+                    inst.state.clear()
                 cls._instance = None
 
 

--- a/tests/test_runtime_environment.py
+++ b/tests/test_runtime_environment.py
@@ -43,3 +43,4 @@ def test_reset_clears_run_meta_and_caches():
     assert prompt.cleared
     assert mapping.cleared
     assert env.run_meta is None
+    assert env.state == {}


### PR DESCRIPTION
## Summary
- Clear all runtime state during `RuntimeEnv.reset`
- Verify `RuntimeEnv.reset` empties state in unit tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_runtime_environment.py::test_reset_clears_run_meta_and_caches -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6b473d740832bb0cf8f92cbc95f66