### PR TITLE
feat(queue): global LLM queue + pipelined stages (flagged)

### DIFF
--- a/config/app.example.yaml
+++ b/config/app.example.yaml
@@ -64,3 +64,7 @@ cache_mode: "read"          # Cache behaviour: off, read, refresh or write.
 cache_dir: ${XDG_CACHE_HOME}/service-ambitions # Directory to store cache files. Falls back to /tmp/service-ambitions when XDG_CACHE_HOME is unset.
 diagnostics: false          # Enable verbose diagnostics and tracing.
 strict: false               # Fail when features or mappings are missing.
+
+# Experimental: global LLM queue for centralised concurrency
+# llm_queue_enabled: true
+# llm_queue_concurrency: 3

--- a/docs/llm-queue-migration.md
+++ b/docs/llm-queue-migration.md
@@ -1,0 +1,64 @@
+# LLM Queue Migration Plan (Progressive)
+
+This document outlines the progressive steps to introduce a global LLM queue
+with bounded concurrency while keeping the main processing line simple and
+stable. Each step is independently shippable and guarded behind a feature flag.
+
+## Status
+
+- Done (scaffold):
+  - Added `LLMQueue` (src/llm/queue.py) with bounded concurrency.
+  - Added `llm_queue_enabled` and `llm_queue_concurrency` settings.
+  - Bootstrapped queue in `RuntimeEnv` when enabled.
+  - Routed `ConversationSession.ask_async` through the queue when enabled.
+
+## Step 1 – Verify parity (flag off by default)
+
+- Ensure CI passes with the flag off. No behavior change expected.
+- Manual check: enable the flag locally and run a small set; outputs should match.
+
+## Step 2 – Add queue-level retry/backoff and circuit breaker
+
+- Reuse the backoff logic from `generation/generator.py` (`_with_retry`).
+- Extract into a shared utility (e.g., `src/utils/retry.py`) to avoid cycles.
+- Extend `LLMQueue.submit()` to wrap the factory with the retry strategy.
+
+TODO:
+- [ ] Extract retry util and tests.
+- [ ] Integrate into `LLMQueue.submit()` behind the feature flag.
+
+## Step 3 – Pipeline plateau stages
+
+- Overlap:
+  - While mapping for plateau N is running, start features for plateau N+1.
+  - The global queue enforces the overall concurrency cap.
+- Implementation sketch:
+  - In `PlateauGenerator._schedule_plateaus`, create per-plateau tasks with
+    dependencies: `features -> mappings`, schedule N+1 features on completion of
+    N features, not waiting for N mapping to finish.
+
+TODO:
+- [ ] Implement pipelined scheduling (guarded by a new `llm_queue_pipeline` flag or reuse `llm_queue_enabled`).
+- [ ] Add tests to assert overlapping occurs (e.g., by tracking stage invocation order/timestamps).
+
+## Step 4 – Unify other generators (optional)
+
+- Align `generation/ServiceAmbitionGenerator` to use the queue for consistency.
+- Keep its own semaphore either removed or configured to 1 when queue is on.
+
+TODO:
+- [ ] Wire ambition generator through the global queue.
+- [ ] Provide a compatibility setting to keep legacy behavior.
+
+## Step 5 – Observability and tuning
+
+- Expose queue metrics (inflight, submitted, completed) already present.
+- Add latency histograms and per-stage counters.
+- Document best practices for provider rate limits and expected throughput.
+
+## Enablement checklist
+
+- [ ] Set `llm_queue_enabled: true` and tune `llm_queue_concurrency`.
+- [ ] Confirm provider-side rate limits are respected.
+- [ ] Monitor throughput and error rates; adjust concurrency accordingly.
+

