### PR TITLE
Simplify plateau feature dispatch

### DIFF
--- a/tests/test_plateau_runtime_helpers.py
+++ b/tests/test_plateau_runtime_helpers.py
@@ -71,103 +71,23 @@ def test_load_cached_payload_reads_valid_file(tmp_path, monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_dispatch_feature_prompt_builds_prompt(monkeypatch) -> None:
-    runtime = PlateauRuntime(plateau=1, plateau_name="p1", description="d")
-    calls: dict[str, object] = {}
-
-    def fake_build(*, service_name, description, roles, required_count):
-        calls.update(
-            {
-                "service_name": service_name,
-                "description": description,
-                "roles": roles,
-                "required_count": required_count,
-            }
-        )
-        return "PROMPT"
-
-    monkeypatch.setattr(runtime, "_build_plateau_prompt", fake_build)
-
-    session = DummySession()
-    payload = await runtime._dispatch_feature_prompt(
-        cast(ConversationSession, session),
-        service_id="svc",
-        service_name="svc",
-        roles=["r"],
-        required_count=1,
-    )
-
-    assert calls["service_name"] == "svc"
-    assert calls["roles"] == ["r"]
-    assert calls["required_count"] == 1
-    assert session.seen == "PROMPT"
-    assert isinstance(payload, PlateauFeaturesResponse)
-
-
-@pytest.mark.asyncio
-async def test_recover_feature_shortfalls(monkeypatch) -> None:
-    runtime = PlateauRuntime(plateau=1, plateau_name="p1", description="d")
-    valid = {"r1": [_dummy_feature("f1")], "r2": []}
-    invalid = ["r2"]
-    missing = {"r1": 1, "r2": 1}
-
-    async def fake_recover_invalid_roles(
-        self, invalid_roles, *, level, description, session, required_count
-    ):
-        return {"r2": [_dummy_feature("f2")]} if "r2" in invalid_roles else {}
-
-    async def fake_request_missing_features_async(
-        self, level, role, description, missing, session
-    ):
-        return [_dummy_feature(f"extra_{role}")]
-
-    monkeypatch.setattr(
-        PlateauRuntime, "_recover_invalid_roles", fake_recover_invalid_roles
-    )
-    monkeypatch.setattr(
-        PlateauRuntime,
-        "_request_missing_features_async",
-        fake_request_missing_features_async,
-    )
-
-    result = await runtime._recover_feature_shortfalls(
-        valid,
-        invalid,
-        missing,
-        level=1,
-        description="d",
-        session=cast(ConversationSession, DummySession()),
-        required_count=2,
-        roles=["r1", "r2"],
-    )
-
-    assert len(result["r1"]) == 2
-    assert len(result["r2"]) == 2
-
-
-@pytest.mark.asyncio
-async def test_dispatch_and_cache_features(monkeypatch, tmp_path) -> None:
+async def test_dispatch_features_caches_payload(monkeypatch, tmp_path) -> None:
     runtime = PlateauRuntime(plateau=1, plateau_name="p1", description="d")
 
     payload = PlateauFeaturesResponse(features={"r": [_dummy_feature("f")]})
+    monkeypatch.setattr(runtime, "_build_plateau_prompt", lambda **_: "PROMPT")
+    session = DummySession()
 
-    async def fake_dispatch(*args, **kwargs):  # noqa: ANN001
+    async def fake_ask_async(prompt: str) -> PlateauFeaturesResponse:
+        session.seen = prompt
         return payload
 
-    def fake_validate(role_data, *, roles, required_count):  # noqa: ANN001
-        return role_data, [], {}
-
-    async def fake_recover(*args, **kwargs):  # noqa: ANN001
-        return payload.features
-
-    monkeypatch.setattr(runtime, "_dispatch_feature_prompt", fake_dispatch)
-    monkeypatch.setattr(runtime, "_validate_roles", fake_validate)
-    monkeypatch.setattr(runtime, "_recover_feature_shortfalls", fake_recover)
+    monkeypatch.setattr(session, "ask_async", fake_ask_async)
 
     cache_file = tmp_path / "features.json"
 
-    result = await runtime._dispatch_and_cache_features(
-        cast(ConversationSession, DummySession()),
+    result = await runtime._dispatch_features(
+        cast(ConversationSession, session),
         service_id="svc",
         service_name="svc",
         roles=["r"],
@@ -179,6 +99,7 @@ async def test_dispatch_and_cache_features(monkeypatch, tmp_path) -> None:
 
     assert result == payload
     assert cache_file.exists()
+    assert session.seen == "PROMPT"
 
 
 @pytest.mark.asyncio

--- a/tests/test_service_execution_helpers.py
+++ b/tests/test_service_execution_helpers.py
@@ -113,8 +113,12 @@ def test_ensure_run_meta_initialises_once(monkeypatch):
 def test_prepare_runtimes_uses_internal_generator(monkeypatch):
     exec_obj = _execution()
 
+    class DummySession:
+        def add_parent_materials(self, _service):
+            return None
+
     class DummyGenerator:
-        description_session = object()
+        description_session = DummySession()
 
         async def _request_descriptions_async(self, names, session):
             return {n: f"{n}-desc" for n in names}


### PR DESCRIPTION
## Summary
- streamline plateau runtime feature generation into a single `ask_async` call
- remove recovery logic and outdated tests
- adjust tests to match simplified behaviour

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: certificate verify failed)*
- `poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=term-missing --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_68bd002ae920832bbf2c6737ce895c69