### PR TITLE
docs: replace placeholders with concrete examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,27 @@ spawns `PlateauRuntime` instances for every plateau.  A thread‑safe
 caches.  See [runtime-architecture](docs/runtime-architecture.md) for a
 detailed walkthrough.
 
+### File layout
+
+```
+.
+├── docs/                # Documentation
+├── prompts/             # Prompt templates
+├── src/                 # Application sources
+│   ├── cli/             # CLI entry points
+│   ├── core/            # Core models and helpers
+│   ├── engine/          # Processing engines
+│   ├── generation/      # Plateau and feature generation
+│   ├── io_utils/        # Input/output helpers
+│   ├── models/          # Data models
+│   ├── observability/   # Logging and metrics
+│   └── runtime/         # Environment and settings
+└── tests/               # Test suite
+```
+
+See [runtime-architecture](docs/runtime-architecture.md) for component-level
+details.
+
 ## Configuration
 
 Copy the sample configuration and customise it for your environment:
@@ -53,6 +74,14 @@ Set `use_local_cache: false` or `cache_mode: "off"` to bypass the cache, or use
 The chat model can be set with the `--model` flag or the `MODEL` environment
 variable. Model identifiers must include a provider prefix, in the form
 `<provider>:<model>`. The default is `openai:gpt-5` with medium reasoning effort.
+
+Example:
+
+```bash
+MODEL=openai:o4-mini poetry run service-ambitions run \
+  --input-file sample-services.jsonl \
+  --output-file evolution.jsonl
+```
 
 Stage-specific model overrides live under the `models` block in
 `config/app.yaml`. Defaults are:
@@ -146,6 +175,20 @@ Alternatively, use the provided shell script which forwards all arguments to the
 ./run.sh reverse --input-file evolutions.jsonl --output-file features.jsonl
 ```
 
+### Docker
+
+Build the image and execute the CLI in an isolated container:
+
+```bash
+docker build -t service-ambitions .
+docker run --rm \
+  -e OPENAI_API_KEY=$OPENAI_API_KEY \
+  -v "$(pwd)/sample-services.jsonl:/data/input.jsonl" \
+  service-ambitions run \
+  --input-file /data/input.jsonl \
+  --output-file /data/evolutions.jsonl
+```
+
 ## Usage
 
 `sample-services.jsonl` contains example services in
@@ -193,7 +236,7 @@ context. The seed includes the service ID and jobs to be done:
 Service ID: S01
 Service name: Learning & Teaching
 Customer type: retail
-Description: Delivers a holistic educational framework ...
+Description: Delivers a holistic educational framework that not only designs modern curricula and dynamic teaching methods but also supports learners’ entire journey. This service enables students to progress confidently from admission through to career readiness, while ensuring quality through defined performance standards and continuous stakeholder reviews.
 Jobs to be done: Access an engaging curriculum, Continually update skills
 ```
 

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -48,13 +48,15 @@ This project follows the principles outlined in *Clean Code: A Handbook of Agile
 
 **Good**
 ```python
-def resize(image: Image, *, max_width: int, max_height: int) -> Image: ...
-````
+def resize(image: Image, *, max_width: int, max_height: int) -> Image:
+    return image.resize((max_width, max_height))
+```
 
 **Refactor from this**
 
 ```python
-def process(a, b, c, d): ...
+def process(a, b, c, d):
+    return (a + b) * (c + d)
 ```
 
 ---
@@ -279,7 +281,8 @@ class Order:
 
 def add_tag(tags: list[str] | None = None) -> list[str]:
     tags = tags or []  # ✅
-    ...
+    tags.append("new")
+    return tags
 ```
 
 **Dependency injection over globals**
@@ -293,14 +296,17 @@ class EmailSender:
         self._client.send(to=user.email, subject="Welcome", body="Hi!")
 
 # In composition root:
-sender = EmailSender(client=SES(...))
+sender = EmailSender(client=SES(region="us-east-1"))
 ```
 
 **Async I/O separation**
 
 ```python
-async def fetch_user(session: ClientSession, user_id: str) -> User: ...
-def compute_score(user: User) -> int: ...
+async def fetch_user(session: ClientSession, user_id: str) -> User:
+    return await session.get_user(user_id)
+
+def compute_score(user: User) -> int:
+    return user.score
 ```
 
 ---

--- a/docs/sd01-flow-of-evolution-prompts.md
+++ b/docs/sd01-flow-of-evolution-prompts.md
@@ -34,7 +34,7 @@
 
 I will give you set of defined services, including description, example service features, a set of example jobs to be done with customer roles. Your actions are:
 
-1. For each services that are supplied ...
+1. For each service supplied, summarise its purpose, key features and jobs to be done.
 2. For each role for the service defined, establish what the service is doing to meet the needs of the defined jobs to be done, and any other appropriate jobs that you might consider.
 3. Iterate through the plateaus,
    1. Consider the style of the service that would exist at that plateau.

--- a/prompts/task_definition.md
+++ b/prompts/task_definition.md
@@ -3,7 +3,7 @@
 I will give you set of defined services, including description, example service features, a set of example jobs to be
 done with customer roles. Your actions are:
 
-1. For each services that are supplied ...
+1. For each service supplied, summarise its purpose, key features and jobs to be done.
 2. For each role for the service defined, establish what the service is doing to meet the needs of the defined jobs to
    be done, and any other appropriate jobs that you might consider.
 3. Iterate through the plateaus,


### PR DESCRIPTION
## Summary
- document file layout and link to runtime architecture
- add explicit MODEL and docker run examples
- flesh out task definitions and coding standards to remove ellipses

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLError: CERTIFICATE_VERIFY_FAILED)*
- `poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=term-missing --cov-fail-under=85` *(fails: ModuleNotFoundError: No module named 'pydantic_ai.models.openai')*

------
https://chatgpt.com/codex/tasks/task_e_68b8ca0fe310832bafd2c956b1d9833d