### PR TITLE
Annotate CLI mapping helpers with Settings

### DIFF
--- a/src/cli/mapping.py
+++ b/src/cli/mapping.py
@@ -20,12 +20,13 @@ from models import (
     PlateauResult,
     ServiceEvolution,
 )
+from runtime.settings import Settings
 from utils import ErrorHandler
 
 
 def load_catalogue(
     mapping_data_dir: Path | None,
-    settings,
+    settings: Settings,
     error_handler: ErrorHandler | None = None,
 ) -> tuple[dict[str, list[MappingItem]], str]:
     """Return mapping catalogue items and hash.
@@ -159,7 +160,7 @@ def _assemble_mapping_groups(
 async def remap_features(
     evolutions: Sequence[ServiceEvolution],
     items: dict[str, list[MappingItem]],
-    settings,
+    settings: Settings,
     cache_mode: Literal["off", "read", "refresh", "write"],
     catalogue_hash: str,
 ) -> None:

--- a/tests/test_cli_mapping_helpers.py
+++ b/tests/test_cli_mapping_helpers.py
@@ -5,29 +5,34 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 
 from cli import mapping as cli_mapping
 from core import mapping
 from models import Contribution, MappingSet, ServiceEvolution
+from runtime.settings import Settings
 
 
-def _settings() -> SimpleNamespace:
+def _settings() -> Settings:
     """Return minimal settings for helper tests."""
 
-    return SimpleNamespace(
-        diagnostics=False,
-        strict_mapping=False,
-        mapping_data_dir=Path("tests/fixtures/catalogue"),
-        mapping_sets=[
-            MappingSet(
-                name="Applications", file="applications.json", field="applications"
-            ),
-            MappingSet(
-                name="Technologies", file="technologies.json", field="technologies"
-            ),
-        ],
+    return cast(
+        Settings,
+        SimpleNamespace(
+            diagnostics=False,
+            strict_mapping=False,
+            mapping_data_dir=Path("tests/fixtures/catalogue"),
+            mapping_sets=[
+                MappingSet(
+                    name="Applications", file="applications.json", field="applications"
+                ),
+                MappingSet(
+                    name="Technologies", file="technologies.json", field="technologies"
+                ),
+            ],
+        ),
     )
 
 
@@ -125,7 +130,9 @@ def test_load_catalogue_invokes_loader(monkeypatch) -> None:
     monkeypatch.setattr(cli_mapping, "configure_mapping_data_dir", fake_configure)
     monkeypatch.setattr(cli_mapping, "load_mapping_items", fake_load)
 
-    settings = SimpleNamespace(mapping_data_dir=Path("cat"), mapping_sets=[1])
+    settings = cast(
+        Settings, SimpleNamespace(mapping_data_dir=Path("cat"), mapping_sets=[1])
+    )
     items, catalogue_hash = cli_mapping.load_catalogue(None, settings)
 
     assert calls["configure"] == Path("cat")


### PR DESCRIPTION
## Summary
- type annotate `load_catalogue` and `remap_features` with `Settings`
- update tests to use `Settings`-typed fixtures

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing tests/test_cli_mapping_helpers.py src/cli/mapping.py`
- `poetry run ruff check --fix tests/test_cli_mapping_helpers.py src/cli/mapping.py`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=term-missing --cov-fail-under=85` *(fails: No module named 'pydantic_ai.models.openai')*

------
https://chatgpt.com/codex/tasks/task_e_68b7cafd8ff8832b8de51f99839fcbdd