### PR TITLE
Refactor reverse cache helpers and expose cache utilities

### DIFF
--- a/src/core/mapping.py
+++ b/src/core/mapping.py
@@ -104,7 +104,7 @@ def _features_hash(features: Sequence[PlateauFeature]) -> str:
     return hashlib.sha256(combined.encode("utf-8")).hexdigest()
 
 
-def _build_cache_key(
+def build_cache_key(
     model_name: str,
     set_name: str,
     catalogue_hash: str,
@@ -134,7 +134,7 @@ def _build_cache_key(
     return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()[:32]
 
 
-def _cache_path(service: str, plateau: int, set_name: str, key: str) -> Path:
+def cache_path(service: str, plateau: int, set_name: str, key: str) -> Path:
     """Return canonical cache path for ``service`` and ``set_name``.
 
     Cache files are grouped by context, service identifier and plateau level.
@@ -172,7 +172,7 @@ def _discover_cache_file(
     canonical path.
     """
 
-    canonical = _cache_path(service, plateau, set_name, key)
+    canonical = cache_path(service, plateau, set_name, key)
     if canonical.exists():
         return canonical, canonical
 
@@ -187,6 +187,11 @@ def cache_write_json_atomic(path: Path, content: Any) -> None:
     """Atomically write ``content`` as pretty JSON to ``path``."""
 
     _cache_manager.write_json_atomic(path, content)
+
+
+# Backwards compatibility for renamed helpers
+_build_cache_key = build_cache_key
+_cache_path = cache_path
 
 
 def _merge_mapping_results(
@@ -343,7 +348,7 @@ async def map_set(
     )
     model_obj = getattr(session, "client", None)
     model_name = getattr(getattr(model_obj, "model", None), "model_name", "")
-    key = _build_cache_key(model_name, set_name, catalogue_hash, features, use_diag)
+    key = build_cache_key(model_name, set_name, catalogue_hash, features, use_diag)
     model_type = cast(
         type[StrictModel],
         getattr(
@@ -548,4 +553,6 @@ __all__ = [
     "map_set",
     "group_features_by_mapping",
     "MappingError",
+    "build_cache_key",
+    "cache_path",
 ]

--- a/tests/test_cli_reverse_helpers.py
+++ b/tests/test_cli_reverse_helpers.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: MIT
+"""Unit tests for reverse CLI helper functions."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from cli.main import _rebuild_mapping_cache, _reconstruct_feature_cache
+from core.mapping import build_cache_key, cache_path
+from models import (
+    FeatureMappingRef,
+    MappingFeatureGroup,
+    MappingSet,
+    MaturityScore,
+    PlateauFeature,
+    PlateauResult,
+)
+from runtime.environment import RuntimeEnv
+
+
+def _settings(tmp_path):
+    return SimpleNamespace(
+        cache_dir=tmp_path / ".cache",
+        context_id="unknown",
+        mapping_sets=[
+            MappingSet(
+                name="Applications", file="applications.json", field="applications"
+            )
+        ],
+        model="gpt-5",
+        diagnostics=False,
+    )
+
+
+def test_reconstruct_feature_cache_writes_grouped(tmp_path) -> None:
+    RuntimeEnv.reset()
+    settings = _settings(tmp_path)
+    RuntimeEnv.initialize(settings)
+    score = MaturityScore(level=1, label="Initial", justification="j")
+    feat = PlateauFeature(
+        feature_id="F1",
+        name="Feature1",
+        description="Desc1",
+        score=score,
+        customer_type="learners",
+        mappings={},
+    )
+    plateau = PlateauResult(
+        plateau=1,
+        plateau_name="alpha",
+        service_description="desc",
+        features=[feat],
+        mappings={},
+    )
+    _reconstruct_feature_cache("svc", plateau)
+    cache_file = settings.cache_dir / "unknown" / "svc" / "1" / "features.json"
+    assert cache_file.exists()
+    data = json.loads(cache_file.read_text(encoding="utf-8"))
+    assert data["features"]["learners"][0]["name"] == "Feature1"
+
+
+def test_rebuild_mapping_cache_writes_entries(tmp_path) -> None:
+    RuntimeEnv.reset()
+    settings = _settings(tmp_path)
+    RuntimeEnv.initialize(settings)
+    score = MaturityScore(level=1, label="Initial", justification="j")
+    feat = PlateauFeature(
+        feature_id="F1",
+        name="Feature1",
+        description="Desc1",
+        score=score,
+        customer_type="learners",
+        mappings={},
+    )
+    group = MappingFeatureGroup(
+        id="app1",
+        name="App1",
+        mappings=[FeatureMappingRef(feature_id="F1", description="Desc1")],
+    )
+    plateau = PlateauResult(
+        plateau=1,
+        plateau_name="alpha",
+        service_description="desc",
+        features=[feat],
+        mappings={"applications": [group]},
+    )
+    _rebuild_mapping_cache("svc", plateau, settings, "0" * 64)
+    assert plateau.mappings == {}
+    key = build_cache_key(
+        settings.model, "applications", "0" * 64, [feat], settings.diagnostics
+    )
+    cache_file = cache_path("svc", 1, "applications", key)
+    assert cache_file.exists()
+    data = json.loads(cache_file.read_text(encoding="utf-8"))
+    assert data["features"][0]["feature_id"] == "F1"

--- a/tests/test_e2e_cli_reverse.py
+++ b/tests/test_e2e_cli_reverse.py
@@ -168,7 +168,7 @@ def test_cli_reverse_generates_caches(monkeypatch, tmp_path) -> None:
         }
     }
 
-    key = mapping._build_cache_key(
+    key = mapping.build_cache_key(
         settings.model, "applications", "0" * 64, [feat], settings.diagnostics
     )
     map_cache = (

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -370,7 +370,7 @@ async def test_map_set_writes_cache(monkeypatch, tmp_path) -> None:
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(mapping, "render_set_prompt", lambda *a, **k: "PROMPT")
-    monkeypatch.setattr(mapping, "_build_cache_key", lambda *a, **k: "key")
+    monkeypatch.setattr(mapping, "build_cache_key", lambda *a, **k: "key")
     response = MappingResponse.model_validate(
         {"features": [{"feature_id": "f1", "applications": [{"item": "a"}]}]}
     )
@@ -407,7 +407,7 @@ async def test_map_set_reads_cache(monkeypatch, tmp_path) -> None:
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(mapping, "render_set_prompt", lambda *a, **k: "PROMPT")
-    monkeypatch.setattr(mapping, "_build_cache_key", lambda *a, **k: "key")
+    monkeypatch.setattr(mapping, "build_cache_key", lambda *a, **k: "key")
     cached = {"features": [{"feature_id": "f1", "applications": [{"item": "a"}]}]}
     old_dir = Path(".cache") / "unknown" / "svc" / "mappings" / "f1" / "applications"
     old_dir.mkdir(parents=True, exist_ok=True)
@@ -451,7 +451,7 @@ async def test_map_set_invalid_cache_halts(monkeypatch, tmp_path) -> None:
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(mapping, "render_set_prompt", lambda *a, **k: "PROMPT")
-    monkeypatch.setattr(mapping, "_build_cache_key", lambda *a, **k: "key")
+    monkeypatch.setattr(mapping, "build_cache_key", lambda *a, **k: "key")
     cache_dir = Path(".cache") / "unknown" / "svc" / "1" / "mappings" / "applications"
     cache_dir.mkdir(parents=True, exist_ok=True)
     bad_file = cache_dir / "key.json"
@@ -484,7 +484,7 @@ async def test_map_set_cache_invalidation(monkeypatch, tmp_path, change) -> None
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(mapping, "render_set_prompt", lambda *a, **k: "PROMPT")
     keys = iter(["key1", "key2"])
-    monkeypatch.setattr(mapping, "_build_cache_key", lambda *a, **k: next(keys))
+    monkeypatch.setattr(mapping, "build_cache_key", lambda *a, **k: next(keys))
     if change == "template":  # Template text changes between calls
         versions = iter(["v1", "v2"])
         monkeypatch.setattr(mapping, "load_prompt_text", lambda _: next(versions))
@@ -550,7 +550,7 @@ async def test_map_set_logs_cache_status(
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(mapping, "render_set_prompt", lambda *a, **k: "PROMPT")
-    monkeypatch.setattr(mapping, "_build_cache_key", lambda *a, **k: "key")
+    monkeypatch.setattr(mapping, "build_cache_key", lambda *a, **k: "key")
     response = json.dumps(
         {"features": [{"feature_id": "f1", "applications": [{"item": "a"}]}]},
         separators=(",", ":"),
@@ -599,7 +599,7 @@ async def test_map_set_cache_modes(
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(mapping, "render_set_prompt", lambda *a, **k: "PROMPT")
-    monkeypatch.setattr(mapping, "_build_cache_key", lambda *a, **k: "key")
+    monkeypatch.setattr(mapping, "build_cache_key", lambda *a, **k: "key")
     response = json.dumps(
         {"features": [{"feature_id": "f1", "applications": [{"item": "a"}]}]}
     )


### PR DESCRIPTION
## Summary
- expose `build_cache_key` and `cache_path` utilities in `core.mapping`
- refactor CLI reverse command into `_reconstruct_feature_cache` and `_rebuild_mapping_cache`
- add unit tests for reverse helpers and update e2e reverse test

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=term-missing --cov-fail-under=85` *(fails: No module named 'pydantic_ai.models.openai')*

------
https://chatgpt.com/codex/tasks/task_e_68b7c883c400832b875dd1744d9ac410