### PR TITLE
refactor: cache generator attributes

### DIFF
--- a/tests/test_service_execution_helpers.py
+++ b/tests/test_service_execution_helpers.py
@@ -67,6 +67,27 @@ def _execution() -> ServiceExecution:
     )
 
 
+def test_build_generator_sets_attributes(monkeypatch):
+    exec_obj = _execution()
+
+    monkeypatch.setattr(se, "Agent", lambda *a, **k: object())
+    monkeypatch.setattr(se, "ConversationSession", lambda *a, **k: object())
+
+    class DummyGenerator:
+        def __init__(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(se, "PlateauGenerator", DummyGenerator)
+
+    exec_obj._build_generator()
+
+    assert isinstance(exec_obj.generator, DummyGenerator)
+    assert exec_obj.desc_name == "descriptions-model"
+    assert exec_obj.feat_name == "features-model"
+    assert exec_obj.map_name == "mapping-model"
+    assert exec_obj.feat_model is not None
+
+
 def test_ensure_run_meta_initialises_once(monkeypatch):
     exec_obj = _execution()
     monkeypatch.setattr(se, "load_mapping_items", lambda *a, **k: ({}, "0" * 64))


### PR DESCRIPTION
## Summary
- store plateau generator and model names as ServiceExecution attributes
- simplify ServiceExecution.run to use cached attributes
- test _build_generator attribute population

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'mapping')*

------
https://chatgpt.com/codex/tasks/task_e_68b6c9ef9884832bbb5b17d6201a4e32