### PR TITLE
Simplify plateau feature dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,9 +376,7 @@ at the top level, while mapping types and their associated datasets live under
 the `mapping_types` section, allowing new categories to be added without code
 changes. Plateau definitions and their level mappings come from
 `data/service_feature_plateaus.json`. Roles are defined in `data/roles.json`
-by default and can be overridden with the ``--roles-file`` CLI flag. The
-required number of features per role is controlled by `features_per_role` in
-`config/app.yaml`.
+by default and can be overridden with the ``--roles-file`` CLI flag.
 
 ## Prompt examples
 
@@ -393,8 +391,7 @@ Generate service features for the {service_name} service at plateau {plateau}.
 
 - Use the service description: {service_description}.
 - Provide keys for each role: {roles}.
-- Each key must map to an array containing at least {required_count} feature
-  objects.
+- Each key must map to an array containing feature objects.
 - Every feature must provide:
   - "name": short feature title.
   - "description": explanation of the feature.

--- a/config/app.example.yaml
+++ b/config/app.example.yaml
@@ -59,7 +59,6 @@ concurrency: 5              # Number of services processed in parallel.
 request_timeout: 60         # Per-request timeout in seconds.
 retries: 5                  # Number of retry attempts.
 retry_base_delay: 0.5       # Initial backoff delay in seconds.
-features_per_role: 5        # Required number of features per role.
 use_local_cache: true       # Enable reading/writing the cache directory.
 cache_mode: "read"          # Cache behaviour: off, read, refresh or write.
 cache_dir: ${XDG_CACHE_HOME}/service-ambitions # Directory to store cache files. Falls back to /tmp/service-ambitions when XDG_CACHE_HOME is unset.

--- a/config/app.yaml
+++ b/config/app.yaml
@@ -57,7 +57,6 @@ concurrency: 5              # Number of services processed in parallel.
 request_timeout: 60         # Per-request timeout in seconds.
 retries: 5                  # Number of retry attempts.
 retry_base_delay: 0.5       # Initial backoff delay in seconds.
-features_per_role: 5        # Required number of features per role.
 use_local_cache: true       # Enable reading/writing the cache directory.
 cache_mode: "read"          # Cache behaviour: off, read, refresh or write.
 cache_dir: ${XDG_CACHE_HOME}/service-ambitions # Directory to store cache files. Falls back to /tmp/service-ambitions when XDG_CACHE_HOME is unset.

--- a/docs/generate-evolution.md
+++ b/docs/generate-evolution.md
@@ -43,9 +43,7 @@ contain empty mapping lists. This turns on a fail-fast mode instead of the
 default best‑effort behaviour.
 
 Services run concurrently using a bounded worker pool configured via the
-`--concurrency` flag or the `concurrency` setting in `config/app.yaml`. The
-required number of features per role comes from the `features_per_role` setting
-in the same file.
+`--concurrency` flag or the `concurrency` setting in `config/app.yaml`.
 
 Include `--seed <value>` to make backoff jitter and model sampling
 deterministic when supported by the provider.

--- a/prompts/plateau_prompt.md
+++ b/prompts/plateau_prompt.md
@@ -51,7 +51,7 @@ Generate service features for the {service_name} service at plateau {plateau} us
 ## Output rules
 
 - "features" must include keys for each role: {roles}.
-- Each role key must map to an array containing at least {required_count} feature objects.
+- Each role key must map to an array containing feature objects.
 - Every feature object must include:
   - "name": short feature title.
   - "description": concise explanation of the feature.

--- a/src/engine/plateau_runtime.py
+++ b/src/engine/plateau_runtime.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, Mapping, Sequence
+from typing import Literal, Mapping, Sequence
 
 import logfire
 from pydantic import ValidationError
@@ -26,7 +25,6 @@ from models import (
     MappingSet,
     PlateauFeature,
     PlateauFeaturesResponse,
-    RoleFeaturesResponse,
 )
 from runtime.environment import RuntimeEnv
 from utils import ShortCodeRegistry
@@ -83,14 +81,12 @@ class PlateauRuntime:
         service_name: str,
         description: str,
         roles: Sequence[str],
