### PR TITLE
feat: allow custom roles file via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,9 +375,10 @@ stored in `config/app.yaml`; the chat model and any reasoning parameters live
 at the top level, while mapping types and their associated datasets live under
 the `mapping_types` section, allowing new categories to be added without code
 changes. Plateau definitions and their level mappings come from
-`data/service_feature_plateaus.json`. Roles are defined in `data/roles.json`,
-and the required number of features per role is controlled by
-`features_per_role` in `config/app.yaml`.
+`data/service_feature_plateaus.json`. Roles are defined in `data/roles.json`
+by default and can be overridden with the ``--roles-file`` CLI flag. The
+required number of features per role is controlled by `features_per_role` in
+`config/app.yaml`.
 
 ## Prompt examples
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -605,6 +605,7 @@ def _apply_args_to_settings(args: argparse.Namespace, settings) -> None:
         "concurrency": ("concurrency", None),
         "strict_mapping": ("strict_mapping", None),
         "mapping_data_dir": ("mapping_data_dir", Path),
+        "roles_file": ("roles_file", Path),
         "web_search": ("web_search", None),
         "use_local_cache": ("use_local_cache", None),
         "cache_mode": ("cache_mode", None),

--- a/src/engine/processing_engine.py
+++ b/src/engine/processing_engine.py
@@ -177,7 +177,7 @@ class ProcessingEngine:
         configure_prompt_dir(settings.prompt_dir)
         configure_mapping_data_dir(settings.mapping_data_dir)
         system_prompt = load_evolution_prompt(settings.context_id, settings.inspiration)
-        role_ids = load_role_ids(Path(self.args.roles_file))
+        role_ids = load_role_ids(self.settings.roles_file)
         services = _load_services_list(
             self.args.input_file, self.args.max_services, self.processed_ids
         )

--- a/src/generation/plateau_generator.py
+++ b/src/generation/plateau_generator.py
@@ -75,7 +75,7 @@ def default_role_ids() -> list[str]:
     """Return core role identifiers."""
 
     settings = RuntimeEnv.instance().settings
-    return load_role_ids(settings.mapping_data_dir)
+    return load_role_ids(settings.roles_file)
 
 
 def _feature_cache_path(service: str, plateau: int) -> Path:

--- a/src/runtime/settings.py
+++ b/src/runtime/settings.py
@@ -66,6 +66,10 @@ class Settings(BaseSettings):
     mapping_data_dir: Path = Field(
         Path("data"), description="Directory containing mapping reference data."
     )
+    roles_file: Path = Field(
+        Path("data/roles.json"),
+        description="Path to JSON file containing role identifiers.",
+    )
     mapping_sets: list[MappingSet] = Field(
         default_factory=list,
         description="Mapping dataset configurations.",
@@ -154,6 +158,11 @@ def load_settings(config_path: Path | str | None = None) -> Settings:
             cache_dir=cache_dir,
             web_search=config.web_search,
             mapping_data_dir=getattr(config, "mapping_data_dir", Path("data")),
+            roles_file=getattr(
+                config,
+                "roles_file",
+                Path("data/roles.json"),
+            ),
             mapping_sets=getattr(config, "mapping_sets", []),
             diagnostics=getattr(config, "diagnostics", False),
             strict=getattr(config, "strict", False),

--- a/tests/test_cli_apply_args_to_settings.py
+++ b/tests/test_cli_apply_args_to_settings.py
@@ -30,6 +30,7 @@ def _prepare_settings():
         use_local_cache=True,
         cache_mode="read",
         cache_dir=cache_dir,
+        roles_file=Path("data/roles.json"),
     )
 
 
@@ -45,6 +46,7 @@ def _build_args(**overrides):
         concurrency=None,
         strict_mapping=None,
         mapping_data_dir=None,
+        roles_file=None,
         web_search=None,
         use_local_cache=None,
         cache_mode=None,
@@ -67,6 +69,7 @@ def _build_args(**overrides):
         ("cache_mode", "cache_mode", "off", "off"),
         ("cache_dir", "cache_dir", "/tmp/cache", Path("/tmp/cache")),
         ("strict", "strict", True, True),
+        ("roles_file", "roles_file", "/tmp/r.json", Path("/tmp/r.json")),
     ],
 )
 def test_apply_args_to_settings_simple(arg_name, attr_name, value, expected):

--- a/tests/test_cli_modes.py
+++ b/tests/test_cli_modes.py
@@ -29,6 +29,7 @@ def _prepare_settings(_config: str | None = None):
         cache_dir=cache_dir,
         prompt_dir=Path("prompts"),
         mapping_data_dir=Path("data"),
+        roles_file=Path("data/roles.json"),
     )
 
 

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -84,7 +84,11 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
     RuntimeEnv.initialize(
         cast(
             Any,
-            SimpleNamespace(mapping_data_dir=Path("data"), prompt_dir=Path("prompts")),
+            SimpleNamespace(
+                mapping_data_dir=Path("data"),
+                prompt_dir=Path("prompts"),
+                roles_file=Path("data/roles.json"),
+            ),
         )
     )
     generator = PlateauGenerator(

--- a/tests/test_plateau_generator.py
+++ b/tests/test_plateau_generator.py
@@ -139,6 +139,7 @@ async def test_map_features_maps_all_sets_with_full_list(monkeypatch) -> None:
                 mapping_sets=mapping_sets,
                 mapping_data_dir=Path("data"),
                 prompt_dir=Path("prompts"),
+                roles_file=Path("data/roles.json"),
             ),
         )
     )
@@ -1190,6 +1191,7 @@ async def test_init_runtimes_generates_defaults(monkeypatch) -> None:
         cache_mode="read",
         mapping_data_dir=Path("data"),
         prompt_dir=Path("prompts"),
+        roles_file=Path("data/roles.json"),
     )
     RuntimeEnv.initialize(cast(Any, settings))
     session = DummySession([])

--- a/tests/test_plateau_metadata_cache.py
+++ b/tests/test_plateau_metadata_cache.py
@@ -11,7 +11,11 @@ def test_plateau_metadata_cached(monkeypatch) -> None:
     RuntimeEnv.initialize(
         cast(
             Any,
-            SimpleNamespace(mapping_data_dir=Path("data"), prompt_dir=Path("prompts")),
+            SimpleNamespace(
+                mapping_data_dir=Path("data"),
+                prompt_dir=Path("prompts"),
+                roles_file=Path("data/roles.json"),
+            ),
         )
     )
 

--- a/tests/test_processing_engine_methods.py
+++ b/tests/test_processing_engine_methods.py
@@ -34,6 +34,7 @@ def _make_settings() -> SimpleNamespace:
         reasoning=None,
         prompt_dir=Path("prompts"),
         mapping_data_dir=Path("mapping"),
+        roles_file=Path("data/roles.json"),
         context_id="ctx",
         inspiration="insp",
         concurrency=2,


### PR DESCRIPTION
## Summary
- allow specifying roles.json path via `--roles-file`
- load roles from settings to enable custom paths
- document roles file override in README and tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /pypi/ag-ui-protocol/0.1.8/json (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1028)')))*
- `poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=term-missing --cov-fail-under=85` *(fails: pytest: error: unrecognized arguments: --cov=src --cov-report=term-missing --cov-fail-under=85)*
- `poetry run pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68b931bb53ac832b967076bb6a2a1cfe