### PR TITLE
refactor: internalize service list in evolution generation

### DIFF
--- a/src/engine/processing_engine.py
+++ b/src/engine/processing_engine.py
@@ -267,18 +267,19 @@ class ProcessingEngine:
             self.progress.update(1)
         return success
 
-    async def _generate_evolution(self, services: list[ServiceInput]) -> bool:
+    async def _generate_evolution(self) -> bool:
         """Run service executions concurrently.
-
-        Args:
-            services: Services to process.
 
         Returns:
             ``True`` when all executions succeed, ``False`` otherwise.
 
         Side effects:
             Updates ``self.executions`` and ``self.new_ids``.
+
+        Notes:
+            Operates on services stored in ``self.services``.
         """
+        services = self.services or []
         async with asyncio.TaskGroup() as tg:
             tasks = [tg.create_task(self._run_service(svc)) for svc in services]
         return all(task.result() for task in tasks)
@@ -303,7 +304,7 @@ class ProcessingEngine:
                 logfire.info("Validated services", count=len(services))
                 return True
             self._init_sessions(len(services))
-            success = await self._generate_evolution(services)
+            success = await self._generate_evolution()
             if self.progress:
                 self.progress.close()
             self.success = success

--- a/tests/test_processing_engine_methods.py
+++ b/tests/test_processing_engine_methods.py
@@ -170,6 +170,7 @@ async def test_generate_evolution_aggregates_success(monkeypatch, tmp_path):
     engine.progress = None
     engine.temp_output_dir = None
     engine.error_handler = handler
-    ok = await engine._generate_evolution(services)
+    engine.services = services
+    ok = await engine._generate_evolution()
     assert ok is False
     assert [r.service.service_id for r in engine.runtimes] == ["a", "b"]


### PR DESCRIPTION
## Summary
- remove `services` argument from `ProcessingEngine._generate_evolution` and iterate over `self.services`
- update `ProcessingEngine.run` to call `_generate_evolution()` without arguments
- adjust tests for new `_generate_evolution` signature

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy src/engine/processing_engine.py tests/test_processing_engine_methods.py`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_processing_engine_methods.py::test_generate_evolution_aggregates_success -q`

------
https://chatgpt.com/codex/tasks/task_e_68b762ed7200832bb9428bb7856fcdd2