### PR TITLE
Refactor session initialization to derive service count

### DIFF
--- a/src/engine/processing_engine.py
+++ b/src/engine/processing_engine.py
@@ -217,9 +217,13 @@ class ProcessingEngine:
         self.role_ids = role_ids
         self.services = services
 
-    def _init_sessions(self, total: int) -> None:
-        """Create concurrency, progress and error-handling helpers."""
+    def _init_sessions(self) -> None:
+        """Create concurrency, progress and error-handling helpers.
 
+        The total number of services is derived from ``self.services``.
+        """
+
+        total = len(self.services or [])
         self.sem = self._setup_concurrency()
         self.progress = self._create_progress(total)
         self.temp_output_dir = (
@@ -299,11 +303,10 @@ class ProcessingEngine:
                 input_file=self.args.input_file,
             )
             self._prepare_models()
-            services = self.services or []
             if self.args.dry_run:
-                logfire.info("Validated services", count=len(services))
+                logfire.info("Validated services", count=len(self.services or []))
                 return True
-            self._init_sessions(len(services))
+            self._init_sessions()
             success = await self._generate_evolution()
             if self.progress:
                 self.progress.close()

--- a/tests/test_processing_engine_methods.py
+++ b/tests/test_processing_engine_methods.py
@@ -93,7 +93,7 @@ def test_init_sessions_uses_runtimeenv(monkeypatch, tmp_path):
     monkeypatch.setattr(engine, "_setup_concurrency", fake_setup_concurrency)
     monkeypatch.setattr(engine, "_create_progress", lambda total: "progress")
 
-    engine._init_sessions(5)
+    engine._init_sessions()
 
     assert captured["settings"] is settings
     assert isinstance(engine.sem, asyncio.Semaphore)


### PR DESCRIPTION
## Summary
- compute session total from available services instead of passing a parameter
- adjust processing engine to call `_init_sessions` without arguments
- update `_init_sessions` unit test for new signature

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest` *(fails: ImportError: cannot import name 'AmbitionModel' from '<unknown module name>')*


------
https://chatgpt.com/codex/tasks/task_e_68b77c0a45e8832bbd513828ec8ee730