### PR TITLE
Ensure ServiceExecution prerequisites present

### DIFF
--- a/src/engine/service_execution.py
+++ b/src/engine/service_execution.py
@@ -232,7 +232,8 @@ class ServiceExecution:
         self.refresh_settings()
         service = self.runtime.service
         self._build_generator()
-        assert self.generator is not None  # mypy safeguard
+        if self.generator is None:
+            raise RuntimeError("Plateau generator is not initialised")
         attrs = {
             "service_id": service.service_id,
             "service_name": service.name,
@@ -247,7 +248,8 @@ class ServiceExecution:
                 runtimes = await self._prepare_runtimes(self.generator)
                 env = RuntimeEnv.instance()
                 meta = env.run_meta
-                assert meta is not None  # mypy safeguard
+                if meta is None:
+                    raise RuntimeError("Run metadata is not initialised")
                 evolution = await self.generator.generate_service_evolution_async(
                     service,
                     runtimes,
@@ -260,6 +262,8 @@ class ServiceExecution:
                 self.runtime.line = to_json(record).decode()
                 self.runtime.success = True
                 return True
+            except RuntimeError:
+                raise
             except Exception as exc:  # noqa: BLE001
                 quarantine_file = await asyncio.to_thread(
                     _writer.write,

--- a/tests/test_service_execution.py
+++ b/tests/test_service_execution.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from engine.service_execution import ServiceExecution
+from test_service_execution_helpers import _execution
+
+
+@pytest.mark.asyncio
+async def test_run_raises_when_generator_missing(monkeypatch):
+    exec_obj = _execution()
+
+    monkeypatch.setattr(ServiceExecution, "_build_generator", lambda self: None)
+
+    with pytest.raises(RuntimeError, match="generator is not initialised"):
+        await exec_obj.run()
+
+
+@pytest.mark.asyncio
+async def test_run_raises_when_run_meta_missing(monkeypatch):
+    exec_obj = _execution()
+
+    class DummyGenerator:  # pragma: no cover - simple stub
+        async def generate_service_evolution_async(self, *a, **k):  # pragma: no cover
+            return None
+
+    monkeypatch.setattr(
+        ServiceExecution,
+        "_build_generator",
+        lambda self: setattr(self, "generator", DummyGenerator()),
+    )
+
+    async def _fake_prepare_runtimes(self, gen):
+        return []
+
+    monkeypatch.setattr(ServiceExecution, "_prepare_runtimes", _fake_prepare_runtimes)
+    monkeypatch.setattr(ServiceExecution, "_ensure_run_meta", lambda self: None)
+    dummy_env = SimpleNamespace(settings=exec_obj.settings, run_meta=None)
+    monkeypatch.setattr("runtime.environment.RuntimeEnv.instance", lambda: dummy_env)
+
+    with pytest.raises(RuntimeError, match="Run metadata is not initialised"):
+        await exec_obj.run()


### PR DESCRIPTION
## Summary
- raise `RuntimeError` when generator or run metadata is missing
- add unit tests covering missing generator and run metadata scenarios

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing src/engine/service_execution.py tests/test_service_execution.py`
- `poetry run ruff check --fix src/engine/service_execution.py tests/test_service_execution.py`
- `poetry run mypy src/engine/service_execution.py tests/test_service_execution.py`
- `poetry run bandit -r src/engine/service_execution.py -ll`
- `poetry run pip-audit`
- `poetry run pytest tests/test_service_execution.py tests/test_service_execution_helpers.py -q`
- `poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=term-missing --cov-fail-under=85` *(failed: ModuleNotFoundError: No module named 'pydantic_ai.models.openai'; 'pydantic_ai.models' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68b780ea6b58832ba2fac27a195b6467