### PR TITLE
Refactor mapping and conversation helpers for clarity

### DIFF
--- a/src/cli/mapping.py
+++ b/src/cli/mapping.py
@@ -70,11 +70,7 @@ async def _apply_mapping_sets(
 
     mapped = list(features)
     for cfg in settings.mapping_sets:  # Apply each mapping set sequentially.
-        mapped = await mapping.map_set(
-            cast(ConversationSession, object()),
-            cfg.field,
-            items[cfg.field],
-            mapped,
+        params = mapping.MapSetParams(
             service_name="svc",
             service_description="desc",
             plateau=1,
@@ -82,6 +78,13 @@ async def _apply_mapping_sets(
             diagnostics=settings.diagnostics,
             cache_mode=cache_mode,
             catalogue_hash=catalogue_hash,
+        )
+        mapped = await mapping.map_set(
+            cast(ConversationSession, object()),
+            cfg.field,
+            items[cfg.field],
+            mapped,
+            params,
         )
     return mapped
 

--- a/src/engine/plateau_runtime.py
+++ b/src/engine/plateau_runtime.py
@@ -12,7 +12,12 @@ from pydantic import ValidationError
 from pydantic_core import from_json
 
 from core.conversation import ConversationSession
-from core.mapping import cache_write_json_atomic, group_features_by_mapping, map_set
+from core.mapping import (
+    MapSetParams,
+    cache_write_json_atomic,
+    group_features_by_mapping,
+    map_set,
+)
 from io_utils.loader import load_mapping_items, load_prompt_text
 from models import (
     FeatureItem,
@@ -435,11 +440,7 @@ class PlateauRuntime:
 
         set_session = session.derive()
         set_session.stage = f"mapping_{cfg.field}"
-        result = await map_set(
-            set_session,
-            cfg.field,
-            items[cfg.field],
-            list(self.features),
+        params = MapSetParams(
             service_name=service_name,
             service_description=service_description,
             plateau=self.plateau,
@@ -447,6 +448,13 @@ class PlateauRuntime:
             strict=strict,
             cache_mode=(cache_mode if use_local_cache else "off"),
             catalogue_hash=catalogue_hash,
+        )
+        result = await map_set(
+            set_session,
+            cfg.field,
+            items[cfg.field],
+            list(self.features),
+            params,
         )
         return group_features_by_mapping(result, cfg.field, items[cfg.field])
 

--- a/tests/test_cli_mapping_helpers.py
+++ b/tests/test_cli_mapping_helpers.py
@@ -39,7 +39,7 @@ def _settings() -> Settings:
 def _stub_map_set(*args, **kwargs):
     """Return deterministic mappings for test features."""
 
-    session, set_name, _, features = args[:4]
+    session, set_name, _, features, *rest = args
     mapped = []
     for feat in features:
         mappings = dict(feat.mappings)

--- a/tests/test_e2e_cli_mapping.py
+++ b/tests/test_e2e_cli_mapping.py
@@ -45,7 +45,7 @@ def _settings() -> SimpleNamespace:
 def _stub_map_set(*args, **kwargs):
     """Return deterministic mappings for test features."""
 
-    session, set_name, _, features = args[:4]
+    session, set_name, _, features, *rest = args
     mapped = []
     for feat in features:
         mappings = dict(feat.mappings)

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -9,7 +9,7 @@ from pydantic_core import from_json
 
 from core import mapping
 from core.conversation import ConversationSession
-from core.mapping import MappingError, cache_write_json_atomic, map_set
+from core.mapping import MappingError, MapSetParams, cache_write_json_atomic, map_set
 from models import (
     Contribution,
     FeatureMappingRef,
@@ -41,6 +41,17 @@ def _init_runtime_env() -> Iterator[None]:
     )
     RuntimeEnv.initialize(settings)
     yield
+
+
+def _params(**kwargs: Any) -> MapSetParams:
+    """Return mapping parameters with sensible defaults for tests."""
+
+    return MapSetParams(
+        service_name="svc",
+        service_description="desc",
+        plateau=1,
+        **kwargs,
+    )
     RuntimeEnv.reset()
 
 
@@ -121,10 +132,7 @@ async def test_map_set_successful_mapping(monkeypatch) -> None:
         "applications",
         [_item()],
         [_feature()],
-        service_name="svc",
-        service_description="desc",
-        plateau=1,
-        service="svc",
+        _params(service="svc"),
     )
     assert session.prompts == ["PROMPT"]
     assert mapped[0].mappings["applications"][0].item == "a"
@@ -161,10 +169,7 @@ async def test_map_set_quarantines_unknown_ids(monkeypatch, tmp_path) -> None:
         "applications",
         [_item()],
         [_feature()],
-        service_name="svc",
-        service_description="desc",
-        plateau=1,
-        service="svc",
+        _params(service="svc"),
     )
     assert [c.item for c in mapped[0].mappings["applications"]] == ["a"]
     qdir = tmp_path / "quarantine" / "svc" / "applications"
@@ -195,20 +200,14 @@ async def test_quarantine_separates_unknown_ids_by_service(
         "applications",
         [_item()],
         [_feature()],
-        service_name="svc1",
-        service_description="desc",
-        plateau=1,
-        service="svc1",
+        _params(service_name="svc1", service="svc1"),
     )
     await map_set(
         cast(ConversationSession, session),
         "applications",
         [_item()],
         [_feature()],
-        service_name="svc2",
-        service_description="desc",
-        plateau=1,
-        service="svc2",
+        _params(service_name="svc2", service="svc2"),
     )
     qfile1 = tmp_path / "quarantine" / "svc1" / "applications" / "unknown_ids_1.json"
     qfile2 = tmp_path / "quarantine" / "svc2" / "applications" / "unknown_ids_1.json"
@@ -231,11 +230,7 @@ async def test_map_set_strict_raises(monkeypatch, tmp_path) -> None:
             "applications",
             [_item()],
             [_feature()],
-            service_name="svc",
-            service_description="desc",
-            plateau=1,
-            service="svc",
-            strict=True,
+            _params(service="svc", strict=True),
         )
     # Only a single attempt is made when validation fails.
     assert session.prompts == ["PROMPT"]
@@ -264,11 +259,7 @@ async def test_map_set_strict_unknown_ids(monkeypatch, tmp_path) -> None:
             "applications",
             [_item()],
             [_feature()],
-            service_name="svc",
-            service_description="desc",
-            plateau=1,
-            service="svc",
-            strict=True,
+            _params(service="svc", strict=True),
         )
     qfile = tmp_path / "quarantine" / "svc" / "applications" / "unknown_ids_1.json"
     assert from_json(qfile.read_text()) == ["x"]
@@ -356,10 +347,7 @@ async def test_map_set_diagnostics_includes_rationale(monkeypatch) -> None:
         "applications",
         [_item()],
         [_feature()],
-        service_name="svc",
-        service_description="desc",
-        plateau=1,
-        diagnostics=True,
+        _params(diagnostics=True),
     )
     assert mapped[0].mappings["applications"][0].item == "a"
 
