### PR TITLE
docs: expand loader and helper docstrings

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -99,7 +99,15 @@ class MaturityScore(BaseModel):
     justification: Annotated[str, Field(min_length=1)]
 
     @model_validator(mode="after")
-    def label_matches_level(self):
+    def label_matches_level(self) -> MaturityScore:
+        """Ensure the textual label corresponds to the numeric CMMI level.
+
+        Returns:
+            The validated ``MaturityScore`` instance.
+
+        Raises:
+            ValueError: If ``label`` does not match ``level``.
+        """
         if self.label != CMMI_LABELS.get(self.level):
             raise ValueError(
                 f"label must match level ({self.level} → {CMMI_LABELS[self.level]})"

--- a/src/utils/cache_manager.py
+++ b/src/utils/cache_manager.py
@@ -27,7 +27,20 @@ class CacheManager(ABC):
 class JSONCacheManager(CacheManager):
     """Cache manager writing JSON objects to disk."""
 
-    def write_json_atomic(self, path: Path, content: Any) -> None:  # noqa: D401
+    def write_json_atomic(self, path: Path, content: Any) -> None:
+        """Write ``content`` to ``path`` as pretty-printed JSON atomically.
+
+        Args:
+            path: Destination file path for the JSON payload.
+            content: JSON-serialisable object or raw JSON string/bytes.
+
+        Returns:
+            None.
+
+        Raises:
+            TypeError: If ``content`` is not a JSON object.
+            OSError: If the file cannot be written.
+        """
         with logfire.span("cache.write_json_atomic", attributes={"path": str(path)}):
             data = (
                 content

--- a/src/utils/error_handler.py
+++ b/src/utils/error_handler.py
@@ -22,7 +22,16 @@ class ErrorHandler(ABC):
 class LoggingErrorHandler(ErrorHandler):
     """Error handler that logs via ``logfire``."""
 
-    def handle(self, message: str, exc: Exception | None = None) -> None:  # noqa: D401
+    def handle(self, message: str, exc: Exception | None = None) -> None:
+        """Log an error message with optional exception context.
+
+        Args:
+            message: Description of the error to record.
+            exc: Exception instance providing additional context.
+
+        Returns:
+            None.
+        """
         if exc:
             logfire.error(f"{message}: {exc}")
         else:

--- a/src/utils/mapping_loader.py
+++ b/src/utils/mapping_loader.py
@@ -47,7 +47,23 @@ class FileMappingLoader(MappingLoader):
 
     def load(
         self, sets: Sequence[MappingSet]
-    ) -> tuple[dict[str, list[MappingItem]], str]:  # noqa: D401
+    ) -> tuple[dict[str, list[MappingItem]], str]:
+        """Return mapping data and a combined hash for ``sets``.
+
+        Args:
+            sets: Collection of mapping definitions specifying which files and
+                fields to load.
+
+        Returns:
+            Two-item tuple containing:
+                * A mapping of field names to their corresponding list of
+                  ``MappingItem`` objects.
+                * A SHA256 digest summarising the loaded sets.
+
+        Raises:
+            FileNotFoundError: If the data directory or a mapping file is missing.
+            pydantic.ValidationError: If a mapping file contains invalid data.
+        """
         key: Tuple[Tuple[str, str], ...] = tuple((s.file, s.field) for s in sets)
         with logfire.span(
             "mapping_loader.load",

--- a/src/utils/prompt_loader.py
+++ b/src/utils/prompt_loader.py
@@ -40,7 +40,19 @@ class FilePromptLoader(PromptLoader):
         self._base_dir = base_dir
         self._cache: dict[str, str] = {}
 
-    def load(self, name: str) -> str:  # noqa: D401 - short delegation
+    def load(self, name: str) -> str:
+        """Retrieve the prompt template for ``name`` from disk.
+
+        Args:
+            name: Identifier of the prompt template without file extension.
+
+        Returns:
+            Template text with surrounding whitespace removed.
+
+        Raises:
+            FileNotFoundError: If the prompt file does not exist.
+            OSError: If an error occurs while reading the file.
+        """
         with logfire.span("prompt_loader.load", attributes={"name": name}):
             if name in self._cache:
                 return self._cache[name]


### PR DESCRIPTION
## Summary
- document loader, cache, and error handling helpers with Google-style docstrings
- annotate and document `MaturityScore.label_matches_level`

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=term-missing --cov-fail-under=85` *(fails: ModuleNotFoundError: No module named 'pydantic_ai.models.openai')*


------
https://chatgpt.com/codex/tasks/task_e_68b7c9693f24832bbcd11cbf52b93bd5