### PR TITLE
feat: add error handler support to loader

### DIFF
--- a/src/io_utils/loader.py
+++ b/src/io_utils/loader.py
@@ -173,16 +173,27 @@ def compile_catalogue_for_set(
     return ordered, digest
 
 
-def _read_yaml_file(path: Path, schema: type[T]) -> T:
-    """Return YAML data loaded from ``path`` validated against ``schema``."""
+def _read_yaml_file(
+    path: Path,
+    schema: type[T],
+    error_handler: ErrorHandler | None = None,
+) -> T:
+    """Return YAML data loaded from ``path`` validated against ``schema``.
 
+    Args:
+        path: File location.
+        schema: Pydantic-compatible schema to validate against.
+        error_handler: Processor for any errors encountered.
+    """
+
+    handler = error_handler or LoggingErrorHandler()
     try:
         adapter = TypeAdapter(schema)
-        return adapter.validate_python(yaml.safe_load(_read_file(path)))
+        return adapter.validate_python(yaml.safe_load(_read_file(path, handler)))
     except FileNotFoundError:
         raise
     except Exception as exc:
-        logfire.error(f"Error reading YAML file {path}: {exc}")
+        handler.handle(f"Error reading YAML file {path}", exc)
         raise RuntimeError(
             f"An error occurred while reading the YAML file: {exc}"
         ) from exc
@@ -267,12 +278,14 @@ def load_mapping_type_config(
 def load_plateau_definitions(
     base_dir: Path | str = Path("data"),
     filename: Path | str = Path(FEATURE_PLATEAUS_JSON),
+    error_handler: ErrorHandler | None = None,
 ) -> list[ServiceFeaturePlateau]:
     """Return service feature plateau definitions from ``base_dir``.
 
     Args:
         base_dir: Directory containing data files.
         filename: Plateau definitions file name.
+        error_handler: Processor for any errors encountered.
 
     Returns:
         List of :class:`ServiceFeaturePlateau` records.
@@ -282,11 +295,12 @@ def load_plateau_definitions(
         RuntimeError: If the file cannot be read or parsed.
     """
 
+    handler = error_handler or LoggingErrorHandler()
     path = Path(base_dir) / Path(filename)
     try:
-        return _read_json_file(path, list[ServiceFeaturePlateau])
+        return _read_json_file(path, list[ServiceFeaturePlateau], handler)
     except Exception as exc:
-        logfire.error(f"Invalid plateau definition data in {path}: {exc}")
+        handler.handle(f"Invalid plateau definition data in {path}", exc)
         raise RuntimeError(f"Invalid plateau definitions: {exc}") from exc
 
 
@@ -294,12 +308,14 @@ def load_plateau_definitions(
 def load_roles(
     base_dir: Path | str = Path("data"),
     filename: Path | str = Path("roles.json"),
+    error_handler: ErrorHandler | None = None,
 ) -> list[Role]:
     """Return role definitions from ``base_dir`` or a direct file path.
 
     Args:
         base_dir: Directory containing data files or the roles file itself.
         filename: Roles definitions file name when ``base_dir`` is a directory.
+        error_handler: Processor for any errors encountered.
 
     Returns:
         List of :class:`Role` records.
@@ -309,14 +325,15 @@ def load_roles(
         RuntimeError: If the file cannot be read or parsed.
     """
 
+    handler = error_handler or LoggingErrorHandler()
     base_path = Path(base_dir)
     # If ``base_dir`` points to a directory append ``filename``; otherwise treat
     # it as the full path to the roles file.
     path = base_path / Path(filename) if base_path.is_dir() else base_path
     try:
-        return _read_json_file(path, list[Role])
+        return _read_json_file(path, list[Role], handler)
     except Exception as exc:
-        logfire.error(f"Invalid role data in {path}: {exc}")
+        handler.handle(f"Invalid role data in {path}", exc)
         raise RuntimeError(f"Invalid roles: {exc}") from exc
 
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -9,8 +9,11 @@ import utils.mapping_loader as mapping_loader
 from io_utils.loader import (
     _read_file,
     _read_json_file,
+    _read_yaml_file,
     compile_catalogue_for_set,
     load_mapping_items,
+    load_plateau_definitions,
+    load_roles,
 )
 from models import MappingSet
 from utils.error_handler import ErrorHandler
@@ -104,3 +107,54 @@ def test_read_json_file_invokes_handler(tmp_path: Path) -> None:
 
     assert handler.messages == [f"Error reading JSON file {bad}"]
     assert handler.exceptions[0] is not None
+
+
+def test_read_yaml_file_invokes_handler(tmp_path: Path) -> None:
+    """_read_yaml_file should delegate errors to the handler."""
+
+    handler = DummyHandler()
+    bad = tmp_path / "data.yaml"
+    bad.write_text("[:", encoding="utf-8")
+    with pytest.raises(RuntimeError):
+        _read_yaml_file(bad, dict[str, str], error_handler=handler)
+
+    assert handler.messages == [f"Error reading YAML file {bad}"]
+    assert handler.exceptions[0] is not None
+
+
+def test_load_plateau_definitions_invokes_handler(tmp_path: Path) -> None:
+    """load_plateau_definitions should delegate errors to the handler."""
+
+    handler = DummyHandler()
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    bad = data_dir / "service_feature_plateaus.json"
+    bad.write_text("not json", encoding="utf-8")
+    with pytest.raises(RuntimeError):
+        load_plateau_definitions(data_dir, error_handler=handler)
+
+    assert handler.messages == [
+        f"Error reading JSON file {bad}",
+        f"Invalid plateau definition data in {bad}",
+    ]
+    assert handler.exceptions[0] is not None
+    assert handler.exceptions[1] is not None
+
+
+def test_load_roles_invokes_handler(tmp_path: Path) -> None:
+    """load_roles should delegate errors to the handler."""
+
+    handler = DummyHandler()
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    bad = data_dir / "roles.json"
+    bad.write_text("not json", encoding="utf-8")
+    with pytest.raises(RuntimeError):
+        load_roles(data_dir, error_handler=handler)
+
+    assert handler.messages == [
+        f"Error reading JSON file {bad}",
+        f"Invalid role data in {bad}",
+    ]
+    assert handler.exceptions[0] is not None
+    assert handler.exceptions[1] is not None


### PR DESCRIPTION
## Summary
- allow custom error handlers for YAML, plateau definitions and role loaders
- route loader errors through provided handler
- verify error handler invocation on load failures

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `OPENAI_API_KEY=dummy poetry run pytest tests/test_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6f5fa31dc832b9cbc6edee1ff956b