@@ -380,11 +368,7 @@ async def test_map_set_writes_cache(monkeypatch, tmp_path) -> None:
         "applications",
         [_item()],
         [_feature()],
-        service_name="svc",
-        service_description="desc",
-        plateau=1,
-        service="svc",
-        cache_mode="read",
+        _params(service="svc", cache_mode="read"),
     )
     cache_file = (
         Path(".cache")
@@ -424,11 +408,7 @@ async def test_map_set_reads_cache(monkeypatch, tmp_path) -> None:
         "applications",
         [_item()],
         [_feature()],
-        service_name="svc",
-        service_description="desc",
-        plateau=1,
-        service="svc",
-        cache_mode="read",
+        _params(service="svc", cache_mode="read"),
     )
     canonical = (
         Path(".cache")
@@ -466,11 +446,7 @@ async def test_map_set_invalid_cache_halts(monkeypatch, tmp_path) -> None:
             "applications",
             [_item()],
             [_feature()],
-            service_name="svc",
-            service_description="desc",
-            plateau=1,
-            service="svc",
-            cache_mode="read",
+            _params(service="svc", cache_mode="read"),
         )
     assert bad_file.exists()
     assert session.prompts == []
@@ -509,22 +485,14 @@ async def test_map_set_cache_invalidation(monkeypatch, tmp_path, change) -> None
         "applications",
         [_item()],
         features1,
-        service_name="svc",
-        service_description="desc",
-        plateau=1,
-        cache_mode="read",
-        catalogue_hash=cat_hash1,
+        _params(cache_mode="read", catalogue_hash=cat_hash1),
     )
     await map_set(
         cast(ConversationSession, session),
         "applications",
         [_item()],
         features2,
-        service_name="svc",
-        service_description="desc",
-        plateau=1,
-        cache_mode="read",
-        catalogue_hash=cat_hash2,
+        _params(cache_mode="read", catalogue_hash=cat_hash2),
     )
     cache_dir = (
         Path(".cache") / "unknown" / "unknown" / "1" / "mappings" / "applications"
@@ -572,10 +540,7 @@ async def test_map_set_logs_cache_status(
         "applications",
         [_item()],
         [_feature()],
-        service_name="svc",
-        service_description="desc",
-        plateau=1,
-        cache_mode=mode,
+        _params(cache_mode=mode),
     )
     assert logs[0][1]["cache"] == expected
     assert logs[0][1]["cache_key"] == "key"
@@ -633,11 +598,7 @@ async def test_map_set_cache_modes(
         "applications",
         [_item()],
         [_feature()],
-        service_name="svc",
-        service_description="desc",
-        plateau=1,
-        service="svc",
-        cache_mode=mode,
+        _params(service="svc", cache_mode=mode),
     )
     assert len(session.prompts) == expected_prompts
     if expected_content is None:  # off mode does not write cache
@@ -676,9 +637,7 @@ async def test_map_set_prompt_logging_respects_flags(monkeypatch) -> None:
         "applications",
         [_item()],
         [_feature()],
-        service_name="svc",
-        service_description="desc",
-        plateau=1,
+        _params(),
     )
     assert logs
     features_json = logs[0][1]["features"]