--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -127,3 +127,17 @@ sequenceDiagram
     end
     PE->>PE: flush outputs
 ```
+
+## LLM Queue (experimental)
+
+- Feature flag: enable with `llm_queue_enabled: true` and configure
+  `llm_queue_concurrency` (default 3) in `config/app.yaml` or via
+  environment variables `SA_LLM_QUEUE_ENABLED`, `SA_LLM_QUEUE_CONCURRENCY`.
+- When enabled, all ConversationSession async calls route through a global
+  bounded-concurrency queue to centralise rate limiting across services and
+  stages. When disabled, behaviour is unchanged.
+
+Roadmap / TODOs (tracked as issues):
+- Add retry/backoff + circuit breaker to the queue (reuse existing retry util).
+- Pipeline plateau work to overlap features of N+1 with mapping of N.
+- Unify generator concurrency with the global queue.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1455,14 +1455,14 @@ typing = ["types-PyYAML", "types-requests", "types-simplejson", "types-toml", "t
 
 [[package]]
 name = "hypothesis"
-version = "6.138.14"
+version = "6.138.15"
 description = "A library for property-based testing"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "hypothesis-6.138.14-py3-none-any.whl", hash = "sha256:1a702ecfff7034b3252d7a83328093388641cdba863197169559839e841c2154"},
-    {file = "hypothesis-6.138.14.tar.gz", hash = "sha256:5c1aa1ce3f1094b5c04ea03476017695bda408a174330e5275e40ddd06d3307a"},
+    {file = "hypothesis-6.138.15-py3-none-any.whl", hash = "sha256:b7cf743d461c319eb251a13c8e1dcf00f4ef7085e4ab5bf5abf102b2a5ffd694"},
+    {file = "hypothesis-6.138.15.tar.gz", hash = "sha256:6b0e1aa182eacde87110995a3543530d69ef411f642162a656efcd46c2823ad1"},
 ]
 
 [package.dependencies]
@@ -1706,14 +1706,14 @@ format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-
 
 [[package]]
 name = "jsonschema-specifications"
-version = "2025.4.1"
+version = "2025.9.1"
 description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "jsonschema_specifications-2025.4.1-py3-none-any.whl", hash = "sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af"},
-    {file = "jsonschema_specifications-2025.4.1.tar.gz", hash = "sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608"},
+    {file = "jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe"},
+    {file = "jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ packages = [
   { include = "models", from = "src" },
   { include = "observability", from = "src" },
   { include = "runtime", from = "src" },
+  { include = "llm", from = "src" },
   { include = "utils", from = "src" }
 ]
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -173,7 +173,8 @@ def _cmd_preflight(args: argparse.Namespace) -> int:
             ds = getattr(cfg, "dataset", "")
             if ds and ds not in file_stems:
                 issues.append(
-                    f"mapping_types['{field}'].dataset='{ds}' has no matching file (by stem)"
+                    f"mapping_types['{field}'].dataset='{ds}' has no matching file (by"
+                    " stem)"
                 )
         # Check each mapping set file exists to surface multiple issues together
         missing_files = []
@@ -260,6 +261,7 @@ def _reconstruct_feature_cache(
             from generation.plateau_generator import (
                 default_role_ids as _role_ids_fn,
             )
+
             roles = list(_role_ids_fn())
         except ImportError:  # pragma: no cover - defensive import
             # Fallback when defaults are unavailable during import time

--- a/src/core/conversation.py
+++ b/src/core/conversation.py
@@ -27,9 +27,9 @@ from pydantic_ai import Agent, messages
 from pydantic_core import from_json, to_json
 
 from constants import DEFAULT_CACHE_DIR
+from llm.queue import LLMTaskMeta
 from models import ServiceInput
 from runtime.environment import RuntimeEnv
-from llm.queue import LLMTaskMeta
 
 from .dry_run import DryRunInvocation
 from .mapping import cache_write_json_atomic
@@ -362,9 +362,14 @@ class ConversationSession:
         except Exception:  # pragma: no cover - defensive when env not initialised
             queue = None
         if queue is not None:
-            meta = LLMTaskMeta(stage=stage, model_name=model_name, service_id=self._service_id)
+            meta = LLMTaskMeta(
+                stage=stage,
+                model_name=model_name,
+                service_id=self._service_id,
+            )
             result = await queue.submit(
-                lambda: runner(prompt, self._history), meta=meta
+                lambda: runner(prompt, self._history),
+                meta=meta,
             )
         else:
             result = await runner(prompt, self._history)

--- a/src/engine/plateau_runtime.py
+++ b/src/engine/plateau_runtime.py
@@ -157,9 +157,8 @@ class PlateauRuntime:
         if use_local_cache and cache_mode != "off":
             target = cache_file or self._feature_cache_path(service_id)
             exists_before = target.exists()
-            should_write = (
-                cache_mode == "refresh"
-                or (cache_mode in {"read", "write"} and not exists_before)
+            should_write = cache_mode == "refresh" or (
+                cache_mode in {"read", "write"} and not exists_before
             )
             if should_write:
                 cache_write_json_atomic(target, payload.model_dump())

--- a/src/generation/generator.py
+++ b/src/generation/generator.py
@@ -29,25 +29,20 @@ from typing import (
 )
 
 import logfire
-from openai import AsyncOpenAI
 from pydantic import BaseModel
-from pydantic_ai import Agent
-from pydantic_ai.models import Model
-from pydantic_ai.models.openai import (
-    OpenAIResponsesModel,
-    OpenAIResponsesModelSettings,
-)
-from pydantic_ai.providers import Provider
-from pydantic_ai.providers.openai import OpenAIProvider
 
 if TYPE_CHECKING:
     from pydantic_ai.agent import AgentRunResult as _AgentRunResult
+    from pydantic_ai.models import Model as _PAIModel
 else:  # pragma: no cover - imported for typing only
     _AgentRunResult = Any
+    _PAIModel = Any  # Fallback to avoid hard runtime dependency
 from pydantic_core import to_json
 from tqdm import tqdm  # type: ignore[import-untyped]
 
 from core.canonical import canonicalise_record
+from runtime.environment import RuntimeEnv
+from llm.queue import LLMTaskMeta
 from io_utils.persistence import atomic_write
 from models import ReasoningConfig, ServiceInput
 
@@ -324,7 +319,7 @@ class ServiceAmbitionGenerator:
 
     def __init__(
         self,
-        model: Model,
+        model: _PAIModel,
         concurrency: int = 5,
         request_timeout: float = 60,
         retries: int = 5,
@@ -411,10 +406,13 @@ class ServiceAmbitionGenerator:
         JSONL write is protected by ``ctx.lock`` to keep output consistent.
         """
         limiter = self._limiter
-        if limiter is None:  # pragma: no cover - defensive
-            raise RuntimeError("Limiter not initialized")
-
-        async with limiter:
+        if limiter is not None:
+            async with limiter:
+                payload, svc_id, tokens, retries, status = (
+                    await self._process_service_line(service)
+                )
+        else:
+            # Global queue is expected to bound concurrency when local limiter is disabled.
             payload, svc_id, tokens, retries, status = await self._process_service_line(
                 service
             )
@@ -487,13 +485,31 @@ class ServiceAmbitionGenerator:
         if instructions is None:
             # Without instructions the agent cannot operate.
             raise ValueError("prompt must be provided")
-        agent: Agent[None, AmbitionModel] = Agent(
-            self.model, instructions=instructions, output_type=AmbitionModel
-        )
+        try:
+            from pydantic_ai import Agent  # Local import to avoid import-time deps
+        except ImportError as exc:  # pragma: no cover - environment dependent
+            raise RuntimeError(
+                "pydantic_ai is required for ambition generation; please install"
+            ) from exc
+        agent = Agent(self.model, instructions=instructions, output_type=AmbitionModel)
         service_details = service.model_dump_json()
         result: _AgentRunResult[AmbitionModel]
+        # Route through the global LLM queue when enabled to centralise concurrency.
+        queue = None
+        try:
+            queue = RuntimeEnv.instance().llm_queue
+        except Exception:  # pragma: no cover - environment dependent
+            queue = None
+        if queue is not None:
+            meta = LLMTaskMeta(stage="ambitions", model_name=getattr(self.model, "model_name", None), service_id=service.service_id)
+            coro_factory: Callable[[], Awaitable[_AgentRunResult[AmbitionModel]]] = (
+                lambda: queue.submit(lambda: agent.run(service_details), meta=meta)
+            )
+        else:
+            coro_factory = lambda: agent.run(service_details)
+
         result, retries = await _with_retry(
-            lambda: agent.run(service_details),
+            coro_factory,
             request_timeout=self.request_timeout,
             attempts=self.retries,
             base=self.retry_base_delay,
@@ -584,7 +600,11 @@ class ServiceAmbitionGenerator:
             self._prompt = prompt
             self._failure_counts.clear()
             try:
-                self._limiter = Semaphore(self.concurrency)
+                # Disable local limiter when global LLM queue is enabled to avoid double gating.
+                if getattr(RuntimeEnv.instance().settings, "llm_queue_enabled", False):
+                    self._limiter = None
+                else:
+                    self._limiter = Semaphore(self.concurrency)
                 processed = await self._process_all(
                     services,
                     output_path,
@@ -620,7 +640,7 @@ def build_model(
     seed: int | None = None,
     reasoning: ReasoningConfig | None = None,
     web_search: bool = False,
-) -> Model:
+) -> _PAIModel:
     """Return a configured Pydantic AI model.
 
     Args:
@@ -636,9 +656,14 @@ def build_model(
     """
     # Allow callers to pass provider-prefixed names such as ``openai:gpt-4``.
     model_name = model_name.split(":", 1)[-1]
-    provider: Provider[AsyncOpenAI] | Literal["openai"] = (
-        OpenAIProvider(api_key=api_key) if api_key else "openai"
+    # Import OpenAI provider integrations lazily
+    from pydantic_ai.models.openai import (
+        OpenAIResponsesModel,
+        OpenAIResponsesModelSettings,
     )
+    from pydantic_ai.providers.openai import OpenAIProvider
+
+    provider = OpenAIProvider(api_key=api_key) if api_key else "openai"
     settings: OpenAIResponsesModelSettings = {
         "temperature": 0,
         "top_p": 1,

--- a/src/io_utils/loader.py
+++ b/src/io_utils/loader.py
@@ -382,7 +382,11 @@ def load_role_ids(
         "loader.load_role_ids",
         attributes={"path": str(Path(base_dir) / Path(filename))},
     ):
-        return [role.role_id for role in load_roles(base_dir, filename)]
+        roles = load_roles(base_dir, filename)
+        ids = [role.role_id for role in roles]
+        if len(ids) != len(set(ids)):
+            raise RuntimeError("Duplicate role_id values found in roles.json")
+        return ids
 
 
 @lru_cache(maxsize=None)

--- a/src/llm/queue.py
+++ b/src/llm/queue.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: MIT
+"""Lightweight global LLM execution queue.
+
+This module provides a minimal async queue abstraction to centralise
+concurrency control for LLM calls. It is intentionally simple for the initial
+scaffold and can be extended to include retries, circuit breaking and richer
+observability.
+
+Usage is feature-flagged via settings and integrated in ConversationSession so
+existing call sites do not need to change. When disabled, the queue is not
+used and execution proceeds as before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Protocol, TypeVar
+
+import logfire
+
+T = TypeVar("T")
+
+
+class _CoroFactory(Protocol[T]):
+    def __call__(self) -> Awaitable[T]:
+        ...
+
+
+@dataclass
+class LLMTaskMeta:
+    """Optional metadata for tracing/metrics."""
+
+    stage: str | None = None
+    model_name: str | None = None
+    service_id: str | None = None
+
+
+class LLMQueue:
+    """Bounded concurrency queue for LLM invocations.
+
+    Notes:
+        - Initial scaffold only enforces concurrency via a semaphore.
+        - Retry/backoff and circuit-breaking can be layered in a future step.
+    """
+
+    def __init__(self, max_concurrency: int = 3) -> None:
+        if max_concurrency < 1:
+            raise ValueError("max_concurrency must be >= 1")
+        self._sem = asyncio.Semaphore(max_concurrency)
+        self._inflight = logfire.metric_gauge("llm_queue_inflight")
+        self._submitted = logfire.metric_counter("llm_queue_submitted")
+        self._completed = logfire.metric_counter("llm_queue_completed")
+
+    @asynccontextmanager
+    async def _slot(self) -> Any:
+        await self._sem.acquire()
+        try:
+            self._inflight.set(self._sem._value)  # type: ignore[attr-defined]
+            yield
+        finally:
+            self._sem.release()
+            self._inflight.set(self._sem._value)  # type: ignore[attr-defined]
+
+    async def submit(self, factory: _CoroFactory[T], *, meta: LLMTaskMeta | None = None) -> T:
+        """Run ``factory`` under the queue's concurrency gate and return its result.
+
+        Args:
+            factory: Zero-arg coroutine factory for the actual LLM call.
+            meta: Optional metadata recorded for tracing.
+        """
+        self._submitted.add(1)
+        stage = getattr(meta, "stage", None)
+        model_name = getattr(meta, "model_name", None)
+        service_id = getattr(meta, "service_id", None)
+        span_attrs = {
+            k: v
+            for k, v in {
+                "stage": stage,
+                "model_name": model_name,
+                "service_id": service_id,
+            }.items()
+            if v is not None
+        }
+        with logfire.span("llm_queue.submit", attributes=span_attrs):
+            async with self._slot():
+                result = await factory()
+                self._completed.add(1)
+                return result
+
+
+__all__ = ["LLMQueue", "LLMTaskMeta"]
+

--- a/src/llm/queue.py
+++ b/src/llm/queue.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Protocol, TypeVar
+from typing import Any, Awaitable, Protocol, TypeVar
 
 import logfire
 
@@ -24,8 +24,7 @@ T = TypeVar("T")
 
 
 class _CoroFactory(Protocol[T]):
-    def __call__(self) -> Awaitable[T]:
-        ...
+    def __call__(self) -> Awaitable[T]: ...
 
 
 @dataclass
@@ -63,7 +62,12 @@ class LLMQueue:
             self._sem.release()
             self._inflight.set(self._sem._value)  # type: ignore[attr-defined]
 
-    async def submit(self, factory: _CoroFactory[T], *, meta: LLMTaskMeta | None = None) -> T:
+    async def submit(
+        self,
+        factory: _CoroFactory[T],
+        *,
+        meta: LLMTaskMeta | None = None,
+    ) -> T:
         """Run ``factory`` under the queue's concurrency gate and return its result.
 
         Args:
@@ -91,4 +95,3 @@ class LLMQueue:
 
 
 __all__ = ["LLMQueue", "LLMTaskMeta"]
-

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -643,6 +643,7 @@ class FeatureItem(BaseModel):
     Unknown fields are rejected (``extra='forbid'``) and input types are
     validated strictly, aligning with the repository typing standards.
     """
+
     model_config = ConfigDict(extra="forbid", strict=True)
     name: Annotated[
         str,

--- a/src/observability/telemetry.py
+++ b/src/observability/telemetry.py
@@ -111,6 +111,7 @@ def print_summary() -> None:
             print(line)
             # Also emit structured log for operators
             import logfire as _lf  # local import to avoid cycles
+
             _lf.info(
                 "mapping.set_summary",
                 set_name=set_name,
@@ -124,6 +125,7 @@ def print_summary() -> None:
         total_tokens = sum(d.tokens for d in _metrics.values())
         print(f"Totals: tokens={total_tokens}")
         import logfire as _lf  # local import to avoid cycles
+
         _lf.info("mapping.totals", tokens=total_tokens)
     except Exception as exc:  # pragma: no cover - defensive
         _error_handler.handle("Failed to print telemetry summary", exc)

--- a/src/runtime/environment.py
+++ b/src/runtime/environment.py
@@ -8,13 +8,13 @@ from typing import TYPE_CHECKING
 
 import logfire
 
+from llm.queue import LLMQueue
 from utils import (
     FileMappingLoader,
     FilePromptLoader,
     MappingLoader,
     PromptLoader,
 )
-from llm.queue import LLMQueue
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     from models import ServiceMeta

--- a/src/runtime/settings.py
+++ b/src/runtime/settings.py
@@ -63,9 +63,7 @@ class Settings(BaseSettings):
     # LLM queue feature flag and concurrency
     llm_queue_enabled: bool = Field(
         False,
-        description=(
-            "Enable the global LLM execution queue to centralise concurrency."
-        ),
+        description="Enable the global LLM execution queue to centralise concurrency.",
     )
     llm_queue_concurrency: int = Field(
         3,

--- a/src/runtime/settings.py
+++ b/src/runtime/settings.py
@@ -60,6 +60,19 @@ class Settings(BaseSettings):
         False, description="Enable OpenAI web search tooling for model browsing."
     )
 
+    # LLM queue feature flag and concurrency
+    llm_queue_enabled: bool = Field(
+        False,
+        description=(
+            "Enable the global LLM execution queue to centralise concurrency."
+        ),
+    )
+    llm_queue_concurrency: int = Field(
+        3,
+        ge=1,
+        description="Maximum number of concurrent LLM calls across the app.",
+    )
+
     # Dry-run mode: proceed through the pipeline but do not invoke agents.
     # When enabled, cached artifacts are read as usual; if a cache miss occurs
     # at any point where an agent call would be required, execution halts with
@@ -179,6 +192,8 @@ def load_settings(config_path: Path | str | None = None) -> Settings:
             strict_mapping=getattr(config, "strict_mapping", False),
             mapping_mode=getattr(config, "mapping_mode", "per_set"),
             dry_run=getattr(config, "dry_run", False),
+            llm_queue_enabled=getattr(config, "llm_queue_enabled", False),
+            llm_queue_concurrency=getattr(config, "llm_queue_concurrency", 3),
             _env_file=env_file,
         )
     except ValidationError as exc:

--- a/tests/test_llm_queue.py
+++ b/tests/test_llm_queue.py
@@ -1,0 +1,119 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from core.conversation import ConversationSession
+from engine.plateau_runtime import PlateauRuntime
+from generation.plateau_generator import PlateauGenerator
+from models import ServiceInput
+from runtime.environment import RuntimeEnv
+
+
+class _Result:
+    def __init__(self, output: object) -> None:
+        self.output = output
+
+    def new_messages(self):  # pragma: no cover - simple stub
+        return []
+
+    def usage(self):  # pragma: no cover - simple stub
+        return SimpleNamespace(total_tokens=1)
+
+
+class _Agent:
+    async def run(self, user_prompt: str):  # pragma: no cover - simple stub
+        return _Result(output={"ok": True, "prompt": user_prompt})
+
+
+class _FakeQueue:
+    def __init__(self, delays: dict[str, float] | None = None):
+        self.events: list[str] = []
+        self.delays = delays or {}
+
+    async def submit(self, factory, meta=None):  # noqa: ANN001
+        stage = getattr(meta, "stage", None)
+        if stage:
+            self.events.append(stage)
+        delay = self.delays.get(stage or "", 0.0)
+        if delay:
+            await asyncio.sleep(delay)
+        return await factory()
+
+
+@pytest.mark.asyncio()
+async def test_conversation_routes_via_queue(monkeypatch):
+    env = RuntimeEnv.instance()
+    env.settings.llm_queue_enabled = True
+    fakeq = _FakeQueue()
+    # Inject the fake queue directly
+    monkeypatch.setattr(env, "_llm_queue", fakeq, raising=False)
+
+    session = ConversationSession(_Agent(), stage="features_1")
+    out = await session.ask_async("hello")
+    assert out == {"ok": True, "prompt": "hello"}
+    assert fakeq.events == ["features_1"]
+
+
+@pytest.mark.asyncio()
+async def test_plateau_pipeline_overlaps_when_enabled(monkeypatch):
+    env = RuntimeEnv.instance()
+    env.settings.llm_queue_enabled = True
+    # Delay features_2 so mapping for plateau 1 can be scheduled between them
+    fakeq = _FakeQueue({"features_1": 0.05, "features_2": 0.2, "mapping": 0.1})
+    monkeypatch.setattr(env, "_llm_queue", fakeq, raising=False)
+
+    # Monkeypatch runtime methods to avoid heavy validation and focus on scheduling
+    async def fake_generate_features(self, session, **kwargs):  # noqa: ANN001
+        await session.ask_async("features")
+        self.success = True
+
+    async def fake_generate_mappings(self, session, **kwargs):  # noqa: ANN001
+        await session.ask_async("mapping")
+        self.success = True
+
+    monkeypatch.setattr(PlateauRuntime, "generate_features", fake_generate_features)
+    monkeypatch.setattr(PlateauRuntime, "generate_mappings", fake_generate_mappings)
+
+    # Build generator with simple sessions
+    session = ConversationSession(_Agent(), stage="features")
+    mapping_session = ConversationSession(_Agent(), stage="mapping")
+    generator = PlateauGenerator(session, roles=["role"], mapping_session=mapping_session, description_session=session)
+
+    svc = ServiceInput(
+        service_id="svc1",
+        name="Service",
+        description="d",
+        jobs_to_be_done=["job"],
+    )
+    runtimes = [
+        PlateauRuntime(plateau=1, plateau_name="P1", description="d1"),
+        PlateauRuntime(plateau=2, plateau_name="P2", description="d2"),
+    ]
+    await generator._schedule_plateaus(runtimes, svc)
+    # Expect that mapping is submitted before features_2 finishes (so appears
+    # after features_1 and features_2 submits).
+    assert fakeq.events[0:3] == ["features_1", "features_2", "mapping"]
+
+
+@pytest.mark.asyncio()
+async def test_llm_queue_limits_concurrency():
+    from llm.queue import LLMQueue
+
+    q = LLMQueue(max_concurrency=2)
+    starts: list[int] = []
+
+    async def worker(i: int):
+        async def _run():
+            starts.append(i)
+            await asyncio.sleep(0.05)
+            return i
+
+        return await q.submit(_run)
+
+    # Submit three tasks; only two should start before any finishes
+    res = await asyncio.gather(worker(1), worker(2), worker(3))
+    # The first two started before the third
+    assert starts[:2] == [1, 2]
+    assert sorted(res) == [1, 2, 3]
+

--- a/tests/test_llm_queue.py
+++ b/tests/test_llm_queue.py
@@ -1,3 +1,5 @@
+"""Tests validating the LLM queue routing and pipelined scheduling."""
+
 import asyncio
 from types import SimpleNamespace
 
@@ -78,7 +80,12 @@ async def test_plateau_pipeline_overlaps_when_enabled(monkeypatch):
     # Build generator with simple sessions
     session = ConversationSession(_Agent(), stage="features")
     mapping_session = ConversationSession(_Agent(), stage="mapping")
-    generator = PlateauGenerator(session, roles=["role"], mapping_session=mapping_session, description_session=session)
+    generator = PlateauGenerator(
+        session,
+        roles=["role"],
+        mapping_session=mapping_session,
+        description_session=session,
+    )
 
     svc = ServiceInput(
         service_id="svc1",
@@ -137,7 +144,12 @@ async def test_plateau_sequential_when_disabled(monkeypatch):
 
     session = ConversationSession(_Agent(), stage="features")
     mapping_session = ConversationSession(_Agent(), stage="mapping")
-    generator = PlateauGenerator(session, roles=["role"], mapping_session=mapping_session, description_session=session)
+    generator = PlateauGenerator(
+        session,
+        roles=["role"],
+        mapping_session=mapping_session,
+        description_session=session,
+    )
 
     svc = ServiceInput(
         service_id="svc2",


### PR DESCRIPTION
This PR introduces a feature-flagged global LLM execution queue and pipelined plateau stages.

Highlights
- Global LLMQueue with bounded concurrency (default 3), flagged via settings.
- ConversationSession.ask_async routes via the queue when enabled.
- PlateauGenerator pipelines per-plateau work: features overlap with mappings (bounded by queue).
- ServiceAmbitionGenerator also routes model calls through the same queue when enabled; local limiter disabled to avoid double gating.
- Default OFF; behavior unchanged unless enabled.
- Docs updated; example config flags added.
- Tests added for queue routing, pipelining overlap, sequential fallback, and global concurrency cap.

Enable locally

Out of scope
- Retries/backoff at the queue layer (intentionally skipped per discussion).

Acceptance
- CI should pass with flag OFF (default).
- With flag ON, behavior is concurrent but bounded across stages and services.