### PR TITLE
refactor: internalise generator state

### DIFF
--- a/src/engine/service_execution.py
+++ b/src/engine/service_execution.py
@@ -189,10 +189,12 @@ class ServiceExecution:
             created=datetime.now(timezone.utc),
         )
 
-    async def _prepare_runtimes(
-        self, generator: PlateauGenerator
-    ) -> list[PlateauRuntime]:
+    async def _prepare_runtimes(self) -> list[PlateauRuntime]:
         """Return plateau runtimes with descriptions."""
+
+        generator = self.generator
+        if generator is None:  # pragma: no cover - defensive
+            raise RuntimeError("Generator not initialised")
 
         names = list(default_plateau_names())
         desc_map = await generator._request_descriptions_async(
@@ -244,7 +246,7 @@ class ServiceExecution:
             try:
                 SERVICES_PROCESSED.add(1)
                 self._ensure_run_meta()
-                runtimes = await self._prepare_runtimes(self.generator)
+                runtimes = await self._prepare_runtimes()
                 env = RuntimeEnv.instance()
                 meta = env.run_meta
                 assert meta is not None  # mypy safeguard


### PR DESCRIPTION
## Summary
- use ServiceExecution.generator directly in _prepare_runtimes
- adapt ServiceExecution.run to the simplified helper
- test _prepare_runtimes uses internal generator state

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing tests/test_service_execution_helpers.py src/engine/service_execution.py`
- `poetry run ruff check --fix tests/test_service_execution_helpers.py src/engine/service_execution.py`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=term-missing --cov-fail-under=85` *(fails: No module named 'pydantic_ai.models.openai')*

------
https://chatgpt.com/codex/tasks/task_e_68b6c8255fb4832baef11d0dbe6b7453