### PR TITLE
Include default config in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,5 @@ FROM gcr.io/distroless/python3-debian12:nonroot
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 WORKDIR /app
+COPY config /app/config
 ENTRYPOINT ["service-ambitions"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ cp config/app.example.yaml config/app.yaml
 
 Then edit `config/app.yaml` to set models, reasoning presets and other options.
 
+The Docker image includes these defaults at `/app/config`. Override any value via
+environment variables or by mounting a replacement configuration directory.
+
 The CLI requires an OpenAI API key available in the `OPENAI_API_KEY` environment
 variable. Settings are loaded via Pydantic, which reads from a `.env` file if
 present. The application will exit if the key is missing. LLM interactions are


### PR DESCRIPTION
## Summary
- copy `config` directory into final container image
- document baked-in defaults and override options

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443) SSLCertVerificationError)*
- `poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=term-missing --cov-fail-under=85` *(fails: ModuleNotFoundError: No module named 'pydantic_ai.models.openai')*


------
https://chatgpt.com/codex/tasks/task_e_68b8c941bf24832baf3241c9bd058bb5