### PR TITLE
refactor: persist session config on engine

### DIFF
--- a/tests/test_processing_engine_methods.py
+++ b/tests/test_processing_engine_methods.py
@@ -163,15 +163,13 @@ async def test_generate_evolution_aggregates_success(monkeypatch, tmp_path):
     ]
     sem = asyncio.Semaphore(2)
     handler = SimpleNamespace(handle=lambda *a, **k: None)
-    ok = await engine._generate_evolution(
-        services,
-        SimpleNamespace(),
-        "",
-        [],
-        sem,
-        None,
-        None,
-        handler,
-    )
+    engine.factory = SimpleNamespace()
+    engine.system_prompt = ""
+    engine.role_ids = []
+    engine.sem = sem
+    engine.progress = None
+    engine.temp_output_dir = None
+    engine.error_handler = handler
+    ok = await engine._generate_evolution(services)
     assert ok is False
     assert [r.service.service_id for r in engine.runtimes] == ["a", "b"]


### PR DESCRIPTION
## Summary
- store model, prompt and runtime settings directly on `ProcessingEngine`
- simplify service execution helpers by consuming instance attributes
- adjust tests for new `ProcessingEngine` API

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'mapping')*

------
https://chatgpt.com/codex/tasks/task_e_68b6bbb3b8a0832b8905ba3701c4bf09