### PR TITLE
docs: add package docstrings

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,17 @@
+"""Core utilities for service evolution workflows.
+
+Exports:
+    canonicalise_record: Return a record with deterministic ordering.
+    ConversationSession: Manage conversational exchanges with an LLM agent.
+    render_set_prompt: Build deterministic feature mapping prompts.
+"""
+
+from .canonical import canonicalise_record
+from .conversation import ConversationSession
+from .mapping_prompt import render_set_prompt
+
+__all__ = [
+    "canonicalise_record",
+    "ConversationSession",
+    "render_set_prompt",
+]

--- a/src/io_utils/__init__.py
+++ b/src/io_utils/__init__.py
@@ -1,0 +1,76 @@
+"""Input and output helpers for prompts, mappings and files.
+
+Exports:
+    configure_prompt_dir: Set the base directory for prompt templates.
+    configure_mapping_data_dir: Set the base directory for mapping catalogues.
+    load_prompt_text: Read a prompt template from disk.
+    load_mapping_items: Load mapping catalogue entries.
+    load_services: Iterate over service definitions in a JSONL file.
+    read_lines: Return existing lines from a file.
+    atomic_write: Write files atomically.
+    validate_jsonl: Validate JSONL files against a Pydantic model.
+    QuarantineWriter: Persist invalid payloads and maintain a manifest.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Sequence
+
+from .diagnostics import validate_jsonl
+from .persistence import atomic_write, read_lines
+from .quarantine import QuarantineWriter
+from .service_loader import load_services
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from models import MappingItem, MappingSet
+    from utils import ErrorHandler
+
+
+def configure_prompt_dir(path: Path | str) -> None:
+    """Set the base directory for prompt templates."""
+
+    from .loader import configure_prompt_dir as _configure_prompt_dir
+
+    _configure_prompt_dir(path)
+
+
+def configure_mapping_data_dir(path: Path | str) -> None:
+    """Set the base directory for mapping catalogues."""
+
+    from .loader import configure_mapping_data_dir as _configure_mapping_data_dir
+
+    _configure_mapping_data_dir(path)
+
+
+def load_prompt_text(prompt_name: str, base_dir: Path | str | None = None) -> str:
+    """Return the contents of a prompt template."""
+
+    from .loader import load_prompt_text as _load_prompt_text
+
+    return _load_prompt_text(prompt_name, base_dir)
+
+
+def load_mapping_items(
+    sets: Sequence["MappingSet"],
+    data_dir: Path | str | None = None,
+    error_handler: "ErrorHandler" | None = None,
+) -> tuple[dict[str, list["MappingItem"]], str]:
+    """Return mapping reference data and a catalogue hash."""
+
+    from .loader import load_mapping_items as _load_mapping_items
+
+    return _load_mapping_items(sets, data_dir, error_handler)
+
+
+__all__ = [
+    "configure_prompt_dir",
+    "configure_mapping_data_dir",
+    "load_prompt_text",
+    "load_mapping_items",
+    "load_services",
+    "read_lines",
+    "atomic_write",
+    "validate_jsonl",
+    "QuarantineWriter",
+]

--- a/src/observability/__init__.py
+++ b/src/observability/__init__.py
@@ -1,0 +1,28 @@
+"""Telemetry and monitoring helpers for the service generator.
+
+Exports:
+    init_logfire: Configure Pydantic Logfire instrumentation.
+    record_mapping_set: Record metrics for a mapping set.
+    record_quarantine: Track creation of quarantine files.
+    print_summary: Output a summary of collected metrics.
+    has_quarantines: Indicate whether quarantined files exist.
+    reset: Clear stored metrics and quarantine paths.
+"""
+
+from .monitoring import init_logfire
+from .telemetry import (
+    has_quarantines,
+    print_summary,
+    record_mapping_set,
+    record_quarantine,
+    reset,
+)
+
+__all__ = [
+    "init_logfire",
+    "record_mapping_set",
+    "record_quarantine",
+    "print_summary",
+    "has_quarantines",
+    "reset",
+]


### PR DESCRIPTION
## Summary
- document core utilities and exports
- describe io_utils helpers and lazy exports
- outline observability telemetry and metrics

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=term-missing --cov-fail-under=85` *(fails: ModuleNotFoundError: No module named 'pydantic_ai.models.openai'; 'pydantic_ai.models' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c95dc418832b9b61e46a17f6baf6