### PR TITLE
feat: allow custom error handlers for mapping items

### DIFF
--- a/src/cli/mapping.py
+++ b/src/cli/mapping.py
@@ -17,10 +17,13 @@ from models import (
     MappingItem,
     ServiceEvolution,
 )
+from utils import ErrorHandler
 
 
 def load_catalogue(
-    mapping_data_dir: Path | None, settings
+    mapping_data_dir: Path | None,
+    settings,
+    error_handler: ErrorHandler | None = None,
 ) -> tuple[dict[str, list[MappingItem]], str]:
     """Return mapping catalogue items and hash.
 
@@ -38,7 +41,7 @@ def load_catalogue(
     """
 
     configure_mapping_data_dir(mapping_data_dir or settings.mapping_data_dir)
-    return load_mapping_items(settings.mapping_sets)
+    return load_mapping_items(settings.mapping_sets, error_handler=error_handler)
 
 
 async def remap_features(

--- a/src/core/mapping.py
+++ b/src/core/mapping.py
@@ -207,7 +207,12 @@ def _merge_mapping_results(
     """
 
     env = RuntimeEnv.instance()
-    catalogues = catalogue_items or load_mapping_items(env.settings.mapping_sets)[0]
+    catalogues = (
+        catalogue_items
+        or load_mapping_items(env.settings.mapping_sets, error_handler=_error_handler)[
+            0
+        ]
+    )
     valid_ids: dict[str, set[str]] = {
         key: {item.id for item in catalogues[cfg.dataset]}
         for key, cfg in mapping_types.items()

--- a/src/engine/service_execution.py
+++ b/src/engine/service_execution.py
@@ -173,7 +173,9 @@ class ServiceExecution:
             "mapping": self.map_name,
             "search": self.factory.model_name("search"),
         }
-        _, catalogue_hash = load_mapping_items(self.settings.mapping_sets)
+        _, catalogue_hash = load_mapping_items(
+            self.settings.mapping_sets, error_handler=self.error_handler
+        )
         context_window = getattr(self.feat_model, "max_input_tokens", 0)
         env.run_meta = ServiceMeta(
             run_id=str(uuid4()),

--- a/src/io_utils/loader.py
+++ b/src/io_utils/loader.py
@@ -40,8 +40,6 @@ FEATURE_PLATEAUS_JSON = "service_feature_plateaus.json"
 
 DEFINITIONS_JSON = "definitions.json"
 
-_error_handler: ErrorHandler = LoggingErrorHandler()
-
 # Core role statement for all system prompts. This line anchors the model's
 # objective before any contextual material is provided.
 NORTH_STAR = (
@@ -213,7 +211,7 @@ def load_prompt_text(prompt_name: str, base_dir: Path | str | None = None) -> st
     try:
         return loader.load(prompt_name)
     except Exception as exc:
-        _error_handler.handle(f"Error loading prompt {prompt_name}", exc)
+        LoggingErrorHandler().handle(f"Error loading prompt {prompt_name}", exc)
         raise
 
 
@@ -231,19 +229,28 @@ def clear_mapping_cache() -> None:
 
 
 def load_mapping_items(
-    sets: Sequence[MappingSet], data_dir: Path | str | None = None
+    sets: Sequence[MappingSet],
+    data_dir: Path | str | None = None,
+    error_handler: ErrorHandler | None = None,
 ) -> tuple[dict[str, list[MappingItem]], str]:
-    """Return mapping reference data and a combined catalogue hash."""
+    """Return mapping reference data and a combined catalogue hash.
+
+    Args:
+        sets: Catalogue definitions to load.
+        data_dir: Optional directory override for catalogue files.
+        error_handler: Processor for any errors encountered.
+    """
 
     loader = (
         FileMappingLoader(Path(data_dir))
         if data_dir is not None
         else RuntimeEnv.instance().mapping_loader
     )
+    handler = error_handler or LoggingErrorHandler()
     try:
         return loader.load(sets)
     except Exception as exc:
-        _error_handler.handle("Error loading mapping items", exc)
+        handler.handle("Error loading mapping items", exc)
         raise
 
 

--- a/tests/test_cli_mapping_helpers.py
+++ b/tests/test_cli_mapping_helpers.py
@@ -60,8 +60,9 @@ def test_load_catalogue_invokes_loader(monkeypatch) -> None:
     def fake_configure(path):
         calls["configure"] = path
 
-    def fake_load(mapping_sets):
+    def fake_load(mapping_sets, *, error_handler=None):
         calls["load"] = mapping_sets
+        assert error_handler is None
         return {"applications": []}, "hash"
 
     monkeypatch.setattr(cli_mapping, "configure_mapping_data_dir", fake_configure)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -141,6 +141,20 @@ def test_load_plateau_definitions_invokes_handler(tmp_path: Path) -> None:
     assert handler.exceptions[1] is not None
 
 
+def test_load_mapping_items_invokes_handler(tmp_path: Path) -> None:
+    """load_mapping_items should delegate errors to the handler."""
+
+    handler = DummyHandler()
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    sets = [MappingSet(name="Apps", file="missing.json", field="applications")]
+    with pytest.raises(FileNotFoundError):
+        load_mapping_items(sets, data_dir=data_dir, error_handler=handler)
+
+    assert handler.messages == ["Error loading mapping items"]
+    assert isinstance(handler.exceptions[0], FileNotFoundError)
+
+
 def test_load_roles_invokes_handler(tmp_path: Path) -> None:
     """load_roles should delegate errors to the handler."""
 


### PR DESCRIPTION
## Summary
- allow passing custom error handlers to mapping loader
- wire error handler through mapping utilities and CLI
- cover loader error handling with new tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_loader.py tests/test_cli_mapping_helpers.py tests/test_service_execution_helpers.py tests/test_small_mapping.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6f77cde04832b9a5a7f124e192e76