@@ -711,9 +670,7 @@ async def test_map_set_prompt_logging_skipped(monkeypatch) -> None:
         "applications",
         [_item()],
         [_feature()],
-        service_name="svc",
-        service_description="desc",
-        plateau=1,
+        _params(),
     )
     assert logs == []
 

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -120,7 +120,7 @@ async def test_map_features_maps_all_sets_with_full_list(monkeypatch) -> None:
     called: list[str] = []
     received: list[list[str]] = []
 
-    async def fake_map_set(session, name, items, feats, **kwargs):
+    async def fake_map_set(session, name, items, feats, params, **kwargs):
         called.append(name)
         received.append([f.feature_id for f in feats])
         return list(feats)

--- a/tests/test_plateau_runtime_helpers.py
+++ b/tests/test_plateau_runtime_helpers.py
@@ -190,7 +190,9 @@ async def test_run_mapping_set_invokes_map_and_groups(monkeypatch) -> None:
     groups = [MappingFeatureGroup(id="x", name="X", mappings=[])]
     called: dict[str, object] = {}
 
-    async def fake_map_set(session, name, items_list, feats, **kwargs):  # noqa: ANN001
+    async def fake_map_set(
+        session, name, items_list, feats, params, **kwargs
+    ):  # noqa: ANN001
         called["set_name"] = name
         called["stage"] = session.stage
         return list(feats)

--- a/tests/test_small_mapping.py
+++ b/tests/test_small_mapping.py
@@ -2,7 +2,7 @@
 import asyncio
 import json
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from pydantic_core import from_json
@@ -10,6 +10,7 @@ from pydantic_core import from_json
 from core import mapping
 from core.canonical import canonicalise_record
 from core.conversation import ConversationSession
+from core.mapping import MapSetParams
 from io_utils import loader
 from models import MappingResponse, MappingSet, ServiceEvolution
 
@@ -35,6 +36,12 @@ def _load_evolutions() -> list[ServiceEvolution]:
         for line in text.splitlines()
         if line.strip()
     ]
+
+
+def _params(**kwargs: Any) -> MapSetParams:
+    return MapSetParams(
+        service_name="svc", service_description="desc", plateau=1, **kwargs
+    )
 
 
 def test_mapping_run_matches_golden(tmp_path) -> None:
@@ -67,10 +74,7 @@ def test_mapping_run_matches_golden(tmp_path) -> None:
             "applications",
             items["applications"],
             features,
-            service_name="svc",
-            service_description="desc",
-            plateau=1,
-            catalogue_hash=catalogue_hash,
+            _params(catalogue_hash=catalogue_hash),
         )
     )
     session_tech = DummySession(
@@ -91,10 +95,7 @@ def test_mapping_run_matches_golden(tmp_path) -> None:
             "technologies",
             items["technologies"],
             mapped,
-            service_name="svc",
-            service_description="desc",
-            plateau=1,
-            catalogue_hash=catalogue_hash,
+            _params(catalogue_hash=catalogue_hash),
         )
     )
     by_id = {f.feature_id: f for f in mapped}
@@ -152,10 +153,7 @@ def test_default_mode_quarantines_unknown_ids(monkeypatch, tmp_path) -> None:
             "applications",
             items["applications"],
             features,
-            service_name="svc",
-            service_description="desc",
-            plateau=1,
-            catalogue_hash=catalogue_hash,
+            _params(catalogue_hash=catalogue_hash),
         )
     )
     assert mapped[0].mappings["applications"][0].item == "app1"
@@ -196,11 +194,7 @@ def test_strict_mapping_raises_on_unknown_ids(monkeypatch, tmp_path) -> None:
                 "applications",
                 items["applications"],
                 features,
-                service_name="svc",
-                service_description="desc",
-                plateau=1,
-                strict=True,
-                catalogue_hash=catalogue_hash,
+                _params(strict=True, catalogue_hash=catalogue_hash),
             )
         )
     qfile = Path("quarantine/unknown/applications/unknown_ids_1.json")


### PR DESCRIPTION
## Summary
- extract MapSetParams and helper dataclasses to simplify mapping workflow
- break ConversationSession._ask_common into cache-aware helpers
- update callers and tests to use parameter objects

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit`
- `poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=term-missing --cov-fail-under=85` *(fails: ModuleNotFoundError: No module named 'pydantic_ai.models.openai')*

------
https://chatgpt.com/codex/tasks/task_e_68b7fcf4ce74832bb865a76f560ddfb6