### PR TITLE
feat: add dataset validation CLI

### DIFF
--- a/src/cli/data_validation.py
+++ b/src/cli/data_validation.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: MIT
+"""Utilities for validating dataset inputs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from io_utils import validate_jsonl
+from models import MappingItem, ServiceInput
+
+
+def validate_data_dir(data_dir: Path) -> None:
+    """Validate JSON inputs within ``data_dir``.
+
+    Parameters
+    ----------
+    data_dir:
+        Directory containing ``services.jsonl`` and an optional ``catalogue``
+        subdirectory with JSON files.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``services.jsonl`` is missing.
+    ValueError
+        If any record fails validation.
+    """
+
+    services_file = data_dir / "services.jsonl"
+    if not services_file.is_file():
+        raise FileNotFoundError(services_file)
+
+    count = validate_jsonl(services_file, ServiceInput)
+    print(f"{services_file}: {count} valid records")
+
+    catalogue_dir = data_dir / "catalogue"
+    if not catalogue_dir.is_dir():
+        return
+
+    for path in sorted(catalogue_dir.glob("*.json")):
+        text = path.read_text(encoding="utf-8")
+        try:
+            items = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
+        if not isinstance(items, list):
+            raise ValueError(f"{path} does not contain a list of items")
+        for idx, item in enumerate(items, start=1):
+            try:
+                MappingItem.model_validate(item)
+            except Exception as exc:  # pragma: no cover - unexpected errors
+                raise ValueError(f"{path} item {idx} invalid: {exc}") from exc
+        print(f"{path}: {len(items)} valid items")

--- a/tests/test_cli_data_validation.py
+++ b/tests/test_cli_data_validation.py
@@ -1,0 +1,35 @@
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+import cli.main as cli
+
+
+def _prepare_dataset(tmp_path: Path, valid: bool) -> Path:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    src = Path(
+        "tests/fixtures/services-valid.jsonl"
+        if valid
+        else "tests/fixtures/services-invalid.jsonl"
+    )
+    (data_dir / "services.jsonl").write_text(
+        src.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    shutil.copytree("tests/fixtures/catalogue", data_dir / "catalogue")
+    return data_dir
+
+
+def test_validate_data_dir_passes(monkeypatch, tmp_path: Path) -> None:
+    data_dir = _prepare_dataset(tmp_path, True)
+    monkeypatch.setattr(sys, "argv", ["main", "validate", "--data", str(data_dir)])
+    cli.main()
+
+
+def test_validate_data_dir_fails(monkeypatch, tmp_path: Path) -> None:
+    data_dir = _prepare_dataset(tmp_path, False)
+    monkeypatch.setattr(sys, "argv", ["main", "validate", "--data", str(data_dir)])
+    with pytest.raises(ValueError, match="Line 2 invalid"):
+        cli.main()


### PR DESCRIPTION
## Summary
- add `validate --data` CLI for fast JSONL and catalogue checks
- cover data validation CLI with tests

## Testing
- `python -m black --preview --enable-unstable-feature string_processing .`
- `python -m ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSLCertVerificationError)*
- `poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=term-missing --cov-fail-under=85` *(fails: ModuleNotFoundError: No module named 'pydantic_ai.models.openai')*

------
https://chatgpt.com/codex/tasks/task_e_68b8c9baa088832b9c41955e358593fe