### PR TITLE
refactor: narrow exception handling

### DIFF
--- a/src/engine/service_execution.py
+++ b/src/engine/service_execution.py
@@ -9,6 +9,7 @@ from typing import Sequence
 from uuid import uuid4
 
 import logfire
+from pydantic import ValidationError
 from pydantic_ai import Agent
 from pydantic_core import to_json
 
@@ -266,7 +267,7 @@ class ServiceExecution:
                 return True
             except RuntimeError:
                 raise
-            except Exception as exc:  # noqa: BLE001
+            except (ValidationError, ValueError, OSError) as exc:
                 quarantine_file = await asyncio.to_thread(
                     _writer.write,
                     "evolution",

--- a/src/utils/cache_paths.py
+++ b/src/utils/cache_paths.py
@@ -18,7 +18,7 @@ def feature_cache(service_id: str, plateau: int) -> Path:
         settings = RuntimeEnv.instance().settings
         cache_root = settings.cache_dir
         context = settings.context_id
-    except Exception:  # pragma: no cover - settings unavailable
+    except RuntimeError:  # pragma: no cover - settings unavailable
         cache_root = Path(".cache")
         context = "unknown"
 


### PR DESCRIPTION
## Summary
- tighten file loading error handling to raise precise failures
- replace broad service execution catch with specific validation and IO errors
- guard cache path helpers against missing runtime settings
- refine conversation caching/transcript logic with targeted exception handling

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=term-missing --cov-fail-under=85` *(fails: unrecognized arguments: --cov=src --cov-report=term-missing --cov-fail-under=85)*
- `poetry run pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'pydantic_ai.models.openai'; 'pydantic_ai.models' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f8974798832ba838e43b91ff5805