### PR TITLE
Avoid hard-coded tmp cache directory

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import os
+import tempfile
 from pathlib import Path
 
 DEFAULT_CACHE_DIR = (
-    Path(os.path.expandvars(os.environ.get("XDG_CACHE_HOME", "/tmp")))
+    Path(os.path.expandvars(os.environ.get("XDG_CACHE_HOME", tempfile.gettempdir())))
     / "service-ambitions"
 )
 


### PR DESCRIPTION
## Summary
- Use `tempfile.gettempdir()` for default cache path

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(failed: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/ag-ui-protocol/0.1.8/json (Caused by SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)')))*
- `poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=term-missing --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_68b9325afe80832ba5a7d41b1369612d