### PR TITLE
Refactor complex functions into helpers

### DIFF
--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -215,3 +215,24 @@ def test_ask_uses_cache_when_available(tmp_path, monkeypatch) -> None:
 
     assert reply == "cached"
     assert agent.called_with == []
+
+
+def test_ask_writes_cache_on_miss(tmp_path, monkeypatch) -> None:
+    """Cache misses should persist responses for future calls."""
+
+    agent = DummyAgent()
+    session = ConversationSession(
+        cast(Agent[None, str], agent),
+        stage="stage",
+        use_local_cache=True,
+        cache_mode="read",
+    )
+    RuntimeEnv.initialize(
+        cast(Any, SimpleNamespace(cache_dir=tmp_path, context_id="ctx"))
+    )
+
+    session.ask("hello")
+
+    key = conversation._prompt_cache_key("hello", "", "stage")
+    path = conversation._prompt_cache_path("unknown", "stage", key)
+    assert path.exists()


### PR DESCRIPTION
## Summary
- Decompose conversation caching logic into helper methods with clear responsibilities
- Split mapping utilities and map_set into smaller units, adding cache and prompt helpers
- Format definition rendering with dedicated item formatter and test cache writes

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing src/core/conversation.py src/core/mapping.py src/io_utils/loader.py tests/test_conversation.py`
- `poetry run ruff check --fix src/core/conversation.py src/core/mapping.py src/io_utils/loader.py tests/test_conversation.py`
- `poetry run mypy src/core/conversation.py src/core/mapping.py src/io_utils/loader.py tests/test_conversation.py`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'pydantic_ai.models.openai')*
- `poetry run radon cc -s src/core/conversation.py`
- `poetry run radon cc -s src/core/mapping.py | rg "map_set" -n`
- `poetry run radon cc -s src/io_utils/loader.py | rg "load_definitions" -n`

------
https://chatgpt.com/codex/tasks/task_e_68b7cdf9c768832ba068904c0015e247