### PR TITLE
Protect RuntimeEnv state with locks and add concurrency test

### DIFF
--- a/tests/test_runtime_environment.py
+++ b/tests/test_runtime_environment.py
@@ -1,4 +1,7 @@
+import asyncio
 from types import SimpleNamespace
+
+import pytest
 
 from runtime.environment import RuntimeEnv
 from utils import MappingLoader, PromptLoader
@@ -30,9 +33,11 @@ class DummyMappingLoader(MappingLoader):
         self.cleared = True
 
 
-def test_reset_clears_run_meta_and_caches():
+def test_reset_clears_run_meta_and_caches(tmp_path):
     RuntimeEnv.reset()
-    RuntimeEnv.initialize(SimpleNamespace())
+    RuntimeEnv.initialize(
+        SimpleNamespace(prompt_dir=tmp_path, mapping_data_dir=tmp_path)
+    )
     env = RuntimeEnv.instance()
     prompt = DummyPromptLoader()
     mapping = DummyMappingLoader()
@@ -43,4 +48,27 @@ def test_reset_clears_run_meta_and_caches():
     assert prompt.cleared
     assert mapping.cleared
     assert env.run_meta is None
-    assert env.state == {}
+
+
+@pytest.mark.asyncio()
+async def test_loader_concurrency(tmp_path):
+    RuntimeEnv.reset()
+    RuntimeEnv.initialize(
+        SimpleNamespace(prompt_dir=tmp_path, mapping_data_dir=tmp_path)
+    )
+    env = RuntimeEnv.instance()
+    prompt = env.prompt_loader
+    mapping = env.mapping_loader
+
+    async def hit_prompt() -> None:
+        await asyncio.sleep(0)
+        assert env.prompt_loader is prompt
+
+    async def hit_mapping() -> None:
+        await asyncio.sleep(0)
+        assert env.mapping_loader is mapping
+
+    async with asyncio.TaskGroup() as tg:
+        for _ in range(50):
+            tg.create_task(hit_prompt())
+            tg.create_task(hit_mapping())


### PR DESCRIPTION
## Summary
- guard RuntimeEnv state with a lock and precompute loaders at init
- simplify reset to clear caches via stored loaders
- test concurrent access to RuntimeEnv loaders

## Testing
- `poetry run ruff check .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL: CERTIFICATE_VERIFY_FAILED)*
- `poetry run pytest tests/test_runtime_environment.py -q`
- `poetry run pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: pydantic_ai.models.openai)*


------
https://chatgpt.com/codex/tasks/task_e_68b8c9914038832b8463003cd60110ed