### PR TITLE
refactor: annotate agent types

### DIFF
--- a/src/engine/service_execution.py
+++ b/src/engine/service_execution.py
@@ -105,22 +105,23 @@ class ServiceExecution:
         self.map_name = self.factory.model_name("mapping")
         self.feat_model = feat_model
 
-        desc_agent = Agent(
+        desc_agent: Agent[None, PlateauDescriptionsResponse] = Agent(
             desc_model,
             instructions=self.system_prompt,
             output_type=PlateauDescriptionsResponse,
         )
-        feat_agent = Agent(
+        feat_agent: Agent[None, PlateauFeaturesResponse] = Agent(
             feat_model,
             instructions=self.system_prompt,
             output_type=PlateauFeaturesResponse,
         )
-        map_agent = Agent(
+        map_output = (
+            MappingDiagnosticsResponse if settings.diagnostics else MappingResponse
+        )
+        map_agent: Agent[None, MappingDiagnosticsResponse | MappingResponse] = Agent(
             map_model,
             instructions=self.system_prompt,
-            output_type=(
-                MappingDiagnosticsResponse if settings.diagnostics else MappingResponse
-            ),
+            output_type=map_output,
         )
 
         desc_session = ConversationSession(

--- a/src/generation/generator.py
+++ b/src/generation/generator.py
@@ -26,6 +26,11 @@ from pydantic_ai.models.openai import (
     OpenAIResponsesModel,
     OpenAIResponsesModelSettings,
 )
+
+if TYPE_CHECKING:
+    from pydantic_ai.agent import AgentRunResult as _AgentRunResult
+else:  # pragma: no cover - imported for typing only
+    _AgentRunResult = Any
 from pydantic_core import to_json
 from tqdm import tqdm  # type: ignore[import-untyped]
 
@@ -443,8 +448,11 @@ class ServiceAmbitionGenerator:
         if instructions is None:
             # Without instructions the agent cannot operate.
             raise ValueError("prompt must be provided")
-        agent = Agent(self.model, instructions=instructions, output_type=AmbitionModel)
+        agent: Agent[None, AmbitionModel] = Agent(
+            self.model, instructions=instructions, output_type=AmbitionModel
+        )
         service_details = service.model_dump_json()
+        result: _AgentRunResult[AmbitionModel]
         result, retries = await _with_retry(
             lambda: agent.run(service_details),
             request_timeout=self.request_timeout,


### PR DESCRIPTION
## Summary
- annotate PydanticAI agent variables and results
- prepare type-only import for AgentRunResult to support tests

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy src`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: CERTIFICATE_VERIFY_FAILED)*
- `poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=term-missing --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_68b932f2a6b0832bbfa03a1cca254414