### PR TITLE
Handle cache_dir env fallback without shell syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ variables:
 ```yaml
 use_local_cache: true # Enable reading/writing the cache directory.
 cache_mode: "read" # Cache behaviour: off, read, refresh or write.
-cache_dir: ${XDG_CACHE_HOME:-/tmp}/service-ambitions # Directory to store cache files.
+cache_dir: ${XDG_CACHE_HOME}/service-ambitions # Directory to store cache files. Falls back to /tmp/service-ambitions when XDG_CACHE_HOME is unset.
 ```
 
 Set `use_local_cache: false` or `cache_mode: "off"` to bypass the cache, or use

--- a/config/app.example.yaml
+++ b/config/app.example.yaml
@@ -62,6 +62,6 @@ retry_base_delay: 0.5       # Initial backoff delay in seconds.
 features_per_role: 5        # Required number of features per role.
 use_local_cache: true       # Enable reading/writing the cache directory.
 cache_mode: "read"          # Cache behaviour: off, read, refresh or write.
-cache_dir: ${XDG_CACHE_HOME:-/tmp}/service-ambitions # Directory to store cache files.
+cache_dir: ${XDG_CACHE_HOME}/service-ambitions # Directory to store cache files. Falls back to /tmp/service-ambitions when XDG_CACHE_HOME is unset.
 diagnostics: false          # Enable verbose diagnostics and tracing.
 strict: false               # Fail when features or mappings are missing.

--- a/config/app.yaml
+++ b/config/app.yaml
@@ -60,4 +60,4 @@ retry_base_delay: 0.5       # Initial backoff delay in seconds.
 features_per_role: 5        # Required number of features per role.
 use_local_cache: true       # Enable reading/writing the cache directory.
 cache_mode: "read"          # Cache behaviour: off, read, refresh or write.
-cache_dir: ${XDG_CACHE_HOME:-/tmp}/service-ambitions # Directory to store cache files.
+cache_dir: ${XDG_CACHE_HOME}/service-ambitions # Directory to store cache files. Falls back to /tmp/service-ambitions when XDG_CACHE_HOME is unset.

--- a/docs/generate-mapping.md
+++ b/docs/generate-mapping.md
@@ -28,7 +28,7 @@ Telemetry via Logfire is always enabled. Prompt text is omitted unless
 
 `--use-local-cache` reads mapping responses under
 `<cache_dir>/<service>/mappings` (default cache dir:
-`${XDG_CACHE_HOME:-/tmp}/service-ambitions`) and optionally writes new entries to
+`${XDG_CACHE_HOME}/service-ambitions`, falling back to `/tmp/service-ambitions` when `XDG_CACHE_HOME` is unset) and optionally writes new entries to
 avoid repeated network requests during development. `--cache-mode` controls how
 the cache is used (`off`, `read`, `refresh`, `write`) with `read` as the default,
 and `--cache-dir` sets the cache storage location.

--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -91,7 +91,8 @@ and role identifiers use similar loaders that cache results on first
 use.
 
 Feature and mapping outputs are cached on disk.  The cache root defaults to
-``${XDG_CACHE_HOME:-/tmp}/service-ambitions`` and the layout is scoped by
+``${XDG_CACHE_HOME}/service-ambitions`` (falling back to ``/tmp/service-ambitions`` when
+``XDG_CACHE_HOME`` is unset) and the layout is scoped by
 context, service and plateau:
 
 ```

--- a/src/generation/generator.py
+++ b/src/generation/generator.py
@@ -16,7 +16,16 @@ from collections import Counter
 from dataclasses import dataclass
 from importlib import import_module
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterable, TextIO, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Iterable,
+    TextIO,
+    TypeVar,
+    cast,
+)
 
 import logfire
 from pydantic import BaseModel
@@ -612,7 +621,7 @@ def build_model(
         # Allow optional access to the ``web_search_preview`` tool which provides
         # browsing capabilities. Disabling keeps runs deterministic and avoids
         # additional cost for schema-only generation.
-        settings["openai_builtin_tools"] = [{"type": "web_search_preview"}]
+        settings["openai_builtin_tools"] = cast(Any, [{"type": "web_search_preview"}])
     if reasoning:
         # Map each supported reasoning field to the ``openai_reasoning_*``
         # parameter. Extra fields allowed by ``ReasoningConfig`` are ignored to

--- a/src/generation/plateau_generator.py
+++ b/src/generation/plateau_generator.py
@@ -127,8 +127,10 @@ class PlateauGenerator:
             mapping_session: Session used for feature mapping.
             strict: Enforce feature and mapping completeness when ``True``.
             use_local_cache: Read and write mapping results from the cache
-                directory (default ``${XDG_CACHE_HOME:-/tmp}/service-ambitions``)
-                when ``True``. Caching is enabled by default.
+                directory (default ``${XDG_CACHE_HOME}/service-ambitions`` and
+                falling back to ``/tmp/service-ambitions`` when
+                ``XDG_CACHE_HOME`` is unset) when ``True``. Caching is enabled
+                by default.
             cache_mode: Caching strategy controlling read/write behaviour.
                 Defaults to ``"read"`` for read-only access.
         """

--- a/src/runtime/settings.py
+++ b/src/runtime/settings.py
@@ -123,7 +123,10 @@ def load_settings(config_path: Path | str | None = None) -> Settings:
     raw_cache_dir = env_cache_dir or str(
         getattr(config, "cache_dir", DEFAULT_CACHE_DIR)
     )
-    cache_dir = Path(os.path.expandvars(raw_cache_dir)).expanduser()
+    expanded_cache_dir = os.path.expandvars(raw_cache_dir)
+    if "$" in expanded_cache_dir:
+        expanded_cache_dir = str(DEFAULT_CACHE_DIR)
+    cache_dir = Path(expanded_cache_dir).expanduser()
     try:
         cache_dir.mkdir(parents=True, exist_ok=True)
         test_file = cache_dir / ".write_test"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from constants import DEFAULT_CACHE_DIR
 from runtime.settings import load_settings
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
@@ -61,6 +62,16 @@ def test_load_settings_uses_xdg_cache_home(monkeypatch, tmp_path) -> None:
     expected = tmp_path / "service-ambitions"
     assert settings.cache_dir == expected
     assert expected.is_dir()
+
+
+def test_load_settings_falls_back_without_xdg(monkeypatch) -> None:
+    """Cache directory should default when ``XDG_CACHE_HOME`` is unset."""
+
+    monkeypatch.setenv("SA_OPENAI_API_KEY", "token")
+    monkeypatch.delenv("SA_CACHE_DIR", raising=False)
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    settings = load_settings()
+    assert settings.cache_dir == DEFAULT_CACHE_DIR
 
 
 def test_load_settings_rejects_unwritable_cache(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary
- remove shell-style default expansion from config and docs
- safely expand cache_dir in settings with fallback when XDG_CACHE_HOME is unset
- cover cache_dir fallback with new test

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(failed: certificate verify failed)*
- `poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=term-missing --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_68ba4f55fb04832bbe58d465fa0c686b