### PR TITLE
feat: document SA_ env vars and mask tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,25 @@ cp config/app.example.yaml config/app.yaml
 
 Then edit `config/app.yaml` to set models, reasoning presets and other options.
 
-The CLI requires an OpenAI API key available in the `OPENAI_API_KEY` environment
-variable. Settings are loaded via Pydantic, which reads from a `.env` file if
-present. The application will exit if the key is missing. LLM interactions are
-handled via [Pydantic AI](https://pydantic.dev/pydantic-ai/).
+All environment variables controlling the application use the `SA_` prefix. The
+CLI requires an OpenAI API key available in the `SA_OPENAI_API_KEY`
+environment variable. Settings are loaded via Pydantic, which reads from a
+`.env` file if present. The application will exit if the key is missing. LLM
+interactions are handled via
+[Pydantic AI](https://pydantic.dev/pydantic-ai/).
 
-Create a `.env` file in the project root with:
+Create a `.env` file in the project root with all variables prefixed by
+`SA_`:
 
 ```
 # Required for API access
-OPENAI_API_KEY=your_api_key_here
+SA_OPENAI_API_KEY=your_api_key_here
 # Optional: provide to publish telemetry to Logfire
-# LOGFIRE_TOKEN=your_logfire_token
+# SA_LOGFIRE_TOKEN=your_logfire_token
+# SA_MODEL=openai:gpt-5
+# SA_LOG_LEVEL=INFO
+# SA_REQUEST_TIMEOUT=60
+# SA_CACHE_MODE=read
 ```
 
 For production deployments, inject the variable using your platform's secret
@@ -39,7 +46,7 @@ manager instead of committing keys to source control.
 
 Caching of mapping responses is enabled by default to speed up repeated runs.
 Disable or change cache behaviour in `config/app.yaml` or via environment
-variables:
+variables using the `SA_` prefix:
 
 ```yaml
 use_local_cache: true # Enable reading/writing the cache directory.
@@ -50,7 +57,7 @@ cache_dir: .cache # Directory to store cache files.
 Set `use_local_cache: false` or `cache_mode: "off"` to bypass the cache, or use
 `write` to record new entries and `refresh` to rewrite existing ones.
 
-The chat model can be set with the `--model` flag or the `MODEL` environment
+The chat model can be set with the `--model` flag or the `SA_MODEL` environment
 variable. Model identifiers must include a provider prefix, in the form
 `<provider>:<model>`. The default is `openai:gpt-5` with medium reasoning effort.
 
@@ -104,7 +111,7 @@ directory, `--context-id` to select a situational context, and
 supports swapping sections to suit different industries.
 
 This project depends on the [Pydantic Logfire](https://logfire.pydantic.dev/)
-libraries for telemetry. The `LOGFIRE_TOKEN` environment variable is optional:
+libraries for telemetry. The `SA_LOGFIRE_TOKEN` environment variable is optional:
 without it, Logfire still records logs and metrics locally but nothing is sent
 to the cloud. Provide a token to stream traces to Logfire. The CLI instruments
 Pydantic, Pydantic AI, OpenAI and system metrics by default. Prompts are

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -34,9 +34,9 @@ Telemetry via Logfire is always enabled. Prompt text is hidden from logs unless
 `--allow-prompt-logging` is passed.
 Use `--roles-file` to supply an alternative roles definition file when needed.
 
-Logfire is required by the CLI but the `LOGFIRE_TOKEN` environment variable is
-optional for local runs. Set the token to stream traces to Logfire; without it,
-telemetry remains local.
+Logfire is required by the CLI but the `SA_LOGFIRE_TOKEN` environment variable
+is optional for local runs. Set the token to stream traces to Logfire; without
+it, telemetry remains local.
 
 Pass `--strict` to abort if any role lacks features or if generated features
 contain empty mapping lists. This turns on a fail-fast mode instead of the

--- a/docs/generate-mapping.md
+++ b/docs/generate-mapping.md
@@ -28,9 +28,10 @@ Telemetry via Logfire is always enabled. Prompt text is omitted unless
 
 `--use-local-cache` reads mapping responses under `.cache/<service>/mappings` and
 optionally writes new entries to avoid repeated network requests during
-development. `--cache-mode` controls
-how the cache is used (`off`, `read`, `refresh`, `write`) with `read` as the
-default, and `--cache-dir` sets the cache storage location.
+development. `--cache-mode` controls how the cache is used (`off`, `read`,
+`refresh`, `write`) with `read` as the default, and `--cache-dir` sets the cache
+storage location. Equivalent environment variables prefixed with `SA_` can
+override these settings.
 
 Mapping runs once per configured set. Each prompt receives the relevant
 reference list—`applications`, `technologies` and `information` by default—and
@@ -59,7 +60,7 @@ simply omitted.
 
 ## Troubleshooting
 
-- Ensure `OPENAI_API_KEY` is set and valid.
+- Ensure `SA_OPENAI_API_KEY` is set and valid.
 - Use `--dry-run` to validate input files without making API calls.
 - Check network access and API quotas if mapping requests fail repeatedly.
 

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Launch the Service Ambitions CLI.
-# Requires OPENAI_API_KEY to be set in the environment.
+# Requires SA_OPENAI_API_KEY to be set in the environment.
 
 set -euo pipefail
 

--- a/src/generation/generator.py
+++ b/src/generation/generator.py
@@ -482,13 +482,13 @@ def build_model(
         A ready-to-use ``Model`` instance.
 
     Side Effects:
-        Sets ``OPENAI_API_KEY`` in the environment if ``api_key`` is provided.
+        Sets ``SA_OPENAI_API_KEY`` in the environment if ``api_key`` is provided.
     """
 
     if api_key:
         # Expose the key via environment variables for model libraries that
         # expect it there rather than accepting it directly.
-        os.environ.setdefault("OPENAI_API_KEY", api_key)
+        os.environ.setdefault("SA_OPENAI_API_KEY", api_key)
     # Allow callers to pass provider-prefixed names such as ``openai:gpt-4``.
     model_name = model_name.split(":", 1)[-1]
     settings: OpenAIResponsesModelSettings = {

--- a/src/observability/monitoring.py
+++ b/src/observability/monitoring.py
@@ -9,6 +9,14 @@ from typing import Literal
 import logfire
 
 
+def _mask_token(value: str | None) -> str | None:
+    """Return a masked representation of ``value`` for safe logging."""
+
+    if not value:
+        return None
+    return f"{value[:4]}..."
+
+
 def init_logfire(
     token: str | None = None,
     min_log_level: Literal[
@@ -18,12 +26,16 @@ def init_logfire(
     """Configure Logfire and enable instrumentation.
 
     Args:
-        token: Optional Logfire API token. If omitted, ``LOGFIRE_TOKEN`` from the
+        token: Optional Logfire API token. If omitted, ``SA_LOGFIRE_TOKEN`` from the
             environment is used. Missing tokens keep telemetry local.
         min_log_level: Minimum level for console and telemetry output.
     """
 
-    key = token or os.getenv("LOGFIRE_TOKEN")
+    key = token or os.getenv("SA_LOGFIRE_TOKEN")
+    masked = _mask_token(key)
+    if key and hasattr(logfire, "add_masking_rule"):
+        logfire.add_masking_rule(key)
+    logfire.debug("Configuring logfire", token=masked)
     logfire.configure(
         token=key,
         service_name="service-ambition-generator",

--- a/src/runtime/environment.py
+++ b/src/runtime/environment.py
@@ -31,8 +31,11 @@ class RuntimeEnv:
 
         self.settings = settings
         self.state: dict[str, Any] = {}
-        # Debug logging helps diagnose configuration loading problems.
-        logfire.debug("RuntimeEnv created", settings=str(settings))
+        mask_fields = settings.model_dump()
+        mask_fields["openai_api_key"] = "***"
+        if mask_fields.get("logfire_token"):
+            mask_fields["logfire_token"] = "***"
+        logfire.debug("RuntimeEnv created", settings=str(mask_fields))
 
     @property
     def run_meta(self) -> "ServiceMeta | None":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ import pytest
 def _mock_openai(monkeypatch):
     """Provide dummy credentials and block outbound OpenAI requests."""
 
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("SA_OPENAI_API_KEY", "test-key")
     try:
         import openai
 

--- a/tests/test_cli_apply_args_to_settings.py
+++ b/tests/test_cli_apply_args_to_settings.py
@@ -11,7 +11,7 @@ import pytest
 
 import cli.main as cli
 
-os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("SA_OPENAI_API_KEY", "test-key")
 
 
 def _prepare_settings():

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -6,6 +6,7 @@ from observability import monitoring
 def test_init_logfire_configures_and_instruments(monkeypatch):
     called: dict[str, object] = {}
     instruments: list[str] = []
+    logs: list[tuple[str, dict[str, object]]] = []
 
     class ConsoleOptions:
         def __init__(self, **kwargs):
@@ -18,20 +19,25 @@ def test_init_logfire_configures_and_instruments(monkeypatch):
         instrument_pydantic_ai=lambda: instruments.append("ai"),
         instrument_pydantic=lambda: instruments.append("pydantic"),
         instrument_openai=lambda: instruments.append("openai"),
+        debug=lambda msg, **kw: logs.append((msg, kw)),
+        add_masking_rule=lambda value: called.setdefault("mask", value),
     )
     monkeypatch.setattr(monitoring, "logfire", dummy_module)
 
     monitoring.init_logfire("token", "info")
 
     assert called["token"] == "token"
+    assert called["mask"] == "token"
     assert called["service_name"] == "service-ambition-generator"
     assert called["console"].min_log_level == "info"
     assert called["metrics"] == {"base": "full"}
     assert instruments == ["ai", "pydantic", "openai"]
+    assert logs[0][1]["token"] == "toke..."
 
 
 def test_init_logfire_without_token(monkeypatch):
     called: dict[str, object] = {}
+    logs: list[tuple[str, dict[str, object]]] = []
 
     class ConsoleOptions:
         def __init__(self, **kwargs):
@@ -44,10 +50,39 @@ def test_init_logfire_without_token(monkeypatch):
         instrument_pydantic_ai=lambda: None,
         instrument_pydantic=lambda: None,
         instrument_openai=lambda: None,
+        debug=lambda msg, **kw: logs.append((msg, kw)),
+        add_masking_rule=lambda value: None,
     )
     monkeypatch.setattr(monitoring, "logfire", dummy_module)
-    monkeypatch.delenv("LOGFIRE_TOKEN", raising=False)
+    monkeypatch.delenv("SA_LOGFIRE_TOKEN", raising=False)
 
     monitoring.init_logfire()
 
     assert "token" in called and called["token"] is None
+    assert logs[0][1]["token"] is None
+
+
+def test_init_logfire_masks_token(monkeypatch):
+    logs: list[tuple[str, dict[str, object]]] = []
+
+    class ConsoleOptions:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    dummy_module = SimpleNamespace(
+        ConsoleOptions=ConsoleOptions,
+        configure=lambda **kwargs: None,
+        instrument_system_metrics=lambda **kw: None,
+        instrument_pydantic_ai=lambda: None,
+        instrument_pydantic=lambda: None,
+        instrument_openai=lambda: None,
+        debug=lambda msg, **kw: logs.append((msg, kw)),
+        add_masking_rule=lambda value: None,
+    )
+    monkeypatch.setattr(monitoring, "logfire", dummy_module)
+
+    monitoring.init_logfire("secret-token", "info")
+
+    assert logs
+    assert logs[0][1]["token"] == "secr..."
+    assert "secret-token" not in logs[0][1]["token"]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -14,10 +14,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 def test_load_settings_reads_env(monkeypatch) -> None:
     """Environment variables should populate the settings model."""
 
-    monkeypatch.setenv("OPENAI_API_KEY", "token")
-    monkeypatch.setenv("USE_LOCAL_CACHE", "1")
-    monkeypatch.setenv("CACHE_MODE", "write")
-    monkeypatch.setenv("CACHE_DIR", "/tmp/cache")
+    monkeypatch.setenv("SA_OPENAI_API_KEY", "token")
+    monkeypatch.setenv("SA_USE_LOCAL_CACHE", "1")
+    monkeypatch.setenv("SA_CACHE_MODE", "write")
+    monkeypatch.setenv("SA_CACHE_DIR", "/tmp/cache")
     settings = load_settings()
     assert settings.openai_api_key == "token"
     assert settings.model == "openai:gpt-5-mini"
@@ -42,9 +42,9 @@ def test_load_settings_reads_env(monkeypatch) -> None:
 def test_load_settings_requires_key(monkeypatch) -> None:
     """Missing API key should raise ``RuntimeError``."""
 
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("USE_LOCAL_CACHE", raising=False)
-    monkeypatch.delenv("CACHE_MODE", raising=False)
-    monkeypatch.delenv("CACHE_DIR", raising=False)
+    monkeypatch.delenv("SA_OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("SA_USE_LOCAL_CACHE", raising=False)
+    monkeypatch.delenv("SA_CACHE_MODE", raising=False)
+    monkeypatch.delenv("SA_CACHE_DIR", raising=False)
     with pytest.raises(RuntimeError):
         load_settings()


### PR DESCRIPTION
## Summary
- document SA_ prefixed environment variables and provide .env example
- mask OpenAI and Logfire tokens in logs and add masking test
- load settings with SA_ env overrides and handle secrets securely

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: SSL: CERTIFICATE_VERIFY_FAILED)*
- `poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=term-missing --cov-fail-under=85` *(fails: unrecognized arguments: --cov=src --cov-report=term-missing --cov-fail-under=85)*
- `poetry run pytest -q` *(fails: ImportError: cannot import name 'AmbitionModel' from '<unknown module name>')*

------
https://chatgpt.com/codex/tasks/task_e_68b8c9260ce4832b9a3744dddefbfdaf