-        required_count: int,
     ) -> str:
         """Return a prompt requesting features for this plateau."""
 
         template = load_prompt_text("plateau_prompt")
         roles_str = ", ".join(f'"{r}"' for r in roles)
         return template.format(
-            required_count=required_count,
             service_name=service_name,
             service_description=description,
             plateau=str(self.plateau),
@@ -112,112 +108,6 @@ class PlateauRuntime:
             for item in raw_features:
                 features.append(self._to_feature(item, role, code_registry))
         return features
-
-    def _validate_roles(
-        self,
-        role_data: dict[str, Any],
-        *,
-        roles: Sequence[str],
-        required_count: int,
-    ) -> tuple[dict[str, list[FeatureItem]], list[str], dict[str, int]]:
-        """Return valid roles, invalid names and missing counts.
-
-        Args:
-            role_data: Raw features keyed by role from the model.
-            roles: Allowed role names.
-            required_count: Required features per role.
-
-        Returns:
-            A tuple of (valid features per role, invalid role names,
-            missing feature counts).
-        """
-
-        valid: dict[str, list[FeatureItem]] = {}
-        invalid: list[str] = []
-        missing: dict[str, int] = {}
-        for role in roles:
-            items = role_data.get(role, [])
-            try:
-                role_block = RoleFeaturesResponse(features=items)
-            except Exception:  # noqa: BLE001
-                invalid.append(role)
-                valid[role] = []
-                continue
-            valid[role] = list(role_block.features)
-            if len(role_block.features) < required_count:
-                missing[role] = required_count - len(role_block.features)
-        return valid, invalid, missing
-
-    async def _request_role_features_async(
-        self,
-        level: int,
-        role: str,
-        description: str,
-        count: int,
-        session: ConversationSession,
-    ) -> list[FeatureItem]:
-        """Return ``count`` features for ``role`` when initial parsing fails."""
-
-        prompt = (
-            f"Previous output returned invalid features for role '{role}'.\nProvide"
-            f" exactly {count} unique features for this role at plateau"
-            f" {level}.\n\nService description:\n{description}"
-        )
-        payload = await session.ask_async(prompt)
-        return payload.features
-
-    async def _recover_invalid_roles(
-        self,
-        invalid: list[str],
-        *,
-        level: int,
-        description: str,
-        session: ConversationSession,
-        required_count: int,
-    ) -> dict[str, list[FeatureItem]]:
-        """Return features for roles that failed validation."""
-
-        fixes: dict[str, list[FeatureItem]] = {}
-        for role in invalid:
-            fixes[role] = await self._request_role_features_async(
-                level, role, description, required_count, session
-            )
-        return fixes
-
-    def _enforce_min_features(
-        self,
-        valid: dict[str, list[FeatureItem]],
-        *,
-        roles: Sequence[str],
-        required: int,
-    ) -> None:
-        """Ensure each role has at least ``required`` features."""
-
-        for role in roles:
-            items = valid.get(role, [])
-            if len(items) < required:
-                raise ValueError(
-                    f"Expected at least {required} features for '{role}', got"
-                    f" {len(items)} after retry"
-                )
-
-    async def _request_missing_features_async(
-        self,
-        level: int,
-        role: str,
-        description: str,
-        missing: int,
-        session: ConversationSession,
-    ) -> list[FeatureItem]:
-        """Return additional features for ``role`` to meet the required count."""
-
-        prompt = (
-            "Previous output returned insufficient features for role"
-            f" '{role}'.\nProvide exactly {missing} additional unique features for this"
-            f" role at plateau {level}.\n\nService description:\n{description}"
-        )
-        payload = await session.ask_async(prompt)
-        return payload.features
 
     def _load_cached_payload(
         self,
@@ -243,129 +133,27 @@ class PlateauRuntime:
                     raise RuntimeError(f"Invalid feature cache: {candidate}") from exc
         return payload, cache_file
 
-    async def _dispatch_feature_prompt(
+    async def _dispatch_features(
         self,
         session: ConversationSession,
         *,
         service_id: str,
         service_name: str,
         roles: Sequence[str],
-        required_count: int,
+        cache_file: Path | None,
+        use_local_cache: bool,
+        cache_mode: Literal["off", "read", "refresh", "write"],
     ) -> PlateauFeaturesResponse:
-        """Return features generated via LLM prompt."""
+        """Return feature payload from a single prompt and optionally cache it."""
 
         prompt = self._build_plateau_prompt(
             service_name=service_name,
             description=self.description,
             roles=roles,
-            required_count=required_count,
         )
         logfire.info("Requesting features", plateau=self.plateau, service=service_id)
-        return await session.ask_async(prompt)
-
-    async def _recover_feature_shortfalls(
-        self,
-        valid: dict[str, list[FeatureItem]],
-        invalid_roles: list[str],
-        missing: dict[str, int],
-        *,
-        level: int,
-        description: str,
-        session: ConversationSession,
-        required_count: int,
-        roles: Sequence[str],
-    ) -> dict[str, list[FeatureItem]]:
-        """Return roles with recovered features.
-
-        Args:
-            valid: Initially valid features keyed by role.
-            invalid_roles: Roles that failed validation.
-            missing: Number of missing features per role.
-            level: Plateau level for follow-up prompts.
-            description: Service description for context.
-            session: Conversation session used for prompts.
-            required_count: Minimum features per role.
-            roles: All role names.
-
-        Returns:
-            Updated mapping of roles to feature lists.
-        """
-
-        fixes = await self._recover_invalid_roles(
-            invalid_roles,
-            level=level,
-            description=description,
-            session=session,
-            required_count=required_count,
-        )
-        valid.update(fixes)
-        tasks = {
-            role: asyncio.create_task(
-                self._request_missing_features_async(
-                    level, role, description, need, session
-                )
-            )
-            for role, need in missing.items()
-        }
-        if tasks:
-            results = await asyncio.gather(*tasks.values())
-            for role, extras in zip(tasks.keys(), results, strict=False):
-                valid[role].extend(extras)
-        self._enforce_min_features(valid, roles=roles, required=required_count)
-        return valid
-
-    async def _dispatch_and_cache_features(
-        self,
-        session: ConversationSession,
-        *,
-        service_id: str,
-        service_name: str,
-        roles: Sequence[str],
-        required_count: int,
-        cache_file: Path | None,
-        use_local_cache: bool,
-        cache_mode: Literal["off", "read", "refresh", "write"],
-    ) -> PlateauFeaturesResponse:
-        """Return validated feature payload and optionally cache it.
-
-        Args:
-            session: Conversation session used to query the model.
-            service_id: Identifier for cache storage.
-            service_name: Human-readable service name for prompts.
-            roles: Customer roles requiring features.
-            required_count: Number of features to collect per role.
-            cache_file: Destination for cached payload.
-            use_local_cache: Whether caching is enabled.
-            cache_mode: Caching behaviour mode.
-
-        Returns:
-            Validated feature payload.
-        """
-
-        payload = await self._dispatch_feature_prompt(
-            session,
-            service_id=service_id,
-            service_name=service_name,
-            roles=roles,
-            required_count=required_count,
-        )
-        role_data = payload.features
-        valid, invalid_roles, missing = self._validate_roles(
-            role_data, roles=roles, required_count=required_count
-        )
-        valid = await self._recover_feature_shortfalls(
-            valid,
-            invalid_roles,
-            missing,
-            level=self.plateau,
-            description=self.description,
-            session=session,
-            required_count=required_count,
-            roles=roles,
-        )
-        payload = PlateauFeaturesResponse(
-            features={role: list(valid.get(role, [])) for role in roles}
-        )
+        raw = await session.ask_async(prompt)
+        payload = PlateauFeaturesResponse.model_validate(raw)
         if use_local_cache and cache_mode != "off":
             cache_write_json_atomic(
                 cache_file or self._feature_cache_path(service_id),
@@ -380,7 +168,6 @@ class PlateauRuntime:
         service_id: str,
         service_name: str,
         roles: Sequence[str],
-        required_count: int,
         code_registry: ShortCodeRegistry,
         use_local_cache: bool,
         cache_mode: Literal["off", "read", "refresh", "write"],
@@ -391,12 +178,11 @@ class PlateauRuntime:
             service_id, use_local_cache, cache_mode
         )
         if payload is None:
-            payload = await self._dispatch_and_cache_features(
+            payload = await self._dispatch_features(
                 session,
                 service_id=service_id,
                 service_name=service_name,
                 roles=roles,
-                required_count=required_count,
                 cache_file=cache_file,
                 use_local_cache=use_local_cache,
                 cache_mode=cache_mode,

--- a/src/engine/service_execution.py
+++ b/src/engine/service_execution.py
@@ -154,7 +154,6 @@ class ServiceExecution:
 
         self.generator = PlateauGenerator(
             feat_session,
-            required_count=settings.features_per_role,
             roles=self.role_ids,
             description_session=desc_session,
             mapping_session=map_session,

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -480,10 +480,6 @@ class AppConfig(StrictModel):
         float,
         Field(gt=0, description="Initial backoff delay in seconds."),
     ] = 0.5
-    features_per_role: Annotated[
-        int,
-        Field(ge=1, description="Required number of features per role."),
-    ] = 5
     use_local_cache: bool = Field(
         True,
         description="Enable reading and writing the cache directory.",

--- a/src/runtime/settings.py
+++ b/src/runtime/settings.py
@@ -43,9 +43,6 @@ class Settings(BaseSettings):
     retry_base_delay: float = Field(
         0.5, gt=0, description="Initial backoff delay in seconds."
     )
-    features_per_role: int = Field(
-        5, ge=1, description="Required number of features per role."
-    )
     use_local_cache: bool = Field(
         True, description="Enable reading and writing the cache directory."
     )
@@ -151,7 +148,6 @@ def load_settings(config_path: Path | str | None = None) -> Settings:
             request_timeout=config.request_timeout,
             retries=config.retries,
             retry_base_delay=config.retry_base_delay,
-            features_per_role=config.features_per_role,
             use_local_cache=(
                 env_use_local_cache.lower() in {"1", "true", "yes"}
                 if env_use_local_cache is not None

--- a/tests/test_e2e_cli_generate.py
+++ b/tests/test_e2e_cli_generate.py
@@ -243,7 +243,6 @@ def _settings(_config: str | None = None) -> SimpleNamespace:
         cache_dir=Path(".cache"),
         mapping_data_dir=Path("data"),
         mapping_sets=[],
-        features_per_role=5,
         web_search=False,
         mapping_mode="per_set",
     )

--- a/tests/test_integration_service_evolution.py
+++ b/tests/test_integration_service_evolution.py
@@ -93,7 +93,6 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
     )
     generator = PlateauGenerator(
         session,
-        required_count=5,
         use_local_cache=False,
         cache_mode="off",
     )
@@ -118,7 +117,7 @@ def test_service_evolution_across_four_plateaus(monkeypatch) -> None:
         self.success = True
 
     monkeypatch.setattr(PlateauRuntime, "generate_mappings", _fake_generate_mappings)
-    template = "{required_count} {service_name} {service_description} {plateau} {roles}"
+    template = "{service_name} {service_description} {plateau} {roles}"
 
     def fake_loader(name, *_, **__):
         if name == "plateau_prompt":

--- a/tests/test_plateau_runtime_helpers.py
+++ b/tests/test_plateau_runtime_helpers.py
@@ -71,107 +71,26 @@ def test_load_cached_payload_reads_valid_file(tmp_path, monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_dispatch_feature_prompt_builds_prompt(monkeypatch) -> None:
+async def test_dispatch_features_caches_payload(monkeypatch, tmp_path) -> None:
     runtime = PlateauRuntime(plateau=1, plateau_name="p1", description="d")
-    calls: dict[str, object] = {}
 
-    def fake_build(*, service_name, description, roles, required_count):
-        calls.update(
-            {
-                "service_name": service_name,
-                "description": description,
-                "roles": roles,
-                "required_count": required_count,
-            }
-        )
-        return "PROMPT"
-
-    monkeypatch.setattr(runtime, "_build_plateau_prompt", fake_build)
-
+    payload = PlateauFeaturesResponse(features={"r": [_dummy_feature("f")]})
+    monkeypatch.setattr(runtime, "_build_plateau_prompt", lambda **_: "PROMPT")
     session = DummySession()
-    payload = await runtime._dispatch_feature_prompt(
+
+    async def fake_ask_async(prompt: str) -> PlateauFeaturesResponse:
+        session.seen = prompt
+        return payload
+
+    monkeypatch.setattr(session, "ask_async", fake_ask_async)
+
+    cache_file = tmp_path / "features.json"
+
+    result = await runtime._dispatch_features(
         cast(ConversationSession, session),
         service_id="svc",
         service_name="svc",
         roles=["r"],
-        required_count=1,
-    )
-
-    assert calls["service_name"] == "svc"
-    assert calls["roles"] == ["r"]
-    assert calls["required_count"] == 1
-    assert session.seen == "PROMPT"
-    assert isinstance(payload, PlateauFeaturesResponse)
-
-
-@pytest.mark.asyncio
-async def test_recover_feature_shortfalls(monkeypatch) -> None:
-    runtime = PlateauRuntime(plateau=1, plateau_name="p1", description="d")
-    valid = {"r1": [_dummy_feature("f1")], "r2": []}
-    invalid = ["r2"]
-    missing = {"r1": 1, "r2": 1}
-
-    async def fake_recover_invalid_roles(
-        self, invalid_roles, *, level, description, session, required_count
-    ):
-        return {"r2": [_dummy_feature("f2")]} if "r2" in invalid_roles else {}
-
-    async def fake_request_missing_features_async(
-        self, level, role, description, missing, session
-    ):
-        return [_dummy_feature(f"extra_{role}")]
-
-    monkeypatch.setattr(
-        PlateauRuntime, "_recover_invalid_roles", fake_recover_invalid_roles
-    )
-    monkeypatch.setattr(
-        PlateauRuntime,
-        "_request_missing_features_async",
-        fake_request_missing_features_async,
-    )
-
-    result = await runtime._recover_feature_shortfalls(
-        valid,
-        invalid,
-        missing,
-        level=1,
-        description="d",
-        session=cast(ConversationSession, DummySession()),
-        required_count=2,
-        roles=["r1", "r2"],
-    )
-
-    assert len(result["r1"]) == 2
-    assert len(result["r2"]) == 2
-
-
-@pytest.mark.asyncio
-async def test_dispatch_and_cache_features(monkeypatch, tmp_path) -> None:
-    runtime = PlateauRuntime(plateau=1, plateau_name="p1", description="d")
-
-    payload = PlateauFeaturesResponse(features={"r": [_dummy_feature("f")]})
-
-    async def fake_dispatch(*args, **kwargs):  # noqa: ANN001
-        return payload
-
-    def fake_validate(role_data, *, roles, required_count):  # noqa: ANN001
-        return role_data, [], {}
-
-    async def fake_recover(*args, **kwargs):  # noqa: ANN001
-        return payload.features
-
-    monkeypatch.setattr(runtime, "_dispatch_feature_prompt", fake_dispatch)
-    monkeypatch.setattr(runtime, "_validate_roles", fake_validate)
-    monkeypatch.setattr(runtime, "_recover_feature_shortfalls", fake_recover)
-
-    cache_file = tmp_path / "features.json"
-
-    result = await runtime._dispatch_and_cache_features(
-        cast(ConversationSession, DummySession()),
-        service_id="svc",
-        service_name="svc",
-        roles=["r"],
-        required_count=1,
         cache_file=cache_file,
         use_local_cache=True,
         cache_mode="write",
@@ -179,6 +98,7 @@ async def test_dispatch_and_cache_features(monkeypatch, tmp_path) -> None:
 
     assert result == payload
     assert cache_file.exists()
+    assert session.seen == "PROMPT"
 
 
 @pytest.mark.asyncio

--- a/tests/test_service_execution_helpers.py
+++ b/tests/test_service_execution_helpers.py
@@ -113,8 +113,12 @@ def test_ensure_run_meta_initialises_once(monkeypatch):
 def test_prepare_runtimes_uses_internal_generator(monkeypatch):
     exec_obj = _execution()
 
+    class DummySession:
+        def add_parent_materials(self, _service):
+            return None
+
     class DummyGenerator:
-        description_session = object()
+        description_session = DummySession()
 
         async def _request_descriptions_async(self, names, session):
             return {n: f"{n}-desc" for n in names}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -29,7 +29,6 @@ def test_load_settings_reads_env(monkeypatch) -> None:
     assert settings.request_timeout == 60
     assert settings.retries == 5
     assert settings.retry_base_delay == 0.5
-    assert settings.features_per_role == 5
     assert settings.use_local_cache is True
     assert settings.cache_mode == "write"
     assert settings.cache_dir == Path("/tmp/cache")


### PR DESCRIPTION
## Summary
- streamline plateau runtime feature generation into a single `ask_async` call
- remove recovery logic and outdated tests
- adjust tests to match simplified behaviour
- keep duplicate features while normalising their fields
- drop features-per-role configuration and `required_count` plumbing

## Testing
- `poetry run black --preview --enable-unstable-feature string_processing .`
- `poetry run ruff check --fix .`
- `poetry run mypy .`
- `poetry run bandit -r src -ll`
- `poetry run pip-audit` *(fails: certificate verify failed)*
- `poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=term-missing --cov-fail-under=85`


------
https://chatgpt.com/codex/tasks/task_e_68bd002ae920832bbf2c6737ce895c69